### PR TITLE
Allow depending on mockchain implementation features in transactions

### DIFF
--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -28,7 +28,7 @@ import qualified Ledger as Pl
 -- | Spends some value from a pubkey by selecting the needed utxos belonging
 --  to that pubkey and returning the leftover to the same pubkey.
 --  This function is here to avoid an import cycle.
-spentByPK :: MonadMockChain m => Pl.PubKeyHash -> Pl.Value -> m [Constraint]
+spentByPK :: MonadMockChain m => Pl.PubKeyHash -> Pl.Value -> m [Constraint (SupportedCtrFeatures m)]
 spentByPK pkh val = do
   allOuts <- pkUtxos pkh
   let (toSpend, leftOver) = spendValueFrom val $ map (second Pl.toTxOut) allOuts

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -18,7 +19,7 @@ prettyEnum :: Doc ann -> Doc ann -> [Doc ann] -> Doc ann
 prettyEnum title tag items =
   PP.hang 1 $ PP.vsep $ title : map (tag <+>) items
 
-prettyTxSkel :: TxSkel -> Doc ann
+prettyTxSkel :: TxSkel features -> Doc ann
 prettyTxSkel (TxSkel lbl signer constr) =
   PP.vsep $
     map ("-" <+>) $
@@ -34,7 +35,7 @@ prettyWallet pkh =
   where
     phash = prettyHash pkh
 
-prettyConstraint :: Constraint -> Doc ann
+prettyConstraint :: Constraint features -> Doc ann
 prettyConstraint (PaysScript val outs) =
   prettyEnum ("PaysScript" <+> prettyTypedValidator val) "-" (map (uncurry (prettyDatumVal val)) outs)
 prettyConstraint (SpendsScript val red outdat) =

--- a/examples/src/Forge/ExampleTokens.hs
+++ b/examples/src/Forge/ExampleTokens.hs
@@ -13,21 +13,15 @@
 
 module Forge.ExampleTokens where
 
-import Data.Aeson (FromJSON, ToJSON)
 import qualified Forge
-import GHC.Generics (Generic)
 import qualified Ledger
-import qualified Ledger.Ada as Ada
 import qualified Ledger.Contexts as Validation
 import qualified Ledger.Typed.Scripts as Scripts
 import qualified Ledger.Value as Value
 import qualified Plutus.Contracts.Currency as Currency
-import qualified Plutus.V2.Ledger.Api as Api
 import qualified PlutusTx
 import qualified PlutusTx.AssocMap as AssocMap
 import PlutusTx.Prelude hiding (Applicative (..))
-import Schema (ToSchema)
-import qualified Prelude as Haskell
 
 -- * Minting Policies
 

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -53,7 +53,7 @@ mkParams = do
   out <- mkThreadToken (wallet 1)
   pure $ Params (walletPK <$> knownWallets) 2 $ threadTokenAssetClass out
   where
-    mkThreadTokenInputSkel :: Wallet -> TxSkel
+    mkThreadTokenInputSkel :: Wallet -> TxSkel fs
     mkThreadTokenInputSkel w = txSkel w [PaysPK (walletPKHash w) mempty]
 
     mkThreadToken :: MonadMockChain m => Wallet -> m Pl.TxOutRef
@@ -349,7 +349,12 @@ execute tParms (parms, tokenRef) = do
 -- ** Auth Token Ducplication Attack
 
 -- Modifies a transaction skeleton by attempting to mint one more provenance token.
-dupTokenAttack :: SpendableOut -> (Params, Pl.TxOutRef) -> TxSkel -> Maybe TxSkel
+dupTokenAttack ::
+  (fs ~ SupportedCtrFeatures StagedMockChain) =>
+  SpendableOut ->
+  (Params, Pl.TxOutRef) ->
+  TxSkel fs ->
+  Maybe (TxSkel fs)
 dupTokenAttack sOut (parms, tokenRef) (TxSkel l s cs) =
   Just $ TxSkel (Just $ DupTokenAttacked l) s (cs ++ attack)
   where


### PR DESCRIPTION
A stab at requiring certain blockchain implementations features in transactions.

`Constraint` (and, transitively, `TxSkel`) is now parameterized by the list of the "features" of the context in which it lives or is interpreted, so, for instance, one of its constructors looks like this:
```haskell
data CtrFeature = Multisign | ...

data Constraint (features :: [CtrFeature]) :: Type where
  SignedBy :: 'Multisign `Elem` features ~ 'True => [Wallet] -> Constraint features
```
which basically says that `SignedBy` is only allowed in a context supporting multiple signatures (names are up for discussion!). Then, using it in a context which does not support that results in a somewhat understandable _compile-time_ error:
```
    * Couldn't match type `Elem 'Multisign fs' with 'True
        arising from a use of `SignedBy'
```

Let me know if you think the extra complexity and cognitive overhead is worth the extra type safety. I'm equally happy to do some finishing touches (like documentation and maybe fixing naming) as well as just ditching this.