### PR TITLE
Use strict Data.Map and LANGUAGE StrictData where it seems to matter

### DIFF
--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -24,7 +24,7 @@ module Cooked.MockChain (
   ) where
 
 import           Data.Void
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import           Data.Maybe (mapMaybe, catMaybes, fromJust)
 import           Control.Arrow (second)
@@ -60,10 +60,10 @@ validateTx tx = do
       let consumedIns = map Pl.txInRef $ S.toList (Pl.txInputs tx) ++ S.toList (Pl.txCollateral tx)
       consumedDHs <- catMaybes <$> mapM (fmap Pl.txOutDatumHash . outFromOutRef) consumedIns
       let consumedDHs' = M.fromList $ zip consumedDHs (repeat ())
-      modify (\st -> st { mcstIndex = ix'
-                        , mcstDatums = (mcstDatums st `M.difference` consumedDHs')
-                                       `M.union` Pl.txData tx
-                        })
+      modify' (\st -> st { mcstIndex = ix'
+                         , mcstDatums = (mcstDatums st `M.difference` consumedDHs')
+                                        `M.union` Pl.txData tx
+                         })
 
 -- * Selecting UTxO's
 

--- a/cooked-validators/src/Cooked/MockChain/Base.hs
+++ b/cooked-validators/src/Cooked/MockChain/Base.hs
@@ -1,12 +1,13 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StrictData                 #-}
 module Cooked.MockChain.Base where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import           Control.Arrow (second)
 import           Control.Monad.Identity
 import           Control.Monad.Except
-import           Control.Monad.State
+import           Control.Monad.State.Strict
 
 import qualified Ledger.Address     as Pl
 import qualified Ledger.Blockchain  as Pl
@@ -72,7 +73,7 @@ instance (Monad m) => Monad (MockChainT m) where
   MockChainT x >>= f =
     MockChainT $ do
       xres <- x
-      modify (\st -> st { mcstSlotCtr = mcscIncrease (mcstSlotCtr st) })
+      modify' (\st -> st { mcstSlotCtr = mcscIncrease (mcstSlotCtr st) })
       unMockChain (f xres)
 
 instance (Monad m) => MonadFail (MockChainT m) where

--- a/cooked-validators/src/Cooked/MockChain/Wallet.hs
+++ b/cooked-validators/src/Cooked/MockChain/Wallet.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 module Cooked.MockChain.Wallet where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 
 import qualified Ledger                as Pl
 import qualified Ledger.Ada            as Pl

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs            #-}
+{-# LANGUAGE StrictData       #-}
 module Cooked.Tx.Constraints where
 
 import           Data.Void
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 
 import qualified Ledger as Pl hiding (unspentOutputs)
 import qualified Ledger.Constraints as Pl


### PR DESCRIPTION
Just something that stood out to my eye as I was looking at the code base. Generally, lazy maps, lazy `modify` and lazy `data` fields are a common (and very easy to fix) source of less than ideal performance, so let's avoid that in the first place.