### PR TITLE
Use github commit sha on cache key to improve cache updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
             ~/.cabal/store
             dist-newstyle
           key: cabal-cache-${{ github.sha }}
-          recovery-keys: |
+          restore-keys: |
             cabal-cache
             new-cabal
       - name: Cabal update.


### PR DESCRIPTION
As cabal updates itself, the store changes, which means `cabal build` still has to do a lot of work to build things. On the limit, this can render our cache useless. 

Having seen [the cache eviction policy](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy) and [how github matches on keys](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key), I'm attempting to create caches that are named `cabal-cache-$COMMIT_SHA`, but restoring on `cabal-cache`. I'm hoping that the eviction policy will evict older caches first, so we can have an ever evolving cache.