### PR TITLE
Update to `plutus-apps` tag `v2021-12-20`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,3 @@
--- We never, ever, want this.
-write-ghc-environment-files: never
-
 -- Bump this if you need newer packages
 index-state: 2021-10-20T00:00:00Z
 
@@ -69,7 +66,7 @@ package cardano-crypto-praos
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus-apps.git
-  tag: v2021-12-06
+  tag: v2021-20-06
   subdir:
     freer-extras
     plutus-chain-index
@@ -103,13 +100,15 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-crypto.git
-  tag: 07397f0e50da97eaa0575d93bee7ac4b2b2576ec
+  tag: f73079303f663e028288f9f4a9e08bcca39a923e
+  --sha256: 1n87i15x54s0cjkh3nsxs4r1x016cdw1fypwmr68936n3xxsjn6q
 
 -- Copied from plutus-core
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 4ea7e2d927c9a7f78ddc69738409a5827ab66b98
+  tag: 654f5b7c76f7cc57900b4ddc664a82fc3b925fb0
+  --sha256: 0j4x9zbx5dkww82sqi086h39p456iq5xr476ylmrnpwcpfb4xai4
   subdir:
     base-deriving-via
     binary
@@ -126,7 +125,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: fd773f7a58412131512b9f694ab95653ac430852
+  tag: bb4ed71ba8e587f672d06edf9d2e376f4b055555
+  --sha256: 00h10l5mmiza9819p9v5q5749nb9pzgi20vpzpy1d34zmh6gf1cj
   subdir:
     cardano-prelude
     cardano-prelude-test
@@ -141,9 +141,11 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/j-mueller/cardano-wallet
-  tag: 6be73ab852c0592713dfe78218856d4a8a0ee69e
+  location: https://github.com/input-output-hk/cardano-wallet
+  tag: 760140e238a5fbca61d1b286d7a80ece058dc729
+  --sha256: 014njpddrlqm9bbab636h2gf58zkm0bx04i1jsn07vh5j3k0gri6
   subdir:
+    lib/dbvar
     lib/text-class
     lib/strict-non-empty-containers
     lib/core
@@ -157,7 +159,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 1f4973f36f689d6da75b5d351fb124d66ef1057d
+  tag: d613de3d872ec8b4a5da0c98afb443f322dc4dab
+  --sha256: 0lfbipfdrzay8v1pcazx0qgkda3d1j0505yig9jrml9j7991rmhl
   subdir:
     monoidal-synchronisation
     typed-protocols
@@ -201,8 +204,9 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-ledger-specs
+  location: https://github.com/input-output-hk/cardano-ledger
   tag: bf008ce028751cae9fb0b53c3bef20f07c06e333
+  --sha256: 0my3801w1vinc0kf5yh9lxl6saqxgwm6ccg0vvzi104pafcwwcqx
   subdir:
     byron/ledger/impl
     cardano-ledger-core
@@ -229,12 +233,18 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node.git
-  tag: b6ca519f97a0e795611a63174687e6bb70c9f752
+  tag: 4f65fb9a27aa7e3a1873ab4211e412af780a3648
+  --sha256: 00k9fqrm0gphjji23x0nc9z6bqh8bqrncgivn3mi3csacjzicrrx
   subdir:
     cardano-api
     cardano-node
     cardano-cli
-    cardano-config
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-config
+  tag: e9de7a2cf70796f6ff26eac9f9540184ded0e4e6
+  --sha256: 1wm1c99r5zvz22pdl8nhkp13falvqmj8dgkm8fxskwa9ydqz01ld
 
 source-repository-package
   type: git

--- a/cabal.project
+++ b/cabal.project
@@ -66,7 +66,7 @@ package cardano-crypto-praos
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus-apps.git
-  tag: v2021-20-06
+  tag: v2021-12-20
   subdir:
     freer-extras
     plutus-chain-index

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -41,7 +41,7 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
 
   txOutByRef ref = fmap Pl.toTxOut <$> C.txOutFromRef ref
 
-  ownPaymentPubKeyHash = C.ownPubKeyHash
+  ownPaymentPubKeyHash = fmap Pl.unPaymentPubKeyHash C.ownPaymentPubKeyHash
 
   currentSlot = C.currentSlot
   currentTime = C.currentTime

--- a/cooked-validators/src/Cooked/MockChain/Wallet.hs
+++ b/cooked-validators/src/Cooked/MockChain/Wallet.hs
@@ -31,7 +31,7 @@ instance Ord Wallet where
   compare = compare `on` CW.mwWalletId
 
 knownWallets :: [Wallet]
-knownWallets = CW.knownWallets
+knownWallets = CW.knownMockWallets
 
 wallet :: Int -> Wallet
 wallet j
@@ -44,7 +44,7 @@ walletPKHashToId = flip M.lookup walletPKHashToIdMap
     walletPKHashToIdMap = M.fromList . flip zip [1 ..] . map walletPKHash $ knownWallets
 
 walletPK :: Wallet -> Pl.PubKey
-walletPK = CW.pubKey
+walletPK = Pl.unPaymentPubKey . CW.paymentPubKey
 
 walletPKHash :: Wallet -> Pl.PubKeyHash
 walletPKHash = Pl.pubKeyHash . walletPK
@@ -53,7 +53,7 @@ walletAddress :: Wallet -> Pl.Address
 walletAddress = (`Pl.Address` Nothing) . Pl.PubKeyCredential . walletPKHash
 
 walletSK :: CW.MockWallet -> Pl.PrivateKey
-walletSK = CW.privateKey
+walletSK = Pl.unPaymentPrivateKey . CW.paymentPrivateKey
 
 toPKHMap :: [Wallet] -> M.Map Pl.PubKeyHash Wallet
 toPKHMap ws = M.fromList [(walletPKHash w, w) | w <- ws]
@@ -61,7 +61,7 @@ toPKHMap ws = M.fromList [(walletPKHash w, w) | w <- ws]
 -- * Signs a transaction
 
 txAddSignature :: Wallet -> Pl.Tx -> Pl.Tx
-txAddSignature w = Pl.addSignature (CW.privateKey w)
+txAddSignature w = Pl.addSignature (walletSK w) "mock-passphrase"
 
 -- * Initial distribution of funds
 

--- a/cooked-validators/src/Cooked/MockChain/Wallet.hs
+++ b/cooked-validators/src/Cooked/MockChain/Wallet.hs
@@ -61,7 +61,7 @@ toPKHMap ws = M.fromList [(walletPKHash w, w) | w <- ws]
 -- * Signs a transaction
 
 txAddSignature :: Wallet -> Pl.Tx -> Pl.Tx
-txAddSignature w = Pl.addSignature (walletSK w) "mock-passphrase"
+txAddSignature w = Pl.addSignature' (walletSK w)
 
 -- * Initial distribution of funds
 

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -59,7 +59,7 @@ toLedgerConstraint (PaysScript v outs) = (lkups, constr)
           (Pl.validatorHash $ Pl.validatorScript v)
           (Pl.Datum $ Pl.toBuiltinData d)
           val
-toLedgerConstraint (PaysPK p v) = (mempty, Pl.mustPayToPubKey p v)
+toLedgerConstraint (PaysPK p v) = (mempty, Pl.mustPayToPubKey (Pl.PaymentPubKeyHash p) v)
 toLedgerConstraint (SpendsPK (oref, o)) = (lkups, constr)
   where
     lkups = Pl.unspentOutputs (M.singleton oref o)
@@ -79,7 +79,7 @@ toLedgerConstraint (After t) = (mempty, constr)
   where
     constr = Pl.mustValidateIn (Pl.from t)
 toLedgerConstraint (ValidateIn r) = (mempty, Pl.mustValidateIn r)
-toLedgerConstraint (SignedBy hashes) = (mempty, foldMap Pl.mustBeSignedBy hashes)
+toLedgerConstraint (SignedBy hashes) = (mempty, foldMap (Pl.mustBeSignedBy . Pl.PaymentPubKeyHash) hashes)
 
 -- | Converts a list of constraints into a 'LedgerConstraint'
 toLedgerConstraints :: [Constraint] -> LedgerConstraint a

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -12,14 +12,11 @@ module Split.OffChain where
 import Control.Monad
 import Cooked.MockChain
 import Cooked.Tx.Constraints
-import Data.Aeson (FromJSON, ToJSON)
-import GHC.Generics (Generic)
 import qualified Ledger as Pl
 import qualified Ledger.Typed.Scripts as Pl
-import Playground.Contract
+import Playground.Contract hiding (ownPaymentPubKeyHash)
 import qualified Plutus.Contract as C
 import qualified Plutus.V1.Ledger.Ada as Pl
-import Schema (ToSchema)
 import Split
 import qualified Wallet.Emulator.Wallet as C
 
@@ -87,7 +84,7 @@ mkSchemaDefinitions ''SplitSchema
 mkSplitData :: LockArgs -> SplitDatum
 mkSplitData LockArgs {recipient1Wallet, recipient2Wallet, totalAda} =
   let convert :: C.Wallet -> Pl.PubKeyHash
-      convert = Pl.pubKeyHash . C.walletPubKey
+      convert = Pl.unPaymentPubKeyHash . C.mockWalletPaymentPubKeyHash
    in SplitDatum
         { recipient1 = convert recipient1Wallet,
           recipient2 = convert recipient2Wallet,

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -109,7 +110,7 @@ mkSign params pmt sk = do
   pkh <- ownPaymentPubKeyHash
   void $ validateTxConstr [PaysScript (pmultisig params) [(Sign pkh sig, mkSignLockedCost)]]
   where
-    sig = Pl.sign (Pl.sha2_256 $ packPayment pmt) sk
+    sig = Pl.sign (Pl.sha2_256 $ packPayment pmt) sk ""
 
     -- Whenever a wallet is signing a payment, it must lock away a certain amount of ada
     -- in an UTxO, otherwise, the Sign UTxO can't be created.

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -50,7 +50,7 @@ data Crowdfunding
 
 instance TScripts.ValidatorTypes Crowdfunding where
   type RedeemerType Crowdfunding = CampaignAction
-  type DatumType Crowdfunding = Ledger.PubKeyHash
+  type DatumType Crowdfunding = Ledger.PaymentPubKeyHash
 
 deriving instance Show CampaignAction
 
@@ -65,7 +65,7 @@ genCampaign collectDelta owner = do
     Campaign
       { campaignDeadline = startTime + deadline,
         campaignCollectionDeadline = startTime + collectDeadline,
-        campaignOwner = walletPKHash owner
+        campaignOwner = Ledger.PaymentPubKeyHash $ walletPKHash owner
       }
 
 -- | Provides some funds to the campaign
@@ -75,7 +75,7 @@ paysCampaign c w val =
     signs w $
       validateTxSkelOpts (def {autoSlotIncrease = False}) $
         txSkel
-          [PaysScript (typedValidator c) [(walletPKHash w, val)]]
+          [PaysScript (typedValidator c) [(Ledger.PaymentPubKeyHash $ walletPKHash w, val)]]
 
 -- | Retrieve funds as being the owner
 retrieveFunds :: (MonadMockChain m) => Ledger.POSIXTime -> Campaign -> Wallet -> m ()


### PR DESCRIPTION
Most changes happened around an additional wrapping over `PubKeyHash`:

```haskell
newtype PaymentPubKeyHash = PaymentPubKeyHash { unPaymentPubKeyHash :: PubKeyHash }
```

Now, everything that mentioned a `PubKeyHash`, now mentions its newtyped-wrapped `PaymentPubKeyHash`.
I decided to maintain a dependency on `PubKeyHash` instead of the new `PaymentPubKeyHash` mainly because that was the easier thing to do and Plutus might change again at any point. While Plutus isn't too stable and concerned with backwards compatibility, lets try to keep `cooked-validators` as stable as possible. Later on we can sit and access the pros and cons of each API decision.