### PR TITLE
Add a couple more constraints

### DIFF
--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -33,8 +33,12 @@ data Constraint where
   PaysPK   :: Pl.PubKeyHash -> Pl.Value -> Constraint
   SpendsPK :: SpendableOut -> Constraint
   Mints    :: [Pl.MintingPolicy] -> Pl.Value -> Constraint
+
   Before   :: Pl.POSIXTime -> Constraint
   After    :: Pl.POSIXTime -> Constraint
+
+  ValidateIn :: Pl.POSIXTimeRange -> Constraint
+  SignedBy   :: [Pl.PubKeyHash] -> Constraint
 
   -- TODO: add more constraints
 
@@ -70,6 +74,8 @@ toLedgerConstraint (Before t) = (mempty, constr)
   where constr = Pl.mustValidateIn (Pl.to t)
 toLedgerConstraint (After t) = (mempty, constr)
   where constr = Pl.mustValidateIn (Pl.from t)
+toLedgerConstraint (ValidateIn r) = (mempty, Pl.mustValidateIn r)
+toLedgerConstraint (SignedBy pkhs) = (mempty, foldMap Pl.mustBeSignedBy pkhs)
 
 -- * Converting 'Constraint's to 'Pl.ScriptLookups' and 'Pl.TxConstraints'
 


### PR DESCRIPTION
Add a couple more constraints that I saw being used in the wild.

I'm not sure if `mustBeSignedBy` requires any script lookups — I think it doesn't, since it seems to be purely a pubkey hash check, but worth double-checking.