### PR TITLE
Fix shebang in scripts in tests directory

### DIFF
--- a/tests/fourmolu-pre-commit-hook.sh
+++ b/tests/fourmolu-pre-commit-hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # command taken from https://github.com/JLLeitschuh/ktlint-gradle  task addKtlintFormatGitPreCommitHook

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 set -uo pipefail
 
 show_help() {


### PR DESCRIPTION
This changes the shebangs in the scripts in the tests directory so they work regardless of where the bash binary is in the system (in particular they did not work on NixOS)