### PR TITLE
Add haskell-language-server-wrapper to dev deps

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -16,15 +16,18 @@ let
   #
   # To do that, we create a hackage-package and specify a patch
   # inside its 'modules' key:
-  custom-hls = (iohkpkgs.haskell-nix.hackage-package {
-    compiler-nix-name = "ghc810420210212";
-    name = "haskell-language-server";
-    version = "1.5.1.0";
-    modules = [{
-          packages.ghcide.patches = [ patches/ghcide_partial_iface.patch ];
-          packages.ghcide.flags.ghc-patched-unboxed-bytecode = true;
-        }];
-  }).components.exes.haskell-language-server;
+  custom-hls =
+    with
+    (iohkpkgs.haskell-nix.hackage-package {
+      compiler-nix-name = "ghc810420210212";
+      name = "haskell-language-server";
+      version = "1.5.1.0";
+      modules = [{
+        packages.ghcide.patches = [ patches/ghcide_partial_iface.patch ];
+        packages.ghcide.flags.ghc-patched-unboxed-bytecode = true;
+      }];
+    }).components.exes;
+    [haskell-language-server haskell-language-server-wrapper];
 in { 
   # We will split our dependencies into those deps that are needed for
   # building and testing; and those that are needed for development


### PR DESCRIPTION
Some editors, including neovim (builtin LSP client with `lspconfig`), rely by default on the `haskell-language-server-wrapper` bin to launch to the language server. This PR adds it to the nix shell.