### PR TITLE
More work on modalities in the lights of the blogpost

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -17,6 +17,7 @@ import Control.Monad.Trans.Control
 import Cooked.MockChain.Wallet
 import Cooked.Tx.Constraints
 import Data.Default
+import Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromJust)
 import Data.Void
@@ -234,7 +235,7 @@ waitNMilliSeconds n = do
 -- we want (a) all branches of @somewhere f tree@ to have a guarantee that they had exactly one action
 -- modified by @f@ and (b) we want 'everywhere' to be the dual of 'somewhere', so its type must be the same.
 class (Monad m) => MonadModal m where
-  type Action m :: *
+  type Action m :: Type
 
   -- | Applies a modification to all possible actions in a tree. If a modification
   -- cannot be applied anywhere, this is the identity: @everywhere (const Nothing) x == x@.
@@ -256,7 +257,7 @@ class (Monad m) => MonadModal m where
 -- > deriving via (AsTrans (ReaderT r) m) instance MonadBlockChain m => MonadBlockChain (ReaderT r m)
 --
 -- and avoid the boilerplate of defining all the methods of the class yourself.
-newtype AsTrans t (m :: * -> *) a = AsTrans {getTrans :: t m a}
+newtype AsTrans t (m :: Type -> Type) a = AsTrans {getTrans :: t m a}
   deriving newtype (Functor, Applicative, Monad, MonadFail, MonadTrans)
 
 instance (MonadTrans t, MonadBlockChain m, MonadFail (t m)) => MonadBlockChain (AsTrans t m) where

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -83,7 +83,7 @@ spec = do
           g x = x * 5
           ms = [Somewhere (Just . f), Somewhere (Just . g)]
           x = 12
-       in map (id *** length) (interpModalities ms x)
+       in map (second length) (interpModalities ms x)
             @?= [ (f (g x), 0),
                   (g x, 1),
                   (f x, 1),

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -42,10 +42,22 @@ spec = do
         interpret (everywhere (const Nothing) tr) `imcEq` interpret tr
 
   it "Somewhere is exponential in branch number" $
+    -- We'll make a trace @tr = a >> b@ with two transactions. Then, we'll execute:
+    --
+    -- > somewhere f $ somewhere g $ tr
+    --
+    -- And we expect there to be four traces as a result:
+    --
+    -- > 1. f (g a) >> b
+    -- > 2. f a >> g b
+    -- > 3. g a >> f b
+    -- > 4. a >> f (g b)
+    --
+    -- Because we're choosing @f = g = id@, we exept the four traces to be equal to tr.
     let tr =
           validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
             >> validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8400)]
-     in interpret (somewhere Just $ somewhere Just tr) `imcEq` asum (replicate 2 $ interpret tr)
+     in interpret (somewhere Just $ somewhere Just tr) `imcEq` asum (replicate 4 $ interpret tr)
 
   it "Modality order is respected" $
     let -- Sample trace

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -1,10 +1,14 @@
 module Cooked.MockChain.Monad.StagedSpec (spec) where
 
 import Control.Applicative
+import Control.Arrow
 import Control.Monad
 import Control.Monad.Writer
 import Cooked.MockChain
+import Cooked.Tx.Constraints
 import Data.Default
+import Data.Foldable
+import qualified Ledger.Ada as Pl
 import Test.HUnit
 import Test.Hspec
 
@@ -16,18 +20,58 @@ imcEq a b = go a @?= go b
 assertAll :: [a] -> (a -> Assertion) -> Assertion
 assertAll space f = mapM_ f space
 
-possibleTraces :: [StagedMockChain Int]
-possibleTraces = [return 42] -- TODO: write more traces to test for laws
+possibleTraces :: [StagedMockChain ()]
+possibleTraces =
+  [ return (),
+    void $ validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)],
+    void $ do
+      validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
+      validateTxConstr [PaysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200)]
+  ]
 
 spec :: Spec
 spec = do
-  describe "MonadModal" $ do
-    describe "somewhere is lawful" $ do
-      it "somewhere (const Nothing) == const empty" $
-        assertAll possibleTraces $ \tr ->
-          interpret (somewhere (const Nothing) tr) `imcEq` empty
+  describe "somewhere is lawful" $ do
+    it "somewhere (const Nothing) == const empty" $
+      assertAll possibleTraces $ \tr ->
+        interpret (somewhere (const Nothing) tr) `imcEq` empty
 
-    describe "everywhere is lawful" $ do
-      it "everywhere (const Nothing) == id" $
-        assertAll possibleTraces $ \tr ->
-          interpret (everywhere (const Nothing) tr) `imcEq` interpret tr
+  describe "everywhere is lawful" $ do
+    it "everywhere (const Nothing) == id" $
+      assertAll possibleTraces $ \tr ->
+        interpret (everywhere (const Nothing) tr) `imcEq` interpret tr
+
+  it "Somewhere is exponential in branch number" $
+    let tr =
+          validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
+            >> validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8400)]
+     in interpret (somewhere Just $ somewhere Just tr) `imcEq` asum (replicate 2 $ interpret tr)
+
+  it "Modality order is respected" $
+    let -- Sample trace
+        tr f g =
+          validateTxConstr
+            [ PaysPK
+                (walletPKHash $ wallet 2)
+                (f $ g $ Pl.lovelaceValueOf 4200)
+            ]
+        -- Function to modify some specific skeletons
+        app f (TxSkel l [PaysPK tgt val]) = Just $ TxSkel l [PaysPK tgt (f val)]
+        app f _ = Nothing
+        -- Two transformations
+        f x = Pl.lovelaceValueOf 3000
+        g x = Pl.lovelaceValueOf (2 * Pl.getLovelace (Pl.fromValue x))
+     in interpret (everywhere (app f) $ everywhere (app g) (tr id id)) `imcEq` interpret (tr f g)
+
+  describe "interpModalities" $ do
+    it "Satisfy one unit test" $
+      let f x = x + 5
+          g x = x * 5
+          ms = [Somewhere (Just . f), Somewhere (Just . g)]
+          x = 12
+       in map (id *** length) (interpModalities ms x)
+            @?= [ (f (g x), 0),
+                  (g x, 1),
+                  (f x, 1),
+                  (x, 2)
+                ]

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -42,9 +42,9 @@ spec = do
         interpret (everywhere (const Nothing) tr) `imcEq` interpret tr
 
   it "Somewhere is exponential in branch number" $
-    -- We'll make a trace @tr = a >> b@ with two transactions. Then, we'll execute:
+    -- If we make a trace @tr = a >> b@ with two transactions, Then execute:
     --
-    -- > somewhere f $ somewhere g $ tr
+    -- > tr' = somewhere f $ somewhere g $ tr
     --
     -- And we expect there to be four traces as a result:
     --
@@ -53,11 +53,13 @@ spec = do
     -- > 3. g a >> f b
     -- > 4. a >> f (g b)
     --
-    -- Because we're choosing @f = g = id@, we exept the four traces to be equal to tr.
+    -- If we execute @somewhere k tr'@ instead, we should expect to see 8 branches.
+    -- Because we're choosing @f = g = k = id@, we exept the eight traces to be equal to tr.
     let tr =
           validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
             >> validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8400)]
-     in interpret (somewhere Just $ somewhere Just tr) `imcEq` asum (replicate 4 $ interpret tr)
+     in interpret (somewhere Just $ somewhere Just $ somewhere Just tr)
+          `imcEq` asum (replicate 8 $ interpret tr)
 
   it "Modality order is respected" $
     let -- Sample trace


### PR DESCRIPTION
@mbg comments on the upcoming blogpost sparked a refactoring of `MonadModal`, in order to present it more generally. This, in turn, meant I had to write more tests to make sure the refactoring wasn't breaking anything. Lo and behold, there was a bug in the original implementation. The interpretation of a Staged mockchain has to return the list of modalities it still didn't use for each branch, this meant we needed another `StateT` hidden deep within the implementation. 

The bug is [here](https://github.com/tweag/plutus-libs/blob/e36dc39f400649f2560f9bfe01ae91bbd1c481d9/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs#L180):

```haskell
    goMod ms (Modify m block cont) = goMod (m : ms) block >>= goMod ms . cont
```

Say `ms == [Somewhere f]`, `m == Somewhere g` and `cont == Return`. We've got trouble now, since `goMod [Somewhere f] . Return == empty`, which means that we will drop all the possible branches that came from evaluating `block`, even if in some of those branches both `Somewhere` modalities would have already been consumed. The trick is to let each possible branch inform the next call of which modalities it still hasn't consumed.