### PR TITLE
Improve Balancing Mechanism

### DIFF
--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -40,5 +40,5 @@ spentByPK :: MonadBlockChain m => Pl.PubKeyHash -> Pl.Value -> m [Constraint]
 spentByPK pkh val = do
   -- TODO: maybe turn spentByPK into a pure function: spentByPK val <$> pkUtxos
   allOuts <- pkUtxos pkh
-  let (toSpend, leftOver) = spendValueFrom val $ map (second Pl.toTxOut) allOuts
+  let (toSpend, leftOver, _) = spendValueFrom val $ map (second Pl.toTxOut) allOuts
   (PaysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -136,7 +136,9 @@ data ValidateTxOpts = ValidateTxOpts
     -- | HUGE HACK; DON'T BRING IT UPSTREAM LIKE THIS
     --
     -- Applies a modification to a transaction after balancing, but before signing.
-    modBalancedTx :: RawModTx
+    modBalancedTx :: RawModTx,
+    debugBalanceTx :: Bool,
+    noBalance :: Bool
   }
   deriving (Eq, Show)
 
@@ -163,7 +165,9 @@ instance Default ValidateTxOpts where
       { adjustUnbalTx = True,
         awaitTxConfirmed = True,
         autoSlotIncrease = True,
-        modBalancedTx = Id
+        modBalancedTx = Id,
+        debugBalanceTx = False,
+        noBalance = False
       }
 
 -- | Calls 'validateTxSkelOpts' with the default set of options

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -183,7 +183,8 @@ validateTxConstr' :: (Show lbl, MonadBlockChain m) => lbl -> [Constraint] -> m P
 validateTxConstr' lbl = validateTxSkel . txSkelLbl lbl
 
 -- | A modal mock chain is a mock chain that also supports modal modifications of transactions.
-type MonadModalMockChain m = (MonadBlockChain m, MonadMockChain m, MonadModal m)
+-- Hence, modal actions are TxSkel's.
+type MonadModalMockChain m = (MonadBlockChain m, MonadMockChain m, MonadModal m, Action m ~ TxSkel)
 
 spendableRef :: (MonadBlockChain m) => Pl.TxOutRef -> m SpendableOut
 spendableRef txORef = do

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -132,7 +132,6 @@ data ValidateTxOpts = ValidateTxOpts
     -- should be no explicit ordering of what comes first. One good example is in the Crowdfunding use case contract.
     -- This has no effect when running in 'Plutus.Contract.Contract'.
     autoSlotIncrease :: Bool,
-
     -- | HUGE HACK; DON'T BRING IT UPSTREAM LIKE THIS
     --
     -- Applies a modification to a transaction after balancing, but before signing.
@@ -153,6 +152,7 @@ applyRawModTx (RawModTx f) tx = f tx
 instance Eq RawModTx where
   Id == Id = True
   _ == _ = False
+
 instance Show RawModTx where
   show Id = "Id"
   show (RawModTx _) = "RawModTx"

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -21,10 +21,10 @@ instance (C.AsContractError e) => MonadFail (C.Contract w s e) where
   fail = C.throwError . review C._OtherError . T.pack
 
 instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
-  validateTxSkelOpts opts txSkel0 = do
+  validateTxSkel txSkel0 = do
     let (lkups, constrs) = toLedgerConstraints @Void (txConstraints txSkel0)
     txId <- Pl.getCardanoTxId <$> C.submitTxConstraintsWith lkups constrs
-    when (awaitTxConfirmed opts) $ C.awaitTxConfirmed txId
+    when (awaitTxConfirmed $ txOpts txSkel0) $ C.awaitTxConfirmed txId
     return txId
 
   utxosSuchThat addr datumPred = do

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -325,7 +325,10 @@ generateTx' opts skel = do
       let adjust = if adjustUnbalTx opts then Pl.adjustUnbalancedTx else id
       signers <- askSigners
       balancedTx <- balanceTxFrom (NE.head signers) (adjust ubtx)
-      return $ foldl (flip txAddSignature) balancedTx (NE.toList signers)
+      return $ foldl (flip txAddSignature)
+                     -- HACK: optionally apply a transformation to a balanced tx before sending it in.
+                     (applyRawModTx (modBalancedTx opts) balancedTx)
+                     (NE.toList signers)
   where
     -- Update the map of pretty printed representations in the mock chain state
     updateDatumStr :: TxSkel -> MockChainSt -> MockChainSt

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -30,7 +30,6 @@ import Data.Maybe (catMaybes, mapMaybe)
 import qualified Data.Set as S
 import Data.Void
 import qualified Ledger as Pl
-import qualified Ledger.Value as Pl
 import qualified Ledger.Ada as Pl
 import qualified Ledger.Constraints as Pl
 import qualified Ledger.Constraints.OffChain as Pl
@@ -411,10 +410,12 @@ fakeBalance (Pl.UnbalancedTx tx0 _reqSigs _uindex slotRange) = do
 
 -- * Utilities
 
+adjustOutputValueAt :: (Pl.Value -> Pl.Value) -> Int -> [Pl.TxOut] -> [Pl.TxOut]
 adjustOutputValueAt f i xs =
   let (pref, Pl.TxOut addr val stak:rest) = L.splitAt i xs
    in pref ++ Pl.TxOut addr (f val) stak : rest
 
+addressIsPK :: Pl.Address -> Maybe Pl.PubKeyHash
 addressIsPK addr = case Pl.addressCredential addr of
                      Pl.PubKeyCredential pkh -> Just pkh
                      _ -> Nothing

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -344,7 +344,11 @@ balanceTxFrom w (Pl.UnbalancedTx tx0 _reqSigs _uindex slotRange) = do
   let lhs = mappend (mconcat $ map Pl.txOutValue lhsInputs) (Pl.txMint tx)
   let rhs = mappend (mconcat $ map Pl.txOutValue $ Pl.txOutputs tx) (Pl.txFee tx)
   let wPKH = walletPKHash w
+  let tgt = rhs Pl.- lhs
+  trace ("Balancing: " ++ show tgt) (return ())
   (usedUTxOs, leftOver) <- balanceWithUTxOsOf (rhs Pl.- lhs) wPKH
+  trace ("  Using extra UTxOs:" ++ show usedUTxOs) (return ())
+  trace ("  Leftovers are:" ++ show leftOver) (return ())
   -- All the UTxOs signed by the sender of the transaction and useful to balance it
   -- are added to the inputs.
   let txIns' = map (`Pl.TxIn` Just Pl.ConsumePublicKeyAddress) usedUTxOs

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -327,7 +327,7 @@ generateTx' skel = do
     Right ubtx -> do
       let adjust = if adjustUnbalTx opts then Pl.adjustUnbalancedTx else id
       signers <- askSigners
-      balancedTx <- balanceTxFrom (noBalance opts) (NE.head signers) (adjust ubtx)
+      balancedTx <- balanceTxFrom (not $ balance opts) (NE.head signers) (adjust ubtx)
       return $
         foldl
           (flip txAddSignature)

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -23,6 +23,7 @@ import Cooked.Tx.Balance
 import Cooked.Tx.Constraints
 import Data.Bifunctor (Bifunctor (first, second))
 import Data.Default
+import Data.Foldable (asum)
 import Data.Function (on)
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -30,7 +31,6 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, mapMaybe)
 import qualified Data.Set as S
 import Data.Void
-import Debug.Trace
 import qualified Ledger as Pl
 import qualified Ledger.Ada as Pl
 import qualified Ledger.Constraints as Pl
@@ -88,6 +88,7 @@ instance Default Pl.Slot where
 data MockChainError
   = MCEValidationError Pl.ValidationErrorInPhase
   | MCETxError Pl.MkTxError
+  | MCEUnbalanceable Pl.Tx BalanceTxRes
   | FailWith String
   deriving (Show, Eq)
 
@@ -326,10 +327,7 @@ generateTx' opts skel = do
     Right ubtx -> do
       let adjust = if adjustUnbalTx opts then Pl.adjustUnbalancedTx else id
       signers <- askSigners
-      balancedTx <-
-        if noBalance opts
-          then fakeBalance (adjust ubtx)
-          else balanceTxFrom (debugBalanceTx opts) (NE.head signers) (adjust ubtx)
+      balancedTx <- balanceTxFrom (noBalance opts) (NE.head signers) (adjust ubtx)
       return $
         foldl
           (flip txAddSignature)
@@ -346,65 +344,125 @@ generateTx' opts skel = do
               mcstStrDatums : (extractDatumStrFromConstraint <$> txConstraints)
         }
 
--- | Balances a transaction with money from a given wallet. For every transaction,
---  it must be the case that @inputs + mint == outputs + fee@.
-balanceTxFrom :: (Monad m) => Bool -> Wallet -> Pl.UnbalancedTx -> MockChainT m Pl.Tx
-balanceTxFrom dbg w (Pl.UnbalancedTx tx0 _reqSigs _uindex slotRange) = do
-  -- We start by gathering all the inputs and summing it
+-- | Sets the 'Pl.txFee' and 'Pl.txValidRange' according to our environment.
+-- TODO: bring in FeeConfig: https://github.com/tweag/plutus-libs/issues/10
+setFeeAndValidRange :: (Monad m) => Pl.UnbalancedTx -> MockChainT m Pl.Tx
+setFeeAndValidRange (Pl.UnbalancedTx tx0 _reqSigs _uindex slotRange) = do
   let tx = tx0 {Pl.txFee = Pl.minFee tx0}
+  config <- asks mceSlotConfig
+  return
+    tx {Pl.txValidRange = Pl.posixTimeRangeToContainedSlotRange config slotRange}
+
+balanceTxFrom :: (Monad m) => Bool -> Wallet -> Pl.UnbalancedTx -> MockChainT m Pl.Tx
+balanceTxFrom skipBalancing w ubtx = do
+  tx <- setFeeAndValidRange ubtx
+  if skipBalancing
+  then return tx
+  else do
+    bres <- calcBalanceTx w tx
+    case applyBalanceTx w bres tx of
+      Just tx' -> return tx'
+      Nothing -> throwError $ MCEUnbalanceable tx bres
+
+data BalanceTxRes = BalanceTxRes
+  { newInputs :: [Pl.TxOutRef],
+    returnValue :: Pl.Value,
+    remainderUtxos :: [(Pl.TxOutRef, Pl.TxOut)]
+  }
+  deriving (Eq, Show)
+
+-- | Calculate the changes needed to balance a transaction with money from a given wallet.
+-- Every transaction that is sent to the chain must be balanced, that is: @inputs + mint == outputs + fee@.
+calcBalanceTx :: (Monad m) => Wallet -> Pl.Tx -> MockChainT m BalanceTxRes
+calcBalanceTx w tx = do
+  -- We start by gathering all the inputs and summing it
   lhsInputs <- mapM (outFromOutRef . Pl.txInRef) (S.toList (Pl.txInputs tx))
   let lhs = mappend (mconcat $ map Pl.txOutValue lhsInputs) (Pl.txMint tx)
   let rhs = mappend (mconcat $ map Pl.txOutValue $ Pl.txOutputs tx) (Pl.txFee tx)
   let wPKH = walletPKHash w
   let usedInTxIns = S.map Pl.txInRef (Pl.txInputs tx)
   allUtxos <- pkUtxos' wPKH
-  let (usedUTxOs, leftOver, excess) =
-        balanceWithUTxOs (rhs Pl.- lhs) $
-          -- It is important that we only consider utxos that have not been spent in the transaction as "available"
-          filter ((`S.notMember` usedInTxIns) . fst) allUtxos
+  -- It is important that we only consider utxos that have not been spent in the transaction as "available"
+  let availableUtxos = filter ((`S.notMember` usedInTxIns) . fst) allUtxos
+  let (usedUTxOs, leftOver, excess) = balanceWithUTxOs (rhs Pl.- lhs) availableUtxos
+  return $
+    BalanceTxRes
+      { -- Now, we will add the necessary utxos to the transaction,
+        newInputs = usedUTxOs,
+        -- Pay to wPKH whatever is leftOver from newTxIns and whatever was excessive to begin with
+        returnValue = leftOver <> excess,
+        -- We also return the remainder utxos that could still be used in case
+        -- we can't 'applyBalanceTx' this 'BalanceTxRes'.
+        remainderUtxos = filter ((`L.notElem` usedUTxOs) . fst) availableUtxos
+      }
 
-  -- Now, we will add the necessary utxos to the transaction,
-  let newTxIns = S.fromList $ map (`Pl.TxIn` Just Pl.ConsumePublicKeyAddress) usedUTxOs
+-- | Once we calculated what is needed to balance a transaction @tx@, we still need to
+-- apply those changes to @tx@. Because of the 'Ledger.minAdaTxOut' constraint, this
+-- might not be possible: imagine the leftover is less than 'Ledger.minAdaTxOut', but
+-- the transaction has no output addressed to the sending wallet. If we just
+-- create a new ouput for @w@ and place the leftover there the resulting tx will fail to validate
+-- with "LessThanMinAdaPerUTxO" error. Instead, we need to consume yet another UTxO belonging to @w@ to
+-- then create the output with the proper leftover. If @w@ has no UTxO, then there's no
+-- way to balance this transaction.
+applyBalanceTx :: Wallet -> BalanceTxRes -> Pl.Tx -> Maybe Pl.Tx
+applyBalanceTx w (BalanceTxRes newTxIns leftover remainders) tx = do
+  -- Here we'll try a few things, in order, until one of them succeeds:
+  --   1. pick out the best possible output to adjust and adjust it as long as it remains with
+  --      more than 'Pl.minAdaTxOut'. No need for additional inputs.
+  --   2. if the leftover is more than 'Pl.minAdaTxOut' and (1) wasn't possible, create a new output
+  --      to return leftover. No need for additional inputs.
+  --   3. Attempt to consume other possible utxos from 'w' in order to combine them
+  --      and return the leftover.
+  (txInsDelta, txOuts') <-
+    asum $
+      [ wOutsBest >>= fmap ([],) . adjustOutputValueAt (<> leftover) (Pl.txOutputs tx), -- 1.
+        guard (isAtLeastMinAda leftover) >> return ([], Pl.txOutputs tx ++ [mkOutWithVal leftover]) -- 2.
+      ] ++ map (fmap (second (Pl.txOutputs tx ++)) . consumeRemainder) (sortByMoreAda remainders) -- 3.
 
-  -- Pay to wPKH whatever is leftOver from newTxIns and whatever was excessive to begin with
-  let adjustedLeftOver = leftOver <> excess
+  let newTxIns' = S.fromList $ map (`Pl.TxIn` Just Pl.ConsumePublicKeyAddress) (newTxIns ++ txInsDelta)
+  return $
+    tx
+      { Pl.txInputs = Pl.txInputs tx <> newTxIns',
+        Pl.txOutputs = txOuts'
+      }
+  where
+    wPKH = walletPKHash w
+    mkOutWithVal v = Pl.TxOut (Pl.Address (Pl.PubKeyCredential wPKH) Nothing) v Nothing
 
-  -- Now, all we have to do is choose (or create) an output for wPKH to add the adjusted leftOver value too.
-  -- Because we cannot create a transaction that produces a UTxO with less than Ledger.minAdaTxOut,
-  -- we make sure to complement only the largest txOut belonging to wPKH.
-  let pkhOutWithMostAda =
-        map fst $
-        L.sortBy (flip compare `on` adaVal) $
+    -- The best output to attempt and modify, if any, is the one with the most ada,
+    -- which is at the head of wOutsIxSorted:
+    wOutsBest = fst <$> L.uncons wOutsIxSorted
+
+    -- The indexes of outputs belonging to w sorted by amount of ada.
+    wOutsIxSorted :: [Int]
+    wOutsIxSorted =
+      map fst $ sortByMoreAda $
           filter ((== Just wPKH) . addressIsPK . Pl.txOutAddress . snd) $
             zip [0 ..] (Pl.txOutputs tx)
 
-  let txOuts' = case pkhOutWithMostAda of
-        [] -> Pl.txOutputs tx ++ [Pl.TxOut (Pl.Address (Pl.PubKeyCredential wPKH) Nothing) adjustedLeftOver Nothing]
-        i : _ -> adjustOutputValueAt (<> adjustedLeftOver) i (Pl.txOutputs tx)
-  config <- asks mceSlotConfig
-  return
-    tx
-      { Pl.txInputs = Pl.txInputs tx <> newTxIns,
-        Pl.txOutputs = txOuts',
-        Pl.txValidRange = Pl.posixTimeRangeToContainedSlotRange config slotRange
-      }
-  where
-    adaVal :: (a, Pl.TxOut) -> Integer
-    adaVal = Pl.getLovelace . Pl.fromValue . Pl.txOutValue . snd
+    sortByMoreAda :: [(a, Pl.TxOut)] ->  [(a, Pl.TxOut)]
+    sortByMoreAda = L.sortBy (flip compare `on` (adaVal . Pl.txOutValue . snd))
 
-fakeBalance :: (Monad m) => Pl.UnbalancedTx -> MockChainT m Pl.Tx
-fakeBalance (Pl.UnbalancedTx tx0 _reqSigs _uindex slotRange) = do
-  let tx = tx0 {Pl.txFee = Pl.minFee tx0}
-  config <- asks mceSlotConfig
-  return
-    tx {Pl.txValidRange = Pl.posixTimeRangeToContainedSlotRange config slotRange}
+    adaVal :: Pl.Value -> Integer
+    adaVal = Pl.getLovelace . Pl.fromValue
+
+    isAtLeastMinAda :: Pl.Value -> Bool
+    isAtLeastMinAda v = adaVal v >= Pl.getLovelace Pl.minAdaTxOut
+
+    adjustOutputValueAt :: (Pl.Value -> Pl.Value) -> [Pl.TxOut] -> Int -> Maybe [Pl.TxOut]
+    adjustOutputValueAt f xs i =
+      let (pref, Pl.TxOut addr val stak : rest) = L.splitAt i xs
+          val' = f val
+       in guard (isAtLeastMinAda val') >> return (pref ++ Pl.TxOut addr val' stak : rest)
+
+    -- Given a list of available utxos; attept to consume them if they would enable the returning
+    -- of the leftover.
+    consumeRemainder :: (Pl.TxOutRef, Pl.TxOut) -> Maybe ([Pl.TxOutRef], [Pl.TxOut])
+    consumeRemainder (remRef, remOut) =
+       let v = leftover <> Pl.txOutValue remOut
+        in guard (isAtLeastMinAda v) >> return ([remRef], [mkOutWithVal v])
 
 -- * Utilities
-
-adjustOutputValueAt :: (Pl.Value -> Pl.Value) -> Int -> [Pl.TxOut] -> [Pl.TxOut]
-adjustOutputValueAt f i xs =
-  let (pref, Pl.TxOut addr val stak : rest) = L.splitAt i xs
-   in pref ++ Pl.TxOut addr (f val) stak : rest
 
 addressIsPK :: Pl.Address -> Maybe Pl.PubKeyHash
 addressIsPK addr = case Pl.addressCredential addr of

--- a/cooked-validators/src/Cooked/Tx/Balance.hs
+++ b/cooked-validators/src/Cooked/Tx/Balance.hs
@@ -83,9 +83,9 @@ spendValueFrom val utxos =
     addInputToBalance curr token i (usedUTxO, leftOver, excess) =
       if i < 0
         then -- If the input of the transaction is already too big,
-          -- then we can't solve it by adding inputs to it. Instead, we keep the
-          -- excess value separate from the leftover and let the user decide what to
-          -- do with it later.
+        -- then we can't solve it by adding inputs to it. Instead, we keep the
+        -- excess value separate from the leftover and let the user decide what to
+        -- do with it later.
           (usedUTxO, leftOver, excess <> Pl.singleton curr token (negate i))
         else
           let thisTokLeftOver = Pl.valueOf leftOver curr token

--- a/cooked-validators/src/Cooked/Tx/Balance.hs
+++ b/cooked-validators/src/Cooked/Tx/Balance.hs
@@ -40,7 +40,7 @@ balanceWithUTxOs ::
 balanceWithUTxOs val =
   -- HACK: We'll order outputs and try to use those with the most ada first;
   -- should hopefully help with: https://github.com/tweag/plutus-libs/issues/71#issuecomment-1016406041
-  -- Nevertheless, we need a better solution
+  -- Nevertheless, we might eventually need a better solution
   spendValueFrom val . sortBy (flip compare `on` (adaValueOf . outValue))
   where
     adaValueOf = Pl.getLovelace . Pl.fromValue

--- a/cooked-validators/src/Cooked/Tx/Balance.hs
+++ b/cooked-validators/src/Cooked/Tx/Balance.hs
@@ -6,12 +6,12 @@
 module Cooked.Tx.Balance where
 
 import Control.Arrow ((***))
-import Data.Kind
 import Data.Function (on)
-import Data.List (sortBy)
+import Data.Kind
+import Data.List (foldl', sortBy)
+import qualified Ledger.Ada as Pl
 import qualified Ledger.Contexts as Pl
 import qualified Ledger.Value as Pl
-import qualified Ledger.Ada as Pl
 import PlutusTx.Numeric ((+), (-))
 import Prelude hiding ((+), (-))
 
@@ -29,22 +29,23 @@ instance BalancableOut (Pl.TxOutRef, Pl.TxOut) where
   outValue = Pl.txOutValue . snd
   outRef = fst
 
--- |This function will try to select a selection of outputs from the set of available
--- outputs given to it in order to have enough to balance out the given value.
+-- | This function will try to select a selection of outputs from the set of available
+--  outputs given to it in order to have enough to balance out the given value.
 balanceWithUTxOs ::
   forall out.
   (BalancableOut out) =>
   Pl.Value ->
   [out] ->
-  ([BOutRef out], Pl.Value)
+  ([BOutRef out], Pl.Value, ExcessiveValue)
 balanceWithUTxOs val =
   -- HACK: We'll order outputs and try to use those with the most ada first;
   -- should hopefully help with: https://github.com/tweag/plutus-libs/issues/71#issuecomment-1016406041
   -- Nevertheless, we need a better solution
-  spendValueFrom val . sortBy (flip compare `on` adaVal)
+  spendValueFrom val . sortBy (flip compare `on` (adaValueOf . outValue))
   where
-    adaVal :: out -> Integer
-    adaVal = Pl.getLovelace . Pl.fromValue . outValue
+    adaValueOf = Pl.getLovelace . Pl.fromValue
+
+type ExcessiveValue = Pl.Value
 
 -- | A helper to make sure that @input + mint = output + fees@ holds for a transaction.
 --
@@ -56,53 +57,52 @@ balanceWithUTxOs val =
 -- We don't balance it in this case,
 -- since we don't want to (and can't, really) choose where that extra output goes.
 --
--- This function returns the UTXOs that were spent (a subset of @utxos@) and any leftover value
--- (in case some UTXOs had more output than we actually need to balance the transaction).
+-- This function returns the UTXOs that were spent (a subset of @utxos@), any leftover value
+-- (in case some UTXOs had more output than we actually need to balance the transaction)
+-- and the excess value which needs to be routed somewhere.
 spendValueFrom ::
   forall out.
   (BalancableOut out) =>
   Pl.Value ->
   [out] ->
-  ([BOutRef out], Pl.Value)
+  ([BOutRef out], Pl.Value, ExcessiveValue)
 spendValueFrom val utxos =
   -- We then go through the output value and investigate for each token
   -- if there is a way to balance it.
-  foldl
-    (\(spentTx, leftO) (curr, tok, i) -> addInputToBalance curr tok i spentTx leftO)
-    ([], mempty)
+  foldl'
+    (\st (sym, tok, i) -> addInputToBalance sym tok i st)
+    ([], mempty, mempty)
     (Pl.flattenValue val)
   where
     addInputToBalance ::
       Pl.CurrencySymbol ->
       Pl.TokenName ->
       Integer ->
-      [BOutRef out] ->
-      Pl.Value ->
-      ([BOutRef out], Pl.Value)
-    addInputToBalance curr token i usedUTxO leftOver =
+      ([BOutRef out], Pl.Value, ExcessiveValue) ->
+      ([BOutRef out], Pl.Value, ExcessiveValue)
+    addInputToBalance curr token i (usedUTxO, leftOver, excess) =
       if i < 0
         then -- If the input of the transaction is already too big,
-        -- then no matter which inputs we add, the transaction will fail.
-        -- We still send it, in order to get the error of the chain.
-        -- However, we know it will be a "MCEValidation(...,ValueNotPreserved(...))".
-        -- We could have try to balance automatically more transaction
-        -- by simply sending the leftover to the creator of the transaction.
-        -- However, in most of the case, allocating the whole money exchanged in the transaction
-        -- is the expected situation, hence we want the author to be aware of this oversight.
-          (usedUTxO, leftOver)
+          -- then we can't solve it by adding inputs to it. Instead, we keep the
+          -- excess value separate from the leftover and let the user decide what to
+          -- do with it later.
+          (usedUTxO, leftOver, excess <> Pl.singleton curr token (negate i))
         else
           let thisTokLeftOver = Pl.valueOf leftOver curr token
-           in if i > thisTokLeftOver
-                then -- Even while using the leftover, we still are looking for some money.
+           in -- Here, the output of the transaction is bigger in i units of the (curr,token) asset class.
+              -- The first thing we check is if the leftOver happens to have enough of the needed token,
+              -- which can happen by pure accident.
+              if i <= thisTokLeftOver
+                then (usedUTxO, leftOver - Pl.singleton curr token i, excess)
+                else -- The leftover does not have enough tokens. We need to select some utxos from the
+                -- pool of available utxos; the 'necessaryUtxosFor' makes sure to never select
+                -- a repeated utxo for us.
 
                   let (newUsedUTxOs, additionalLeftover) =
                         necessaryUtxosFor curr token (i - thisTokLeftOver) utxos usedUTxO
                    in -- The part taken form the leftover, is not in the previous leftover anymore.
                       let prevLeftOver = leftOver - Pl.singleton curr token thisTokLeftOver
-                       in (usedUTxO ++ newUsedUTxOs, prevLeftOver <> additionalLeftover)
-                else -- If the leftover contains more (or exactly) money than required,
-                -- then it is simply taken from the left-over.
-                  (usedUTxO, leftOver - Pl.singleton curr token i)
+                       in (usedUTxO ++ newUsedUTxOs, prevLeftOver <> additionalLeftover, excess)
 
 -- Given an asset name (both currency and token),
 -- an integer n, a list of UTxOs and the subset of those which are already used,

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -8,7 +9,8 @@ import Cooked.MockChain.UtxoState
 import Cooked.MockChain.Wallet
 import Cooked.Tx.Constraints.Type
 import Data.Char
-import Data.Maybe (catMaybes)
+import Data.Default
+import Data.Maybe (catMaybes, mapMaybe)
 import qualified Ledger as Pl hiding (unspentOutputs)
 import qualified Ledger.Typed.Scripts as Pl (DatumType, TypedValidator, validatorScript)
 import Prettyprinter (Doc, (<+>))
@@ -19,12 +21,13 @@ prettyEnum title tag items =
   PP.hang 1 $ PP.vsep $ title : map (tag <+>) items
 
 prettyTxSkel :: [Wallet] -> TxSkel -> Doc ann
-prettyTxSkel signers (TxSkel lbl constr) =
+prettyTxSkel signers (TxSkel lbl opts constr) =
   PP.vsep $
     map ("-" <+>) $
       catMaybes
         [ Just $ "Signers:" <+> PP.list (map (prettyWallet . walletPKHash) signers),
           fmap (("Label:" <+>) . prettyDatum) lbl,
+          fmap ("Opts:" <+>) (prettyOpts opts),
           Just $ prettyEnum "Constraints:" "/\\" (map prettyConstraint constr)
         ]
 
@@ -85,6 +88,30 @@ prettyDatumVal ::
   Doc ann
 prettyDatumVal _ d value =
   PP.align $ PP.vsep $ catMaybes [Just $ prettyDatum d, mPrettyValue value]
+
+-- | Prettifies a 'TxOpts'; returns 'Nothing' if we're looking at default options.
+prettyOpts :: TxOpts -> Maybe (Doc ann)
+prettyOpts opts = case mapMaybe cmpAgainstDefAndPrint fields of
+  [] -> Nothing
+  xs -> Just $ PP.sep $ map (PP.semi <+>) xs
+  where
+    cmpAgainstDefAndPrint :: Field TxOpts -> Maybe (Doc ann)
+    cmpAgainstDefAndPrint (Field fn f)
+      | f opts == f def = Nothing
+      | otherwise = Just $ PP.pretty fn <> PP.colon <+> PP.viaShow (f opts)
+
+    -- Internal: if you add fields to TxOpts, make sure to add them here.
+    fields :: [Field TxOpts]
+    fields =
+      [ Field "adjustUnbalTx" adjustUnbalTx,
+        Field "awaitTxConfirmed" awaitTxConfirmed,
+        Field "autoSlotIncrease" autoSlotIncrease,
+        Field "unsafeModTx" unsafeModTx,
+        Field "noBalance" noBalance
+      ]
+
+data Field record where
+  Field :: (Show x, Eq x) => String -> (record -> x) -> Field record
 
 -- * Shortening Hashes from Show Instances
 

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -107,7 +107,7 @@ prettyOpts opts = case mapMaybe cmpAgainstDefAndPrint fields of
         Field "awaitTxConfirmed" awaitTxConfirmed,
         Field "autoSlotIncrease" autoSlotIncrease,
         Field "unsafeModTx" unsafeModTx,
-        Field "noBalance" noBalance
+        Field "balance" balance
       ]
 
 data Field record where

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -147,7 +147,7 @@ data TxOpts = TxOpts
     --  By default, this is set to @True@.
     autoSlotIncrease :: Bool,
     -- | Applies an arbitrary modification to a transaction after it has been pottentially adjusted ('adjustUnbalTx')
-    - and balanced. This is prefixed with /unsafe/ to draw attention that modifying a transaction at
+    -- and balanced. This is prefixed with /unsafe/ to draw attention that modifying a transaction at
     -- that stage might make it invalid. Still, this offers a hook for being able to alter a transaction
     -- in unforeseen ways. It is mostly used to test contracts that have been written for custom PABs.
     --

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -146,19 +146,19 @@ data TxOpts = TxOpts
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     --  By default, this is set to @True@.
     autoSlotIncrease :: Bool,
-    -- | Applies a modification to a transaction after it has been pottentially adjusted ('adjustUnbalTx')
-    -- and balanced. This is prefixed with /unsafe/ to draw attention that modifying a transaction at
+    -- | Applies an arbitrary modification to a transaction after it has been pottentially adjusted ('adjustUnbalTx')
+    - and balanced. This is prefixed with /unsafe/ to draw attention that modifying a transaction at
     -- that stage might make it invalid. Still, this offers a hook for being able to alter a transaction
     -- in unforeseen ways. It is mostly used to test contracts that have been written for custom PABs.
     --
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     -- By default, this is set to 'Id'.
     unsafeModTx :: RawModTx,
-    -- | Whether or not to skip balancing the transaction altogether.
+    -- | Whether to balance the transaction or not.
     --
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
-    -- By default, this is set to @False@.
-    noBalance :: Bool
+    -- By default, this is set to @True@.
+    balance :: Bool
   }
   deriving (Eq, Show)
 
@@ -189,5 +189,5 @@ instance Default TxOpts where
         awaitTxConfirmed = True,
         autoSlotIncrease = True,
         unsafeModTx = Id,
-        noBalance = False
+        balance = True
       }

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -1,9 +1,9 @@
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE ConstraintKinds #-}
 
 module Cooked.Tx.Constraints.Type where
 
@@ -49,8 +49,6 @@ type SpendsConstrs a =
     Pl.ToData (Pl.RedeemerType a),
     Show (Pl.DatumType a),
     Show (Pl.RedeemerType a),
-    Eq (Pl.DatumType a),
-    Eq (Pl.RedeemerType a),
     Typeable a
   )
 

--- a/cooked-validators/tests/Cooked/BalanceSpec.hs
+++ b/cooked-validators/tests/Cooked/BalanceSpec.hs
@@ -10,14 +10,15 @@
 
 module Cooked.BalanceSpec (spec) where
 
-import qualified Data.List as L
 import Control.Monad.Identity
 import Control.Monad.State
 import Cooked.MockChain
 import Cooked.Tx.Balance
 import Cooked.Tx.Constraints
 import qualified Data.ByteString.Char8 as BS
+import Data.Either
 import Data.Kind
+import qualified Data.List as L
 import qualified Data.Map as M
 import Data.Maybe (mapMaybe)
 import Data.String
@@ -33,7 +34,6 @@ import qualified PlutusTx.Builtins.Internal as PlI
 import Test.Hspec
 import Test.QuickCheck
 import qualified Wallet.Emulator.Wallet as Pl
-import Data.Either
 
 -- Instead of relying on Plutus TxOut and TxOutRef, we mock our own
 -- version of it for testing, this way we can generate aribtrary values.
@@ -114,20 +114,21 @@ spec = do
     -- Here wallet 11 will have 8.4 Ada, and it will want to pay 8 to wallet 1, but its not possible.
     -- It would leave it with a 0.4 ada UTxO which is less than min ada.
     it "Fails for unbalanceable transactions" $
-      let tr = validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-               >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-               >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
-      in runMockChain tr `shouldSatisfy` isLeft
+      let tr =
+            validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
+       in runMockChain tr `shouldSatisfy` isLeft
 
     -- Unlike the test above, we now want to see this being possible, but the transaction will need
     -- to consume the additional utxo of wallet 11.
     it "Uses additional utxos on demand" $
-      let tr = validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-               >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-               >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 1_700_000)]
-               >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
-      in runMockChain tr `shouldSatisfy` isRight
-
+      let tr =
+            validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 1_700_000)]
+              >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
+       in runMockChain tr `shouldSatisfy` isRight
 
 outsOf :: Int -> Pl.UtxoIndex -> [(Pl.TxOutRef, Pl.TxOut)]
 outsOf i utxoIndex =
@@ -198,7 +199,7 @@ instance Arbitrary Pl.Value where
       x = arbitrary
 
 instance Arbitrary MockReference where
-  arbitrary = MockReference <$> (vectorOf 5 $ elements ['a'..'z'])
+  arbitrary = MockReference <$> vectorOf 5 (elements ['a' .. 'z'])
 
 instance Arbitrary MockBalancable where
   arbitrary = MockBalancable . vwmValue @Positive <$> arbitrary

--- a/cooked-validators/tests/Cooked/BalanceSpec.hs
+++ b/cooked-validators/tests/Cooked/BalanceSpec.hs
@@ -126,7 +126,7 @@ spec = do
       let tr =
             validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
               >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 1_700_000)]
+              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 3_700_000)]
               >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
        in runMockChain tr `shouldSatisfy` isRight
 

--- a/cooked-validators/tests/Cooked/BalanceSpec.hs
+++ b/cooked-validators/tests/Cooked/BalanceSpec.hs
@@ -10,6 +10,7 @@
 
 module Cooked.BalanceSpec (spec) where
 
+import qualified Data.List as L
 import Control.Monad.Identity
 import Control.Monad.State
 import Cooked.MockChain
@@ -18,6 +19,7 @@ import Cooked.Tx.Constraints
 import qualified Data.ByteString.Char8 as BS
 import Data.Kind
 import qualified Data.Map as M
+import Data.Maybe (mapMaybe)
 import Data.String
 import qualified Ledger.Crypto as Pl
 import qualified Ledger.Index as Pl
@@ -32,16 +34,96 @@ import Test.Hspec
 import Test.QuickCheck
 import qualified Wallet.Emulator.Wallet as Pl
 
-newtype MockBalancable = MockBalancable {getMBValue :: Pl.Value}
+-- Instead of relying on Plutus TxOut and TxOutRef, we mock our own
+-- version of it for testing, this way we can generate aribtrary values.
+
+newtype MockReference = MockReference {mrRef :: String}
   deriving (Eq, Show)
 
-instance BalancableOut MockBalancable where
-  type BOutRef MockBalancable = MockBalancable
-  outValue = getMBValue
-  outRef = id
+newtype MockBalancable = MockBalancable {mbValue :: Pl.Value}
+  deriving (Eq, Show)
 
-strings :: Int -> [Pl.BuiltinByteString]
-strings m = [PlI.BuiltinByteString $ BS.singleton c | c <- take m ['a' ..]]
+type MockOutOutRef = (MockReference, MockBalancable)
+
+instance BalancableOut (MockReference, MockBalancable) where
+  type BOutRef (MockReference, MockBalancable) = MockReference
+  outValue = mbValue . snd
+  outRef = fst
+
+spec :: SpecWith ()
+spec = do
+  describe "spendValueFrom" $ do
+    -- In a simple case, where one has only one output, it is simply to balance it.
+    it "spends money from the output" $
+      let txOut1 = outsOf 1 utxoIndex0
+       in shouldBe
+            (spendValueFrom (Pl.lovelaceValueOf 10_000) txOut1)
+            (map fst txOut1, Pl.lovelaceValueOf 99_990_000)
+    -- It is necessary to spend both outputs of w11 to gather 8 Adas (8_000_000 lovelaces).
+    it "spends money from the outputs" $
+      let Right (st, _) = tracePayWallet11
+       in let txOut11 = outsOf 11 $ mcstIndex st
+           in shouldBe
+                (spendValueFrom (Pl.lovelaceValueOf 8_000_000) txOut11)
+                (map fst txOut11, Pl.lovelaceValueOf 400_000)
+    it "spends nothing if nothing to balance" $
+      property $ \(IndependentUtxos utxos) -> do
+        let (usedUtxos, leftovers) = spendValueFrom @MockOutOutRef mempty utxos
+        usedUtxos `shouldBe` []
+        leftovers `shouldBe` mempty
+    it "if a (curr, tok) pair is unbalanced, it's used" $
+      property $ \(ValueWithMods diff :: ValueWithMods Positive) (IndependentUtxos utxos) -> do
+        let utxosCurrsToks = allUtxosCurrsToks (map snd utxos)
+            (usedUtxosRefs, _) = spendValueFrom @MockOutOutRef diff utxos
+            usedUtxos = mapMaybe (`L.lookup` utxos) usedUtxosRefs
+            usedUtxosCurrsToks = allUtxosCurrsToks usedUtxos
+        forM_ (Pl.flattenValue diff) $ \(curr, tok, _) -> do
+          when ((curr, tok) `elem` utxosCurrsToks) $
+            (curr, tok) `shouldSatisfy` (`elem` usedUtxosCurrsToks)
+    it "pointwise sum of spent and leftover" $
+      -- If @(usedUtxos, leftovers) = spendValueFrom diff utxos@, then,
+      -- for each (curr, token) in @usedUtxos@,
+      -- if there's enough of that pair in utxos, then
+      -- @usedUtxos ! (curr, token) = diff ! (curr, token) + leftovers ! (curr, token)@.
+      -- otherwise @usedUtxos ! (curr, token) = utxos ! (curr, token)@.
+      --
+      -- TODO this latter case is not necessarily a must-have for our implementation.
+      property $ \(ValueWithMods diff :: ValueWithMods Positive) (IndependentUtxos utxos) -> do
+        let (usedUtxosRefs, leftovers) = spendValueFrom @MockOutOutRef diff utxos
+            usedUtxos = mapMaybe (`L.lookup` utxos) usedUtxosRefs
+            usedUtxosTotal = Pl.flattenValue $ foldMap mbValue usedUtxos
+            allUtxosValue = foldMap outValue utxos
+        forM_ usedUtxosTotal $ \(curr, token, utxoVal) -> do
+          let rhsVal = Pl.valueOf (diff <> leftovers) curr token
+              availableVal = Pl.valueOf allUtxosValue curr token
+          if availableVal >= Pl.valueOf diff curr token
+            then (leftovers, usedUtxosTotal) `shouldSatisfy` const (utxoVal == rhsVal)
+            else (leftovers, usedUtxosTotal) `shouldSatisfy` const (utxoVal == availableVal)
+
+outsOf :: Int -> Pl.UtxoIndex -> [(Pl.TxOutRef, Pl.TxOut)]
+outsOf i utxoIndex =
+  M.foldlWithKey
+    ( \acc k tx ->
+        case Pl.txOutPubKey tx of
+          Nothing -> acc
+          Just pk ->
+            if pk == walletPKHash (wallet i)
+              then (k, tx) : acc
+              else acc
+    )
+    []
+    (Pl.getIndex utxoIndex)
+
+tracePayWallet11 :: Either MockChainError (MockChainSt, UtxoState)
+tracePayWallet11 =
+  runMockChain $ do
+    validateTxConstr
+      [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+    validateTxConstr
+      [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+    MockChainT get
+
+-- * Helper Instances
 
 instance Arbitrary Pl.CurrencySymbol where
   arbitrary = Pl.CurrencySymbol <$> elements (strings 5)
@@ -80,79 +162,22 @@ instance (ArbitraryMod cntMod, Arbitrary (cntMod Integer)) => Arbitrary (ValueWi
         pure [Pl.singleton sym tok cnt | (tok, cnt) <- symToks]
     pure $ ValueWithMods $ mconcat syms
 
+instance Arbitrary MockReference where
+  arbitrary = MockReference <$> (vectorOf 5 $ elements ['a'..'z'])
+
 instance Arbitrary MockBalancable where
   arbitrary = MockBalancable . vwmValue @Positive <$> arbitrary
 
+newtype IndependentUtxos = IndependentUtxos [MockOutOutRef]
+  deriving (Eq, Show)
+
+instance Arbitrary IndependentUtxos where
+  arbitrary = IndependentUtxos <$> (arbitrary `suchThat` (unique . map fst))
+    where
+      unique l = l == L.nub l
+
 allUtxosCurrsToks :: [MockBalancable] -> [(Pl.CurrencySymbol, Pl.TokenName)]
-allUtxosCurrsToks bs = [(curr, tok) | (curr, tok, _) <- Pl.flattenValue $ foldMap getMBValue bs]
+allUtxosCurrsToks bs = [(curr, tok) | (curr, tok, _) <- Pl.flattenValue $ foldMap mbValue bs]
 
-spec :: SpecWith ()
-spec = do
-  describe "spendValueFrom" $ do
-    -- In a simple case, where one has only one output, it is simply to balance it.
-    it "spends money from the output" $
-      let txOut1 = outsOf 1 utxoIndex0
-       in shouldBe
-            (spendValueFrom (Pl.lovelaceValueOf 10_000) txOut1)
-            (map fst txOut1, Pl.lovelaceValueOf 99_990_000)
-    -- It is necessary to spend both outputs of w11 to gather 8 Adas (8_000_000 lovelaces).
-    it "spends money from the outputs" $
-      let Right (st, _) = tracePayWallet11
-       in let txOut11 = outsOf 11 $ mcstIndex st
-           in shouldBe
-                (spendValueFrom (Pl.lovelaceValueOf 8_000_000) txOut11)
-                (map fst txOut11, Pl.lovelaceValueOf 400_000)
-    it "spends nothing if nothing to balance" $
-      property $ \utxos -> do
-        let (usedUtxos, leftovers) = spendValueFrom @MockBalancable mempty utxos
-        usedUtxos `shouldBe` []
-        leftovers `shouldBe` mempty
-    it "if a (curr, tok) pair is unbalanced, it's used" $
-      property $ \(ValueWithMods diff :: ValueWithMods Positive) utxos -> do
-        let utxosCurrsToks = allUtxosCurrsToks utxos
-            (usedUtxos, _) = spendValueFrom diff utxos
-            usedUtxosCurrsToks = allUtxosCurrsToks usedUtxos
-        forM_ (Pl.flattenValue diff) $ \(curr, tok, _) -> do
-          when ((curr, tok) `elem` utxosCurrsToks) $
-            (curr, tok) `shouldSatisfy` (`elem` usedUtxosCurrsToks)
-    it "pointwise sum of spent and leftover" $
-      -- If @(usedUtxos, leftovers) = spendValueFrom diff utxos@, then,
-      -- for each (curr, token) in @usedUtxos@,
-      -- if there's enough of that pair in utxos, then
-      -- @usedUtxos ! (curr, token) = diff ! (curr, token) + leftovers ! (curr, token)@.
-      -- otherwise @usedUtxos ! (curr, token) = utxos ! (curr, token)@.
-      --
-      -- TODO this latter case is not necessarily a must-have for our implementation.
-      property $ \(ValueWithMods diff :: ValueWithMods Positive) utxos -> do
-        let (usedUtxos, leftovers) = spendValueFrom @MockBalancable diff utxos
-            usedUtxosTotal = Pl.flattenValue $ foldMap getMBValue usedUtxos
-            allUtxosValue = foldMap getMBValue utxos
-        forM_ usedUtxosTotal $ \(curr, token, utxoVal) -> do
-          let rhsVal = Pl.valueOf (diff <> leftovers) curr token
-              availableVal = Pl.valueOf allUtxosValue curr token
-          if availableVal >= Pl.valueOf diff curr token
-            then (leftovers, usedUtxosTotal) `shouldSatisfy` const (utxoVal == rhsVal)
-            else (leftovers, usedUtxosTotal) `shouldSatisfy` const (utxoVal == availableVal)
-
-outsOf :: Int -> Pl.UtxoIndex -> [(Pl.TxOutRef, Pl.TxOut)]
-outsOf i utxoIndex =
-  M.foldlWithKey
-    ( \acc k tx ->
-        case Pl.txOutPubKey tx of
-          Nothing -> acc
-          Just pk ->
-            if pk == walletPKHash (wallet i)
-              then (k, tx) : acc
-              else acc
-    )
-    []
-    (Pl.getIndex utxoIndex)
-
-tracePayWallet11 :: Either MockChainError (MockChainSt, UtxoState)
-tracePayWallet11 =
-  runMockChain $ do
-    validateTxConstr
-      [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-    validateTxConstr
-      [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-    MockChainT get
+strings :: Int -> [Pl.BuiltinByteString]
+strings m = [PlI.BuiltinByteString $ BS.singleton c | c <- take m ['a' ..]]

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 module Cooked.MockChain.Monad.StagedSpec (spec) where
 
 import Control.Applicative
@@ -23,10 +24,10 @@ assertAll space f = mapM_ f space
 possibleTraces :: [StagedMockChain ()]
 possibleTraces =
   [ return (),
-    void $ validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)],
+    void $ validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)],
     void $ do
-      validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
-      validateTxConstr [PaysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200)]
+      validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)]
+      validateTxConstr [PaysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200000)]
   ]
 
 spec :: Spec
@@ -56,8 +57,8 @@ spec = do
     -- If we execute @somewhere k tr'@ instead, we should expect to see 8 branches.
     -- Because we're choosing @f = g = k = id@, we exept the eight traces to be equal to tr.
     let tr =
-          validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
-            >> validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8400)]
+          validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)]
+            >> validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)]
      in interpret (somewhere Just $ somewhere Just $ somewhere Just tr)
           `imcEq` asum (replicate 8 $ interpret tr)
 
@@ -67,25 +68,33 @@ spec = do
           validateTxConstr
             [ PaysPK
                 (walletPKHash $ wallet 2)
-                (f $ g $ Pl.lovelaceValueOf 4200)
+                (f $ g $ Pl.lovelaceValueOf 4_200_000)
             ]
         -- Function to modify some specific skeletons
-        app f (TxSkel l [PaysPK tgt val]) = Just $ TxSkel l [PaysPK tgt (f val)]
+        app f (TxSkel l opts [PaysPK tgt val]) = Just $ TxSkel l opts [PaysPK tgt (f val)]
         app f _ = Nothing
         -- Two transformations
-        f x = Pl.lovelaceValueOf 3000
+        f x = Pl.lovelaceValueOf 3_000_000
         g x = Pl.lovelaceValueOf (2 * Pl.getLovelace (Pl.fromValue x))
      in interpret (everywhere (app f) $ everywhere (app g) (tr id id)) `imcEq` interpret (tr f g)
 
-  describe "interpModalities" $ do
-    it "Satisfy one unit test" $
+  describe "interpModalities unit tests" $ do
+    it "works as expected for two 'Somewhere'" $
       let f x = x + 5
           g x = x * 5
           ms = [Somewhere (Just . f), Somewhere (Just . g)]
           x = 12
        in map (second length) (interpModalities ms x)
-            @?= [ (f (g x), 0),
-                  (g x, 1),
-                  (f x, 1),
-                  (x, 2)
+            @?= [ (f (g x), 0), -- applied both functions, nothing to consume
+                  (g x, 1), -- applied one, has one to consume
+                  (f x, 1), -- applied one, has one to consume
+                  (x, 2) -- applied none, has two to consume
                 ]
+
+    it "works as expected for two 'Everywhere'" $
+      let f x = 3
+          g x = x * 5
+          ms = [Everywhere (Just . f), Everywhere (Just . g)]
+          x = 12
+       in map (second length) (interpModalities ms x)
+            @?= [ (f (g x), 2) ] -- applied both, but since they stay there, there's still 2.

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NumericUnderscores #-}
+
 module Cooked.MockChain.Monad.StagedSpec (spec) where
 
 import Control.Applicative
@@ -97,4 +98,4 @@ spec = do
           ms = [Everywhere (Just . f), Everywhere (Just . g)]
           x = 12
        in map (second length) (interpModalities ms x)
-            @?= [ (f (g x), 2) ] -- applied both, but since they stay there, there's still 2.
+            @?= [(f (g x), 2)] -- applied both, but since they stay there, there's still 2.

--- a/cooked-validators/tests/Cooked/QuickValueSpec.hs
+++ b/cooked-validators/tests/Cooked/QuickValueSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 module Cooked.QuickValueSpec (spec) where
 
 import Cooked.MockChain
@@ -5,6 +6,7 @@ import Cooked.Tx.Constraints
 import qualified Data.Map as Map
 import qualified Ledger.Value as Pl
 import Test.Hspec
+import Data.Default
 
 spec :: SpecWith ()
 spec = do
@@ -24,7 +26,9 @@ customInitialDistribution =
 paymentAfterCustomInitialization :: Either MockChainError ((), UtxoState)
 paymentAfterCustomInitialization =
   runMockChainFrom customInitialDistribution $ do
-    validateTxConstr
+    validateTxConstrOpts
+      -- we have to adjust the tx in order for it not to fail with ValueLessThanMinAda
+      (def { adjustUnbalTx = True })
       [PaysPK (walletPKHash $ wallet 2) (quickValue "goldenCoins" 12)]
     return ()
 

--- a/cooked-validators/tests/Cooked/QuickValueSpec.hs
+++ b/cooked-validators/tests/Cooked/QuickValueSpec.hs
@@ -1,12 +1,11 @@
-{-# LANGUAGE NumericUnderscores #-}
 module Cooked.QuickValueSpec (spec) where
 
 import Cooked.MockChain
 import Cooked.Tx.Constraints
+import Data.Default
 import qualified Data.Map as Map
 import qualified Ledger.Value as Pl
 import Test.Hspec
-import Data.Default
 
 spec :: SpecWith ()
 spec = do
@@ -28,7 +27,7 @@ paymentAfterCustomInitialization =
   runMockChainFrom customInitialDistribution $ do
     validateTxConstrOpts
       -- we have to adjust the tx in order for it not to fail with ValueLessThanMinAda
-      (def { adjustUnbalTx = True })
+      (def {adjustUnbalTx = True})
       [PaysPK (walletPKHash $ wallet 2) (quickValue "goldenCoins" 12)]
     return ()
 

--- a/examples/src/Forge.hs
+++ b/examples/src/Forge.hs
@@ -42,7 +42,7 @@ data Params = Params
 PlutusTx.makeLift ''Params
 
 newtype DatumBigBoss = BigBoss [Api.PubKeyHash]
-  deriving stock (Haskell.Show)
+  deriving stock (Haskell.Eq, Haskell.Show)
 
 PlutusTx.unstableMakeIsData ''DatumBigBoss
 
@@ -65,7 +65,7 @@ data DatumSmith = Forge
   { owner :: Api.PubKeyHash,
     forged :: Integer
   }
-  deriving stock (Haskell.Show, Generic)
+  deriving stock (Haskell.Eq, Haskell.Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
 PlutusTx.unstableMakeIsData ''DatumSmith

--- a/examples/src/Forge/ExampleTokens.hs
+++ b/examples/src/Forge/ExampleTokens.hs
@@ -13,21 +13,15 @@
 
 module Forge.ExampleTokens where
 
-import Data.Aeson (FromJSON, ToJSON)
 import qualified Forge
-import GHC.Generics (Generic)
 import qualified Ledger
-import qualified Ledger.Ada as Ada
 import qualified Ledger.Contexts as Validation
 import qualified Ledger.Typed.Scripts as Scripts
 import qualified Ledger.Value as Value
 import qualified Plutus.Contracts.Currency as Currency
-import qualified Plutus.V2.Ledger.Api as Api
 import qualified PlutusTx
 import qualified PlutusTx.AssocMap as AssocMap
 import PlutusTx.Prelude hiding (Applicative (..))
-import Schema (ToSchema)
-import qualified Prelude as Haskell
 
 -- * Minting Policies
 

--- a/examples/src/Split.hs
+++ b/examples/src/Split.hs
@@ -35,7 +35,7 @@ data SplitDatum = SplitDatum
     recipient2 :: Ledger.PubKeyHash,
     amount :: Integer
   }
-  deriving stock (Haskell.Show, Generic)
+  deriving stock (Haskell.Eq, Haskell.Show, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
 
 type SplitRedeemer = ()

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -12,14 +12,11 @@ module Split.OffChain where
 import Control.Monad
 import Cooked.MockChain
 import Cooked.Tx.Constraints
-import Data.Aeson (FromJSON, ToJSON)
-import GHC.Generics (Generic)
 import qualified Ledger as Pl
 import qualified Ledger.Typed.Scripts as Pl
 import Playground.Contract
 import qualified Plutus.Contract as C
 import qualified Plutus.V1.Ledger.Ada as Pl
-import Schema (ToSchema)
 import Split
 import qualified Wallet.Emulator.Wallet as C
 
@@ -32,7 +29,7 @@ import qualified Wallet.Emulator.Wallet as C
 txLock :: MonadBlockChain m => Pl.TypedValidator Split -> SplitDatum -> m ()
 txLock script datum =
   void $
-    validateTxConstr'
+    validateTxConstrLbl
       (TxLock datum)
       [ PaysScript
           script
@@ -60,7 +57,7 @@ txUnlock script = do
   let share1 = half
   let share2 = amount - half
   void $
-    validateTxConstr'
+    validateTxConstrLbl
       TxUnlock
       [ SpendsScript script () (output, datum),
         PaysPK r1 (Pl.lovelaceValueOf share1),

--- a/examples/tests/ForgeSpec.hs
+++ b/examples/tests/ForgeSpec.hs
@@ -37,7 +37,7 @@ initBigBoss = do
   let bbId = (h, i)
   let oneBBNFT = Value.assetClassValue (bigBossNFT bbId) 1
   void $
-    validateTxConstr'
+    validateTxConstrLbl
       InitBigBoss
       [ mints [bigBossPolicy bbId] oneBBNFT,
         PaysScript (bigBossVal bbId) [(BigBoss [], oneBBNFT <> minAda)]
@@ -54,7 +54,7 @@ openForge bbId = do
   let oneAuthToken = Value.assetClassValue (authToken bbId) 1
   wPKH <- ownPaymentPubKeyHash
   void $
-    validateTxConstr'
+    validateTxConstrLbl
       OpenForge
       [ SpendsScript (bigBossVal bbId) Open (outBB, datBB),
         mints [authTokenPolicy bbId] oneAuthToken,
@@ -71,7 +71,7 @@ smiths bbId val = do
   pkh <- ownPaymentPubKeyHash
   (outSmith, datSmith@(Forge owner forged)) : _ <- scriptUtxosSuchThat (smithVal bbId) (\d _ -> d `belongsTo` pkh)
   void $
-    validateTxConstr'
+    validateTxConstrLbl
       (Smiths val)
       [ SpendsScript (smithVal bbId) Adjust (outSmith, datSmith),
         mints [smithingPolicy bbId] (Value.assetClassValue (smithed bbId) val),

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -81,7 +81,7 @@ mkProposal reqSigs pmt = do
       let params = Params pkTable reqSigs klass
       let threadToken = paramsToken params
       _ <-
-        validateTxConstr'
+        validateTxConstrLbl
           (ProposalSkel reqSigs pmt)
           [ mints [threadTokenPolicy (fst spendableOut) threadTokenName] threadToken,
             -- We don't have SpendsPK or PaysPK wrt the wallet `w`
@@ -107,14 +107,19 @@ mkProposal reqSigs pmt = do
 mkSign :: MonadBlockChain m => Params -> Payment -> Pl.PrivateKey -> m ()
 mkSign params pmt sk = do
   pkh <- ownPaymentPubKeyHash
-  void $ validateTxConstr [PaysScript (pmultisig params) [(Sign pkh sig, mkSignLockedCost)]]
+  void $
+    validateTxConstrOpts
+      (def {adjustUnbalTx = True})
+      [PaysScript (pmultisig params) [(Sign pkh sig, mkSignLockedCost)]]
   where
     sig = Pl.sign (Pl.sha2_256 $ packPayment pmt) sk
 
     -- Whenever a wallet is signing a payment, it must lock away a certain amount of ada
     -- in an UTxO, otherwise, the Sign UTxO can't be created.
+    -- Hence, we'll create the script utxo with 1 lovelace but we'll validate with adjustUnbalTx
+    -- set to @True@, which will increase this value to however many lovelace are currently needed.
     mkSignLockedCost :: Pl.Value
-    mkSignLockedCost = Pl.lovelaceValueOf 1 -- see issue #46
+    mkSignLockedCost = Pl.lovelaceValueOf 1
 
 minAda :: Pl.Value
 minAda = Pl.lovelaceValueOf 2000000
@@ -322,8 +327,8 @@ execute tParms (parms, tokenRef) = do
 
 -- Modifies a transaction skeleton by attempting to mint one more provenance token.
 dupTokenAttack :: SpendableOut -> (Params, Pl.TxOutRef) -> TxSkel -> Maybe TxSkel
-dupTokenAttack sOut (parms, tokenRef) (TxSkel l cs) =
-  Just $ TxSkel (Just $ DupTokenAttacked l) (cs ++ attack)
+dupTokenAttack sOut (parms, tokenRef) (TxSkel l opts cs) =
+  Just $ TxSkel (Just $ DupTokenAttacked l) opts (cs ++ attack)
   where
     attack =
       [ mints [threadTokenPolicy tokenRef threadTokenName] (paramsToken parms),

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -115,6 +115,13 @@ usageExample = assertSucceeds $ do
   txLock Split.splitValidator lockParams `as` wallet 1
   txUnlock Split.splitValidator `as` wallet 2
 
+
+ex :: (MonadMockChain m) => m ()
+ex = do
+  txLock Split.splitValidator lockParams `as` wallet 1
+  txLock Split.splitValidator lockParams2 `as` wallet 1
+  txUnlock Split.splitValidator `as` wallet 2
+
 tests :: TestTree
 tests =
   testGroup

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -49,7 +49,7 @@ txUnlock' mRecipient1 mRecipient2 mAmountChanger issuer = do
             )
           ]
   void $
-    validateTxConstr'
+    validateTxConstrLbl
       (TxUnlock' mRecipient1 mRecipient2 (fmap ($ 100) mAmountChanger))
       (constraints <> [remainderConstraint | remainder > 0])
       `as` issuer
@@ -59,24 +59,25 @@ data TxUnlock' = TxUnlock' (Maybe Wallet) (Maybe Wallet) (Maybe Integer) derivin
 -- | Template for an unlock attack.
 -- Conditions for the attack: 2 split utxos in the ledger, with the same locked
 -- amount, and sharing the same second recipient.
--- Attack: the second recipient is paid only one of his shares, the remainder
+-- Attack: the second recipient is paid only one of their shares, the remainder
 -- goes to the issuer of the transaction.
 txUnlockAttack :: MonadMockChain m => Wallet -> m ()
 txUnlockAttack issuer = do
-  (output1, datum1@(Split.SplitDatum r11 r12 amount))
-    : (output2, datum2@(Split.SplitDatum r21 _ _))
+  (output1, datum1@(Split.SplitDatum r11 r12 amount1))
+    : (output2, datum2@(Split.SplitDatum r21 r22 amount2))
     : _ <-
     scriptUtxosSuchThat Split.splitValidator (\_ _ -> True)
-  let half = Pl.lovelaceValueOf (div amount 2)
+  unless (r12 == r22) (fail "second recipiend must match")
+  let half1 = Pl.lovelaceValueOf (amount1 `div` 2)
+      half2 = Pl.lovelaceValueOf (amount2 `div` 2)
       constraints =
         [ SpendsScript Split.splitValidator () (output1, datum1),
           SpendsScript Split.splitValidator () (output2, datum2),
-          PaysPK r11 half,
-          PaysPK r12 half,
-          PaysPK r21 half,
-          PaysPK (walletPKHash issuer) half
+          PaysPK r11 half1,
+          PaysPK r12 (if amount1 > amount2 then half1 else half2),
+          PaysPK r21 half2
         ]
-  void $ validateTxConstr' TxUnlockAttack constraints `as` issuer
+  void $ validateTxConstrLbl TxUnlockAttack constraints `as` issuer
 
 data TxUnlockAttack = TxUnlockAttack deriving (Show)
 
@@ -98,7 +99,7 @@ lockParams =
   Split.SplitDatum
     { Split.recipient1 = walletPKHash (wallet 2),
       Split.recipient2 = walletPKHash (wallet 3),
-      Split.amount = 2_000_000
+      Split.amount = 20_000_000
     }
 
 -- | Parameters to share 400 among wallets 3 and 4
@@ -107,7 +108,7 @@ lockParams2 =
   Split.SplitDatum
     { Split.recipient1 = walletPKHash (wallet 4),
       Split.recipient2 = walletPKHash (wallet 3),
-      Split.amount = 4_000_000
+      Split.amount = 40_000_000
     }
 
 usageExample :: Assertion
@@ -133,8 +134,8 @@ tests =
           assertFails $ do
             txLock Split.splitValidator lockParams `as` wallet 1
             txUnlockTooMuch (wallet 2),
-      testCase "Can unlocking in small parts" $
-        assertSucceeds $ do
+      testCase "Cannot unlock in small parts" $
+        assertFails $ do
           txLock Split.splitValidator lockParams `as` wallet 1
           txUnlockNotEnough (wallet 2)
           txUnlockNotEnough (wallet 2),

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -115,7 +115,6 @@ usageExample = assertSucceeds $ do
   txLock Split.splitValidator lockParams `as` wallet 1
   txUnlock Split.splitValidator `as` wallet 2
 
-
 ex :: (MonadMockChain m) => m ()
 ex = do
   txLock Split.splitValidator lockParams `as` wallet 1

--- a/examples/tests/SplitUPLCSpec.hs
+++ b/examples/tests/SplitUPLCSpec.hs
@@ -28,7 +28,7 @@ lockParams =
   Split.SplitDatum
     { Split.recipient1 = walletPKHash (wallet 2),
       Split.recipient2 = walletPKHash (wallet 3),
-      Split.amount = 2_000_000
+      Split.amount = 20_000_000
     }
 
 tests :: TestTree

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -73,9 +73,9 @@ paysCampaign :: (MonadMockChain m) => Campaign -> Wallet -> Ledger.Value -> m ()
 paysCampaign c w val =
   void $
     signs w $
-      validateTxSkelOpts (def {autoSlotIncrease = False}) $
-        txSkel
-          [PaysScript (typedValidator c) [(walletPKHash w, val)]]
+      validateTxConstrOpts
+        (def {autoSlotIncrease = False})
+        [PaysScript (typedValidator c) [(walletPKHash w, val)]]
 
 -- | Retrieve funds as being the owner
 retrieveFunds :: (MonadMockChain m) => Ledger.POSIXTime -> Campaign -> Wallet -> m ()
@@ -83,13 +83,13 @@ retrieveFunds t c owner = do
   funds <- scriptUtxosSuchThat (typedValidator c) (\_ _ -> True)
   void $
     signs owner $
-      validateTxSkelOpts (def {autoSlotIncrease = False}) $
-        txSkel
-          ( map (SpendsScript (typedValidator c) Collect) funds
-              ++ [ PaysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds),
-                   ValidateIn $ collectionRange c
-                 ]
-          )
+      validateTxConstrOpts
+        (def {autoSlotIncrease = False})
+        ( map (SpendsScript (typedValidator c) Collect) funds
+            ++ [ PaysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds),
+                 ValidateIn $ collectionRange c
+               ]
+        )
 
 -- * Tests
 


### PR DESCRIPTION
The main purpose of this PR is to fix #71; It did take quite some work but it seems to be converging; I should be able to finish this by today. The important bits are:

* Added a specific `MockChainError` for unbalanceable transactions.
* Aggressively balancing more situations: if the input of the tx is larger, the leftover will be given to the sender. Will add an option to not to this by default, but given how hard it is to read the `ValueNotPreserved` errors from large transactions, I'm attempting to minimize those.
* Balancing now takes into account that it cannot create outputs with less than `Ledger.minAdaPerUTxO`, and will attempt to consume fresh UTxO's to avoid that.
* Renamed `ValidateTxOpts` to `TxOpts` and moved it into `TxSkel`, this way the modalities can change options too, giving us an easy way to modify options of entire traces easily without placing `TxOpts` into a state or reader
* __Made adjustUnbalTx FALSE by default__; this is important since we don't call our balancing code when running in the `Contract` monad and the PAB changed: it doesn't adjust transactions to accomotade for minAdaPerTxOut, the user has to call it themselves. I've made issue #78 to pottentially change that later.

Unrelated:
* Fix an important bug in how modalities were handled. Our test was vacuous because `adjustUnbalTx` was making everything output 2 Ada.