### PR TITLE
Make the types of `somewhere` and `everywhere` more general.

### DIFF
--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -63,6 +63,7 @@ library
     , scientific
     , streaming
     , tasty
+    , tasty-hunit
     , text
     , transformers
   default-language: Haskell2010
@@ -72,6 +73,7 @@ test-suite spec
   main-is: Spec.hs
   other-modules:
       Cooked.BalanceSpec
+      Cooked.MockChain.Monad.StagedSpec
       Cooked.QuickValueSpec
       Paths_cooked_validators
   hs-source-dirs:
@@ -108,6 +110,7 @@ test-suite spec
     , scientific
     , streaming
     , tasty
+    , tasty-hunit
     , text
     , transformers
   default-language: Haskell2010

--- a/cooked-validators/package.yaml
+++ b/cooked-validators/package.yaml
@@ -34,6 +34,7 @@ dependencies:
   - scientific
   - streaming
   - tasty
+  - tasty-hunit
   - text
   - transformers
   - HUnit

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -230,7 +230,7 @@ waitNMilliSeconds n = do
 -- | Monads supporting modifying transaction skeletons with modalities.
 class (Monad m) => MonadModal m where
   -- | Applies a modification to all possible transactions in a tree. If a modification
-  -- cannot be applied anywhewhere, this is the identity: @everywhere (const Nothing) x == x@.
+  -- cannot be applied anywhere, this is the identity: @everywhere (const Nothing) x == x@.
   everywhere :: (TxSkel -> Maybe TxSkel) -> m a -> m a
 
   -- | Applies a modification to some transactions in a tree, note that

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -229,14 +229,15 @@ waitNMilliSeconds n = do
 
 -- | Monads supporting modifying transaction skeletons with modalities.
 class (Monad m) => MonadModal m where
-  -- | Applies a modification to all transactions in a tree
-  everywhere :: (TxSkel -> TxSkel) -> m () -> m ()
+  -- | Applies a modification to all possible transactions in a tree. If a modification
+  -- cannot be applied anywhewhere, this is the identity: @everywhere (const Nothing) x == x@.
+  everywhere :: (TxSkel -> Maybe TxSkel) -> m a -> m a
 
   -- | Applies a modification to some transactions in a tree, note that
   -- @somewhere (const Nothing) x == empty@, because 'somewhere' implies
   -- progress, hence if it is not possible to apply the transformation anywhere
   -- in @x@, there would be no progress.
-  somewhere :: (TxSkel -> Maybe TxSkel) -> m () -> m ()
+  somewhere :: (TxSkel -> Maybe TxSkel) -> m a -> m a
 
 -- ** Deriving further 'MonadBlockChain' instances
 

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -50,7 +50,7 @@ data MockChainOp a where
 data StagedMockChain a where
   Return :: a -> StagedMockChain a
   Instr :: MockChainOp a -> (a -> StagedMockChain b) -> StagedMockChain b
-  -- Modify is implemented as a seoarate constructor into `StagedMockChain` to simplify
+  -- Modify is implemented as a separate constructor into `StagedMockChain` to simplify
   -- the definition of `interpretOp`; otherwise, we'd need to pass the set of modalities
   -- one is interpreting into `interpretOp`.
   Modify :: Modality TxSkel -> StagedMockChain a -> (a -> StagedMockChain b) -> StagedMockChain b

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -50,16 +50,10 @@ data MockChainOp a where
 data StagedMockChain a where
   Return :: a -> StagedMockChain a
   Instr :: MockChainOp a -> (a -> StagedMockChain b) -> StagedMockChain b
-  -- Here's the catch! Because modify will yield a list of results, its as if
-  -- the modified tree returned a list of things; but the type can't be
-  -- StagedMockChain [a] because then, StagedMockChain wouldn't be a functor.
-  -- We have two options, define:
-  --
-  -- Modify :: TxModality -> StagedMockchain a -> ([a] -> b) -> StagedMockChain b
-  --
-  -- Where the pure function ([a] -> b) is the observation over the non-determistic computation,
-  -- or, we stick to not observing the computation at all:
-  Modify :: Modality TxSkel -> StagedMockChain () -> StagedMockChain a -> StagedMockChain a
+  -- Modify is implemented as a seoarate constructor into `StagedMockChain` to simplify
+  -- the definition of `interpretOp`; otherwise, we'd need to pass the set of modalities
+  -- one is interpreting into `interpretOp`.
+  Modify :: Modality TxSkel -> StagedMockChain a -> (a -> StagedMockChain b) -> StagedMockChain b
 
 singleton :: MockChainOp a -> StagedMockChain a
 singleton op = Instr op Return
@@ -67,7 +61,7 @@ singleton op = Instr op Return
 instance Functor StagedMockChain where
   fmap f (Return x) = Return $ f x
   fmap f (Instr op cont) = Instr op (fmap f . cont)
-  fmap f (Modify h m cont) = Modify h m (fmap f cont)
+  fmap f (Modify h m cont) = Modify h m (fmap f . cont)
 
 instance Applicative StagedMockChain where
   pure = Return
@@ -76,7 +70,7 @@ instance Applicative StagedMockChain where
 instance Monad StagedMockChain where
   (Return x) >>= f = f x
   (Instr i m) >>= f = Instr i (m >=> f)
-  (Modify h tree cont) >>= f = Modify h tree (cont >>= f)
+  (Modify h tree cont) >>= f = Modify h tree (cont >=> f)
 
 -- I) return x >>= f ~ f x
 --
@@ -87,7 +81,7 @@ instance Monad StagedMockChain where
 -- Induction on m; case m of
 --   Return x -> Rturn x >>= return ~ return x ~ Return x
 --   Instr i m -> Instr i m >>= return ~ Instr i (m >=> return) ~ Instr i m
---   Modify h t c -> Modify h t c >>= return ~ Modify h t (c >>= return) ~ Modify h t c
+--   Modify h t c -> Modify h t c >>= return ~ Modify h t (c >=> return) ~ Modify h t c
 --
 --
 -- III) (h >>= g) >>= j ~ h >>= (g >=> j)
@@ -105,9 +99,9 @@ instance Monad StagedMockChain where
 --             ~  Instr i m >>= (h >=> j)
 --
 --   Modify h t c -> (Modify h t c >>= h) >>= j
---                 ~ Modify h t (c >>= h) >>= j
---                 ~ Modify h t ((c >>= h) >>= j)
---                 ~ Modify h t (c >>= (h >=> j))
+--                 ~ Modify h t (c >=> h) >>= j
+--                 ~ Modify h t ((c >=> h) >>= j)
+--                 ~ Modify h t (c >=> (h >=> j))
 --                 ~ Modify h t c >>= (h >=> j)
 --
 -- On our particular case, it must be that (Modify (Everwhere f) Return c ~ c),
@@ -146,8 +140,8 @@ instance MonadMockChain StagedMockChain where
   askSigners = singleton AskSigners
 
 instance MonadModal StagedMockChain where
-  somewhere m tree = Modify (Somewhere m) tree (Return ())
-  everywhere m tree = Modify (Everywhere m) tree (Return ())
+  somewhere m tree = Modify (Somewhere m) tree Return
+  everywhere m tree = Modify (Everywhere m) tree Return
 
 type InterpMockChain = MockChainT (WriterT TraceDescr [])
 
@@ -172,21 +166,18 @@ interpret = goDet
     goDet :: StagedMockChain a -> InterpMockChain a
     goDet (Return a) = return a
     goDet (Instr op f) = interpBind op (goDet . f)
-    goDet (Modify c block cont) = goMod [c] block >> goDet cont
+    goDet (Modify c block cont) = goMod [c] block >>= goDet . cont
 
     -- Interprets a staged MockChain with modalities over the transactions
     -- that are meant to be submitted.
     goMod :: [Modality TxSkel] -> StagedMockChain a -> InterpMockChain a
     -- When returning, if we are returning from a point where a /Somewhere/ modality is yet to be consumed,
     -- return empty. If we return a, it would correspond to a trace where the modality was never applied.
-    --
-    -- TODO: I'm not entirely sure about this, actually! In particular, it means that the law
-    --       we devised above can't hold! Modify (Somewhere f) (Return ()) x >>= h ~> empty
     goMod ms (Return a)
       | any isSomewhere ms = empty
       | otherwise = return a
     -- When interpreting a new modality, we just compose them by pushing it into the stack
-    goMod ms (Modify m block cont) = goMod (m : ms) block >> goMod ms cont
+    goMod ms (Modify m block cont) = goMod (m : ms) block >>= goMod ms . cont
     -- Finally, when interpreting a instruction, we evaluate the modalities
     goMod ms (Instr (ValidateTxSkel opts skel) f) =
       asum $ map (uncurry (validateThenGoMod opts f)) $ interpModalities ms skel
@@ -211,7 +202,7 @@ interpretAndRun smc = interpretAndRunRaw smc def def
 -- * Modalities
 
 -- | Modalities apply a function to a trace;
-data Modality a = Somewhere (a -> Maybe a) | Everywhere (a -> a)
+data Modality a = Somewhere (a -> Maybe a) | Everywhere (a -> Maybe a)
 
 isSomewhere :: Modality a -> Bool
 isSomewhere (Somewhere _) = True
@@ -232,9 +223,11 @@ isSomewhere _ = False
 --  of a modality, and which modalities to consider when continuing to evaluate such universe.
 interpModalities :: [Modality a] -> a -> [(a, [Modality a])]
 interpModalities [] s = [(s, [])]
-interpModalities (Everywhere f : ms) s = map here $ interpModalities ms s
+interpModalities (Everywhere f : ms) s = concatMap here $ interpModalities ms s
   where
-    here (hs, mods) = (f hs, Everywhere f : mods)
+    here (hs, mods)
+      | Just fhs <- f hs = [(fhs, Everywhere f : mods)]
+      | otherwise = []
 interpModalities (Somewhere f : ms) s = concatMap hereOrThere $ interpModalities ms s
   where
     hereOrThere (hs, mods)

--- a/cooked-validators/src/Cooked/MockChain/UtxoState.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoState.hs
@@ -23,10 +23,12 @@ import qualified Prettyprinter
 
 -- | A 'UtxoState' provides us with the mental picture of the state of the UTxO graph.
 newtype UtxoState = UtxoState {utxoState :: M.Map Pl.Address [(Pl.Value, Maybe UtxoDatum)]}
+  deriving (Eq)
 
 -- | A 'UtxoDatum' contains a datum whic his @Datum $ Pl.toBuiltinData x@ for some @x :: X@,
 -- but we also include @show x@ to be able to print this value in a more user friendly fashion.
 data UtxoDatum = UtxoDatum {utxoDatum :: Pl.Datum, utxoShow :: String}
+  deriving (Eq)
 
 instance Show UtxoDatum where
   show = utxoShow

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -1,0 +1,34 @@
+module Cooked.MockChain.Monad.StagedSpec (spec) where
+
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Writer
+import Cooked.MockChain
+import Data.Default
+import Test.HUnit
+import Test.Hspec
+import Test.QuickCheck
+
+imcEq :: (Show a, Eq a) => InterpMockChain a -> InterpMockChain a -> Assertion
+imcEq a b = go a @?= go b
+  where
+    go = map fst . runWriterT . runMockChainTRaw def def
+
+assertAll :: [a] -> (a -> Assertion) -> Assertion
+assertAll space f = mapM_ f space
+
+possibleTraces :: [StagedMockChain Int]
+possibleTraces = [return 42] -- TODO: write more traces to test for laws
+
+spec :: Spec
+spec = do
+  describe "MonadModal" $ do
+    describe "somewhere is lawful" $ do
+      it "somewhere (const Nothing) == const empty" $
+        assertAll possibleTraces $ \tr ->
+          interpret (somewhere (const Nothing) tr) `imcEq` empty
+
+    describe "everywhere is lawful" $ do
+      it "everywhere (const Nothing) == id" $
+        assertAll possibleTraces $ \tr ->
+          interpret (everywhere (const Nothing) tr) `imcEq` interpret tr

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -7,7 +7,6 @@ import Cooked.MockChain
 import Data.Default
 import Test.HUnit
 import Test.Hspec
-import Test.QuickCheck
 
 imcEq :: (Show a, Eq a) => InterpMockChain a -> InterpMockChain a -> Assertion
 imcEq a b = go a @?= go b

--- a/cooked-validators/tests/Spec.hs
+++ b/cooked-validators/tests/Spec.hs
@@ -1,4 +1,5 @@
 import qualified Cooked.BalanceSpec as Ba
+import qualified Cooked.MockChain.Monad.StagedSpec as StagedSpec
 import qualified Cooked.QuickValueSpec as QuickValueSpec
 import Test.Hspec
 
@@ -9,3 +10,4 @@ spec :: Spec
 spec = do
   describe "Balancing transactions" Ba.spec
   describe "Quick values" QuickValueSpec.spec
+  describe "Staged monad" StagedSpec.spec


### PR DESCRIPTION
While writing a blog post, I realised that some comments about our
MonadModal decisions were actually false. Its perfectly possible to
have `somewhere :: (Tx -> Maybe Tx) -> m a -> m a`.

Moreover, I changed `everywhere`'s type to be the same as `somewhere`
and added a test to check one of the laws that should be satisfied
due to their duality.