### PR TITLE
Handle staking credentials

### DIFF
--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -78,6 +78,7 @@ test-suite spec
       Cooked.BalanceSpec
       Cooked.MockChain.Monad.StagedSpec
       Cooked.MockChain.UtxoStateSpec
+      Cooked.MockChain.WalletSpec
       Cooked.QuickValueSpec
       Paths_cooked_validators
   hs-source-dirs:

--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -39,8 +39,6 @@ library
     , aeson
     , base >=4.9 && <5
     , bytestring
-    , cardano-crypto
-    , cardano-wallet-core
     , containers
     , data-default
     , deepseq
@@ -50,7 +48,6 @@ library
     , freer-extras
     , freer-simple
     , lens
-    , memory
     , monad-control
     , mtl
     , plutus-contract
@@ -88,8 +85,6 @@ test-suite spec
     , aeson
     , base >=4.9 && <5
     , bytestring
-    , cardano-crypto
-    , cardano-wallet-core
     , containers
     , cooked-validators
     , data-default
@@ -101,7 +96,6 @@ test-suite spec
     , freer-simple
     , hspec
     , lens
-    , memory
     , monad-control
     , mtl
     , plutus-contract

--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -39,6 +39,8 @@ library
     , aeson
     , base >=4.9 && <5
     , bytestring
+    , cardano-crypto
+    , cardano-wallet-core
     , containers
     , data-default
     , deepseq
@@ -48,6 +50,7 @@ library
     , freer-extras
     , freer-simple
     , lens
+    , memory
     , monad-control
     , mtl
     , plutus-contract
@@ -85,6 +88,8 @@ test-suite spec
     , aeson
     , base >=4.9 && <5
     , bytestring
+    , cardano-crypto
+    , cardano-wallet-core
     , containers
     , cooked-validators
     , data-default
@@ -96,6 +101,7 @@ test-suite spec
     , freer-simple
     , hspec
     , lens
+    , memory
     , monad-control
     , mtl
     , plutus-contract

--- a/cooked-validators/package.yaml
+++ b/cooked-validators/package.yaml
@@ -40,9 +40,6 @@ dependencies:
   - transformers
   - HUnit
   - QuickCheck
-  - cardano-crypto
-  - cardano-wallet-core
-  - memory
 
 library:
   source-dirs: src

--- a/cooked-validators/package.yaml
+++ b/cooked-validators/package.yaml
@@ -40,6 +40,9 @@ dependencies:
   - transformers
   - HUnit
   - QuickCheck
+  - cardano-crypto
+  - cardano-wallet-core
+  - memory
 
 library:
   source-dirs: src

--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -30,7 +30,7 @@ import Cooked.MockChain.UtxoState
 import Cooked.MockChain.UtxoState.Testing
 import Cooked.MockChain.Wallet
 import Cooked.Tx.Balance
-import Cooked.Tx.Constraints (Constraint (..), SpendableOut, paysPK)
+import Cooked.Tx.Constraints (Constraint (..), SpendableOut)
 import qualified Ledger as Pl
 
 -- | Spends some value from a pubkey by selecting the needed utxos belonging
@@ -41,4 +41,4 @@ spentByPK pkh val = do
   -- TODO: maybe turn spentByPK into a pure function: spentByPK val <$> pkUtxos
   allOuts <- pkUtxos pkh
   let (toSpend, leftOver, _) = spendValueFrom val $ map (second Pl.toTxOut) allOuts
-  (paysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend
+  (PaysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend

--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -30,7 +30,7 @@ import Cooked.MockChain.UtxoState
 import Cooked.MockChain.UtxoState.Testing
 import Cooked.MockChain.Wallet
 import Cooked.Tx.Balance
-import Cooked.Tx.Constraints (Constraint (..), SpendableOut)
+import Cooked.Tx.Constraints (Constraint (..), SpendableOut, paysPK)
 import qualified Ledger as Pl
 
 -- | Spends some value from a pubkey by selecting the needed utxos belonging
@@ -41,4 +41,4 @@ spentByPK pkh val = do
   -- TODO: maybe turn spentByPK into a pure function: spentByPK val <$> pkUtxos
   allOuts <- pkUtxos pkh
   let (toSpend, leftOver, _) = spendValueFrom val $ map (second Pl.toTxOut) allOuts
-  (PaysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend
+  (paysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -136,7 +136,7 @@ outFromOutRef outref = do
 
 -- | Return all utxos belonging to a pubkey
 pkUtxos :: (MonadBlockChain m) => Pl.PubKeyHash -> m [SpendableOut]
-pkUtxos = fmap (map fst) . flip (pkUtxosSuchThat @_ @Void) (const $ const True)
+pkUtxos pkh = map fst <$> pkUtxosSuchThat @_ @Void pkh (const $ const True)
 
 -- | Return all utxos belonging to a pubkey, but keep them as 'Pl.TxOut'. This is
 --  for internal use.

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -50,7 +50,7 @@ class (MonadFail m) => MonadBlockChain m where
   validateTxSkel :: TxSkel -> m Pl.TxId
 
   -- | Returns a list of spendable outputs that belong to a given address and satisfy a given predicate;
-  --  Additionally, return any datum present in the specific output. It is important
+  --  Additionally, return the datum present in there if it happened to be a script output. It is important
   --  to use @-XTypeApplications@ and pass a value for type variable @a@ below.
   utxosSuchThat ::
     (Pl.FromData a) =>
@@ -63,14 +63,8 @@ class (MonadFail m) => MonadBlockChain m where
 
   -- | Returns the hash of our own public key. When running in the "Plutus.Contract.Contract" monad,
   --  this is a proxy to 'Pl.ownPubKey'; when running in mock mode, the return value can be
-  --  controlled with 'signingWith': the head of the non-empty list will be considered as the "ownWallet".
+  --  controlled with 'signingWith': the head of the non-empty list will be considered as the "ownPubkey".
   ownPaymentPubKeyHash :: m Pl.PubKeyHash
-
-  -- | Returns the hash of our own staking public key. When running in the "Plutus.Contract.Contract" monad
-  -- this will error because there is no equivalent method in there yet; when running in mock mode,
-  -- the return value can be controlled with 'signingWith': the head of the non-empty list will
-  -- be considered as the "ownWallet".
-  ownStakingPubKeyHash :: m Pl.PubKeyHash
 
   -- | Returns the current slot number
   currentSlot :: m Pl.Slot
@@ -137,19 +131,14 @@ spendableRef txORef = do
   Just txOut <- txOutByRef txORef
   return (txORef, fromJust (Pl.fromTxOut txOut))
 
--- | Public-key UTxO's that have no datum, hence, can be selected easily with
---  a simpler variant of 'utxosSuchThat'.
-pkUtxosSuchThat ::
-  (MonadBlockChain m) =>
-  Pl.PubKeyHash ->
-  (Pl.Value -> Bool) ->
-  m [SpendableOut]
+-- | Public-key UTxO's have no datum, hence, can be selected easily with
+--  a simpler variant of 'utxosSuchThat'
+pkUtxosSuchThat :: (MonadBlockChain m) => Pl.PubKeyHash -> (Pl.Value -> Bool) -> m [SpendableOut]
 pkUtxosSuchThat pkh predicate =
   map fst
-    <$> utxosSuchThat @_ @()
-      -- TODO: StakingCredential?
+    <$> utxosSuchThat @_ @Void
       (Pl.Address (Pl.PubKeyCredential pkh) Nothing)
-      (const predicate)
+      (maybe predicate absurd)
 
 -- | Script UTxO's always have a datum, hence, can be selected easily with
 --  a simpler variant of 'utxosSuchThat'. It is important to pass a value for type variable @a@

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -43,14 +43,6 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
 
   ownPaymentPubKeyHash = fmap Pl.unPaymentPubKeyHash C.ownPaymentPubKeyHash
 
-  ownStakingPubKeyHash =
-    fail $
-      concat
-        [ "Cannot return our own staking public key when running under 'Contract'.",
-          "If you believe you should be able to do so, please submit an issue and",
-          "we will address this asap"
-        ]
-
   currentSlot = C.currentSlot
   currentTime = C.currentTime
   awaitSlot = C.awaitSlot

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -43,6 +43,14 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
 
   ownPaymentPubKeyHash = fmap Pl.unPaymentPubKeyHash C.ownPaymentPubKeyHash
 
+  ownStakingPubKeyHash =
+    fail $
+      concat
+        [ "Cannot return our own staking public key when running under 'Contract'.",
+          "If you believe you should be able to do so, please submit an issue and",
+          "we will address this asap"
+        ]
+
   currentSlot = C.currentSlot
   currentTime = C.currentTime
   awaitSlot = C.awaitSlot

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -27,17 +27,17 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
     when (awaitTxConfirmed $ txOpts txSkel0) $ C.awaitTxConfirmed txId
     return txId
 
-  utxosSuchThat addr datumPred = do
-    allUtxos <- M.toList <$> C.utxosAt addr
-    maybeUtxosWithDatums <- forM allUtxos $ \utxo -> do
-      let (Pl.TxOut _ val datumHash) = Pl.toTxOut $ snd utxo
-      datum <- maybe (pure Nothing) C.datumFromHash datumHash
-      let typedDatum = datum >>= Pl.fromBuiltinData . Pl.getDatum
-      pure $
-        if datumPred typedDatum val
-          then Just (utxo, typedDatum)
-          else Nothing
-    pure $ catMaybes maybeUtxosWithDatums
+  -- TODO: We're completely ignoring staking credentials here... would be
+  -- nice to issue a warning or something when the user uses this.
+  utxosSuchThat _ _ =
+    fail $
+      unwords
+        [ "The staking credential is being completely ignored.",
+          "Make sure to use addrUtxosSuchThat and craft the address",
+          "with any relevant staking credential you might have"
+        ]
+
+  addrUtxosSuchThat = addrUtxosSuchThatContract
 
   txOutByRef ref = fmap Pl.toTxOut <$> C.txOutFromRef ref
 
@@ -47,3 +47,21 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
   currentTime = C.currentTime
   awaitSlot = C.awaitSlot
   awaitTime = C.awaitTime
+
+addrUtxosSuchThatContract ::
+  forall w s e a.
+  (C.AsContractError e, Pl.FromData a) =>
+  Pl.Address ->
+  (Maybe a -> Pl.Value -> Bool) ->
+  C.Contract w s e [(SpendableOut, Maybe a)]
+addrUtxosSuchThatContract addr datumPred = do
+  allUtxos <- M.toList <$> C.utxosAt addr
+  maybeUtxosWithDatums <- forM allUtxos $ \utxo -> do
+    let (Pl.TxOut _ val datumHash) = Pl.toTxOut $ snd utxo
+    datum <- maybe (pure Nothing) C.datumFromHash datumHash
+    let typedDatum = datum >>= Pl.fromBuiltinData . Pl.getDatum
+    pure $
+      if datumPred typedDatum val
+        then Just (utxo, typedDatum)
+        else Nothing
+  pure $ catMaybes maybeUtxosWithDatums

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -28,7 +28,7 @@ import Data.Function (on)
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
-import Data.Maybe (catMaybes, mapMaybe)
+import Data.Maybe (catMaybes, isJust, mapMaybe)
 import qualified Data.Set as S
 import Data.Void
 import qualified Ledger as Pl
@@ -220,6 +220,8 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
 
   ownPaymentPubKeyHash = asks (walletPKHash . NE.head . mceSigners)
 
+  ownStakingPubKeyHash = asks (walletStakingPKHash . NE.head . mceSigners)
+
   utxosSuchThat = utxosSuchThat'
 
   currentSlot = gets mcstCurrentSlot
@@ -278,24 +280,25 @@ utxosSuchThat' addr datumPred = do
   mapMaybe (fmap assocl . rstr) <$> mapM (\(oref, out) -> (oref,) <$> go oref out) (M.toList ix')
   where
     go :: Pl.TxOutRef -> Pl.TxOut -> MockChainT m (Maybe (Pl.ChainIndexTxOut, Maybe a))
-    go oref (Pl.TxOut oaddr val mdatumH) =
+    go oref (Pl.TxOut oaddr val mdatumH) = do
+      -- We begin by attempting to lookup the given datum hash in our map of managed datums.
+      managedDatums <- gets mcstDatums
+      let mdatum = mdatumH >>= (`M.lookup` managedDatums)
+      -- Now, depending on whether we're looking at a utxo that belongs to a pk or a script,
+      -- there's a slight difference in treatment:
       case Pl.addressCredential oaddr of
-        -- A PK credential has no datum; just check whether we want to select this output or not.
-        Pl.PubKeyCredential _ ->
-          if datumPred Nothing val
-            then return . Just $ (Pl.PublicKeyChainIndexTxOut oaddr val, Nothing)
+        -- PubKey outputs are not required to have a datum, hence, if we have noe we pass it to the
+        -- predicate, otherwise we don't.
+        Pl.PubKeyCredential _ -> do
+          let ma = mdatum >>= Pl.fromBuiltinData . Pl.getDatum
+          if datumPred ma val
+            then return . Just $ (Pl.PublicKeyChainIndexTxOut oaddr val, ma)
             else return Nothing
-        -- A script credential, on the other hand, must have a datum. Hence, we'll go look on our map of
-        -- managed datum for a relevant datum, try to convert it to a value of type @a@ then see
-        -- if the user wants to select said output.
+        -- Script addresses, on the other hand, /must/ have a datum present. Hence, we check
+        -- that and fail accordingly if needed.
         Pl.ScriptCredential (Pl.ValidatorHash vh) -> do
-          managedDatums <- gets mcstDatums
           datumH <- maybe (fail $ "ScriptCredential with no datum hash: " ++ show oref) return mdatumH
-          datum <-
-            maybe
-              (fail $ "Unmanaged datum with hash: " ++ show datumH ++ " at: " ++ show oref)
-              return
-              $ M.lookup datumH managedDatums
+          datum <- maybe (fail $ "Unmanaged datum with hash: " ++ show datumH ++ " at: " ++ show oref) return mdatum
           a <-
             maybe
               (fail $ "Can't convert from builtin data at: " ++ show oref ++ "; are you sure this is the right type?")

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -269,40 +269,39 @@ validateTx' tx = do
 utxosSuchThat' ::
   forall a m.
   (Monad m, Pl.FromData a) =>
-  Pl.Credential ->
-  (Maybe Pl.StakingCredential -> Maybe a -> Pl.Value -> Bool) ->
+  Pl.Address ->
+  (Maybe a -> Pl.Value -> Bool) ->
   MockChainT m [(SpendableOut, Maybe a)]
-utxosSuchThat' cred datumPred = do
+utxosSuchThat' addr datumPred = do
   ix <- gets (Pl.getIndex . mcstIndex)
-  let ix' = M.filter ((== cred) . Pl.addressCredential . Pl.txOutAddress) ix
+  let ix' = M.filter ((== addr) . Pl.txOutAddress) ix
   mapMaybe (fmap assocl . rstr) <$> mapM (\(oref, out) -> (oref,) <$> go oref out) (M.toList ix')
   where
     go :: Pl.TxOutRef -> Pl.TxOut -> MockChainT m (Maybe (Pl.ChainIndexTxOut, Maybe a))
-    go oref (Pl.TxOut oaddr@(Pl.Address ocred stak) val mdatumH) = do
-      -- We begin by attempting to lookup the given datum hash in our map of managed datums.
-      managedDatums <- gets mcstDatums
-      let mdatum = mdatumH >>= (`M.lookup` managedDatums)
-      -- Now, depending on whether we're looking at a utxo that belongs to a pk or a script,
-      -- there's a slight difference in treatment:
-      case ocred of
-        -- PubKey outputs are not required to have a datum, hence, we don't care if mdatum is Nothing.
-        Pl.PubKeyCredential _ -> do
-          let ma = mdatum >>= Pl.fromBuiltinData . Pl.getDatum
-          if datumPred stak ma val
-            then return . Just $ (Pl.PublicKeyChainIndexTxOut oaddr val, ma)
+    go oref (Pl.TxOut oaddr val mdatumH) =
+      case Pl.addressCredential oaddr of
+        -- A PK credential has no datum; just check whether we want to select this output or not.
+        Pl.PubKeyCredential _ ->
+          if datumPred Nothing val
+            then return . Just $ (Pl.PublicKeyChainIndexTxOut oaddr val, Nothing)
             else return Nothing
-        -- Script addresses, on the other hand, /must/ have a datum present. Hence, we check that mdatum
-        -- is a just. If this happens, it probably means there's a bug in cooked and we lost some datum.
-        -- Therefore, we check a few different things in order to provide a better debugging experience.
+        -- A script credential, on the other hand, must have a datum. Hence, we'll go look on our map of
+        -- managed datum for a relevant datum, try to convert it to a value of type @a@ then see
+        -- if the user wants to select said output.
         Pl.ScriptCredential (Pl.ValidatorHash vh) -> do
+          managedDatums <- gets mcstDatums
           datumH <- maybe (fail $ "ScriptCredential with no datum hash: " ++ show oref) return mdatumH
-          datum <- maybe (fail $ "Unmanaged datum with hash: " ++ show datumH ++ " at: " ++ show oref) return mdatum
+          datum <-
+            maybe
+              (fail $ "Unmanaged datum with hash: " ++ show datumH ++ " at: " ++ show oref)
+              return
+              $ M.lookup datumH managedDatums
           a <-
             maybe
               (fail $ "Can't convert from builtin data at: " ++ show oref ++ "; are you sure this is the right type?")
               return
               (Pl.fromBuiltinData (Pl.getDatum datum))
-          if datumPred stak (Just a) val
+          if datumPred (Just a) val
             then return . Just $ (Pl.ScriptChainIndexTxOut oaddr (Left $ Pl.ValidatorHash vh) (Right datum) val, Just a)
             else return Nothing
 

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -269,39 +269,40 @@ validateTx' tx = do
 utxosSuchThat' ::
   forall a m.
   (Monad m, Pl.FromData a) =>
-  Pl.Address ->
-  (Maybe a -> Pl.Value -> Bool) ->
+  Pl.Credential ->
+  (Maybe Pl.StakingCredential -> Maybe a -> Pl.Value -> Bool) ->
   MockChainT m [(SpendableOut, Maybe a)]
-utxosSuchThat' addr datumPred = do
+utxosSuchThat' cred datumPred = do
   ix <- gets (Pl.getIndex . mcstIndex)
-  let ix' = M.filter ((== addr) . Pl.txOutAddress) ix
+  let ix' = M.filter ((== cred) . Pl.addressCredential . Pl.txOutAddress) ix
   mapMaybe (fmap assocl . rstr) <$> mapM (\(oref, out) -> (oref,) <$> go oref out) (M.toList ix')
   where
     go :: Pl.TxOutRef -> Pl.TxOut -> MockChainT m (Maybe (Pl.ChainIndexTxOut, Maybe a))
-    go oref (Pl.TxOut oaddr val mdatumH) =
-      case Pl.addressCredential oaddr of
-        -- A PK credential has no datum; just check whether we want to select this output or not.
-        Pl.PubKeyCredential _ ->
-          if datumPred Nothing val
-            then return . Just $ (Pl.PublicKeyChainIndexTxOut oaddr val, Nothing)
+    go oref (Pl.TxOut oaddr@(Pl.Address ocred stak) val mdatumH) = do
+      -- We begin by attempting to lookup the given datum hash in our map of managed datums.
+      managedDatums <- gets mcstDatums
+      let mdatum = mdatumH >>= (`M.lookup` managedDatums)
+      -- Now, depending on whether we're looking at a utxo that belongs to a pk or a script,
+      -- there's a slight difference in treatment:
+      case ocred of
+        -- PubKey outputs are not required to have a datum, hence, we don't care if mdatum is Nothing.
+        Pl.PubKeyCredential _ -> do
+          let ma = mdatum >>= Pl.fromBuiltinData . Pl.getDatum
+          if datumPred stak ma val
+            then return . Just $ (Pl.PublicKeyChainIndexTxOut oaddr val, ma)
             else return Nothing
-        -- A script credential, on the other hand, must have a datum. Hence, we'll go look on our map of
-        -- managed datum for a relevant datum, try to convert it to a value of type @a@ then see
-        -- if the user wants to select said output.
+        -- Script addresses, on the other hand, /must/ have a datum present. Hence, we check that mdatum
+        -- is a just. If this happens, it probably means there's a bug in cooked and we lost some datum.
+        -- Therefore, we check a few different things in order to provide a better debugging experience.
         Pl.ScriptCredential (Pl.ValidatorHash vh) -> do
-          managedDatums <- gets mcstDatums
           datumH <- maybe (fail $ "ScriptCredential with no datum hash: " ++ show oref) return mdatumH
-          datum <-
-            maybe
-              (fail $ "Unmanaged datum with hash: " ++ show datumH ++ " at: " ++ show oref)
-              return
-              $ M.lookup datumH managedDatums
+          datum <- maybe (fail $ "Unmanaged datum with hash: " ++ show datumH ++ " at: " ++ show oref) return mdatum
           a <-
             maybe
               (fail $ "Can't convert from builtin data at: " ++ show oref ++ "; are you sure this is the right type?")
               return
               (Pl.fromBuiltinData (Pl.getDatum datum))
-          if datumPred (Just a) val
+          if datumPred stak (Just a) val
             then return . Just $ (Pl.ScriptChainIndexTxOut oaddr (Left $ Pl.ValidatorHash vh) (Right datum) val, Just a)
             else return Nothing
 

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -19,7 +19,6 @@ import Cooked.Tx.Constraints
 import Data.Foldable
 import qualified Data.List.NonEmpty as NE
 import qualified Ledger as Pl
-import qualified Ledger.Credential as Pl
 import qualified PlutusTx as Pl (FromData)
 import Prettyprinter (Doc, (<+>))
 import qualified Prettyprinter as PP
@@ -72,8 +71,8 @@ data MockChainOp a where
   AwaitTime :: Pl.POSIXTime -> MockChainOp Pl.POSIXTime
   UtxosSuchThat ::
     (Pl.FromData a) =>
-    Pl.Credential ->
-    (Maybe Pl.StakingCredential -> Maybe a -> Pl.Value -> Bool) ->
+    Pl.Address ->
+    (Maybe a -> Pl.Value -> Bool) ->
     MockChainOp [(SpendableOut, Maybe a)]
   OwnPubKey :: MockChainOp Pl.PubKeyHash
   --

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -75,6 +75,7 @@ data MockChainOp a where
     (Maybe a -> Pl.Value -> Bool) ->
     MockChainOp [(SpendableOut, Maybe a)]
   OwnPubKey :: MockChainOp Pl.PubKeyHash
+  OwnStakingPubKey :: MockChainOp Pl.PubKeyHash
   --
   SigningWith :: NE.NonEmpty Wallet -> StagedMockChain a -> MockChainOp a
   AskSigners :: MockChainOp (NE.NonEmpty Wallet)
@@ -181,6 +182,7 @@ instance MonadBlockChain StagedMockChain where
   utxosSuchThat addr = singleton . UtxosSuchThat addr
   txOutByRef = singleton . TxOutByRef
   ownPaymentPubKeyHash = singleton OwnPubKey
+  ownStakingPubKeyHash = singleton OwnStakingPubKey
   currentSlot = singleton GetCurrentSlot
   currentTime = singleton GetCurrentTime
   awaitSlot = singleton . AwaitSlot

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -19,6 +19,7 @@ import Cooked.Tx.Constraints
 import Data.Foldable
 import qualified Data.List.NonEmpty as NE
 import qualified Ledger as Pl
+import qualified Ledger.Credential as Pl
 import qualified PlutusTx as Pl (FromData)
 import Prettyprinter (Doc, (<+>))
 import qualified Prettyprinter as PP
@@ -71,8 +72,8 @@ data MockChainOp a where
   AwaitTime :: Pl.POSIXTime -> MockChainOp Pl.POSIXTime
   UtxosSuchThat ::
     (Pl.FromData a) =>
-    Pl.Address ->
-    (Maybe a -> Pl.Value -> Bool) ->
+    Pl.Credential ->
+    (Maybe Pl.StakingCredential -> Maybe a -> Pl.Value -> Bool) ->
     MockChainOp [(SpendableOut, Maybe a)]
   OwnPubKey :: MockChainOp Pl.PubKeyHash
   --
@@ -252,7 +253,7 @@ prettyMockChainOp _ _ = mempty
 newtype TraceDescr = TraceDescr {trApp :: [Doc ()] -> [Doc ()]}
 
 trSingleton :: Doc ann -> TraceDescr
-trSingleton d = TraceDescr (fmap (const ()) d :)
+trSingleton d = TraceDescr (void d :)
 
 instance Show TraceDescr where
   show (TraceDescr gen) =

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -75,7 +75,6 @@ data MockChainOp a where
     (Maybe a -> Pl.Value -> Bool) ->
     MockChainOp [(SpendableOut, Maybe a)]
   OwnPubKey :: MockChainOp Pl.PubKeyHash
-  OwnStakingPubKey :: MockChainOp Pl.PubKeyHash
   --
   SigningWith :: NE.NonEmpty Wallet -> StagedMockChain a -> MockChainOp a
   AskSigners :: MockChainOp (NE.NonEmpty Wallet)
@@ -182,7 +181,6 @@ instance MonadBlockChain StagedMockChain where
   utxosSuchThat addr = singleton . UtxosSuchThat addr
   txOutByRef = singleton . TxOutByRef
   ownPaymentPubKeyHash = singleton OwnPubKey
-  ownStakingPubKeyHash = singleton OwnStakingPubKey
   currentSlot = singleton GetCurrentSlot
   currentTime = singleton GetCurrentTime
   awaitSlot = singleton . AwaitSlot

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -16,9 +16,8 @@ import Cooked.MockChain.Wallet
 import Cooked.Tx.Constraints.Pretty
 import Cooked.Tx.Constraints.Type
 import qualified Data.Map.Strict as M
-import qualified Ledger as Pl hiding (singleton, unspentOutputs)
+import qualified Ledger as Pl hiding (unspentOutputs)
 import qualified Ledger.Constraints as Pl
-import qualified Ledger.Constraints.TxConstraints as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, validatorScript)
 import qualified PlutusTx as Pl
 
@@ -38,8 +37,6 @@ extractDatumStrFromConstraint (PaysScript _validator datumsAndValues) =
     $ datumsAndValues
 extractDatumStrFromConstraint (SpendsScript _validator _redeemer (_out, datum)) =
   M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData datum) (show datum)
-extractDatumStrFromConstraint (PaysPKWithDatum _pk _stak mdat _v) =
-  maybe M.empty (\d -> M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d) (show d)) mdat
 extractDatumStrFromConstraint _ = M.empty
 
 -- | Converts our constraint into a 'LedgerConstraint',
@@ -62,12 +59,7 @@ toLedgerConstraint (PaysScript v outs) = (lkups, constr)
           (Pl.validatorHash $ Pl.validatorScript v)
           (Pl.Datum $ Pl.toBuiltinData d)
           val
-toLedgerConstraint (PaysPKWithDatum p stak dat v) = (lkups, constr)
-  where
-    mData = fmap (Pl.Datum . Pl.toBuiltinData) dat
-
-    lkups = maybe mempty Pl.otherData mData
-    constr = Pl.singleton $ Pl.MustPayToPubKeyAddress (Pl.PaymentPubKeyHash p) stak mData v
+toLedgerConstraint (PaysPK p v) = (mempty, Pl.mustPayToPubKey (Pl.PaymentPubKeyHash p) v)
 toLedgerConstraint (SpendsPK (oref, o)) = (lkups, constr)
   where
     lkups = Pl.unspentOutputs (M.singleton oref o)

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -66,7 +66,11 @@ toLedgerConstraint (PaysPKWithDatum p stak dat v) = (lkups, constr)
   where
     mData = fmap (Pl.Datum . Pl.toBuiltinData) dat
 
-    lkups = maybe mempty Pl.otherData mData
+    lkups =
+      maybe mempty Pl.otherData mData
+        -- TODO: do we want to akk ownStakePubKeyHash on 'PaysPKWithDatum'? Would we rather have
+        -- a different 'WithOwnStakePubKeyHash' constraint?
+        <> maybe mempty Pl.ownStakePubKeyHash stak
     constr = Pl.singleton $ Pl.MustPayToPubKeyAddress (Pl.PaymentPubKeyHash p) stak mData v
 toLedgerConstraint (SpendsPK (oref, o)) = (lkups, constr)
   where

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -16,8 +16,9 @@ import Cooked.MockChain.Wallet
 import Cooked.Tx.Constraints.Pretty
 import Cooked.Tx.Constraints.Type
 import qualified Data.Map.Strict as M
-import qualified Ledger as Pl hiding (unspentOutputs)
+import qualified Ledger as Pl hiding (singleton, unspentOutputs)
 import qualified Ledger.Constraints as Pl
+import qualified Ledger.Constraints.TxConstraints as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, validatorScript)
 import qualified PlutusTx as Pl
 
@@ -37,6 +38,8 @@ extractDatumStrFromConstraint (PaysScript _validator datumsAndValues) =
     $ datumsAndValues
 extractDatumStrFromConstraint (SpendsScript _validator _redeemer (_out, datum)) =
   M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData datum) (show datum)
+extractDatumStrFromConstraint (PaysPKWithDatum _pk _stak mdat _v) =
+  maybe M.empty (\d -> M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d) (show d)) mdat
 extractDatumStrFromConstraint _ = M.empty
 
 -- | Converts our constraint into a 'LedgerConstraint',
@@ -59,7 +62,12 @@ toLedgerConstraint (PaysScript v outs) = (lkups, constr)
           (Pl.validatorHash $ Pl.validatorScript v)
           (Pl.Datum $ Pl.toBuiltinData d)
           val
-toLedgerConstraint (PaysPK p v) = (mempty, Pl.mustPayToPubKey (Pl.PaymentPubKeyHash p) v)
+toLedgerConstraint (PaysPKWithDatum p stak dat v) = (lkups, constr)
+  where
+    mData = fmap (Pl.Datum . Pl.toBuiltinData) dat
+
+    lkups = maybe mempty Pl.otherData mData
+    constr = Pl.singleton $ Pl.MustPayToPubKeyAddress (Pl.PaymentPubKeyHash p) stak mData v
 toLedgerConstraint (SpendsPK (oref, o)) = (lkups, constr)
   where
     lkups = Pl.unspentOutputs (M.singleton oref o)

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -45,8 +45,16 @@ prettyConstraint (SpendsScript val red outdat) =
     ("SpendsScript" <+> prettyTypedValidator val)
     "-"
     ["Redeemer:" <+> PP.viaShow red, prettyOutputDatum val outdat]
-prettyConstraint (PaysPK pkh val) =
-  prettyEnum ("PaysPK" <+> prettyWallet pkh) PP.emptyDoc (catMaybes [mPrettyValue val])
+prettyConstraint (PaysPKWithDatum pkh stak dat val) =
+  prettyEnum
+    ("PaysPK" <+> prettyWallet pkh)
+    PP.emptyDoc
+    ( catMaybes
+        [ fmap (("StakePKH:" <+>) . PP.pretty) stak,
+          fmap (("Datum:" <+>) . prettyDatum) dat,
+          mPrettyValue val
+        ]
+    )
 prettyConstraint (SpendsPK out) =
   let (ppAddr, mppVal) = prettyTxOut $ Pl.toTxOut $ snd out
    in prettyEnum "SpendsPK" "-" $ catMaybes [Just ppAddr, mppVal]

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -45,16 +45,8 @@ prettyConstraint (SpendsScript val red outdat) =
     ("SpendsScript" <+> prettyTypedValidator val)
     "-"
     ["Redeemer:" <+> PP.viaShow red, prettyOutputDatum val outdat]
-prettyConstraint (PaysPKWithDatum pkh stak dat val) =
-  prettyEnum
-    ("PaysPK" <+> prettyWallet pkh)
-    PP.emptyDoc
-    ( catMaybes
-        [ fmap (("StakePKH:" <+>) . PP.pretty) stak,
-          fmap (("Datum:" <+>) . prettyDatum) dat,
-          mPrettyValue val
-        ]
-    )
+prettyConstraint (PaysPK pkh val) =
+  prettyEnum ("PaysPK" <+> prettyWallet pkh) PP.emptyDoc (catMaybes [mPrettyValue val])
 prettyConstraint (SpendsPK out) =
   let (ppAddr, mppVal) = prettyTxOut $ Pl.toTxOut $ snd out
    in prettyEnum "SpendsPK" "-" $ catMaybes [Just ppAddr, mppVal]

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -67,13 +67,11 @@ data Constraint where
     Pl.RedeemerType a ->
     (SpendableOut, Pl.DatumType a) ->
     Constraint
-  PaysPKWithDatum ::
-    (Pl.ToData a, Show a) =>
-    Pl.PubKeyHash ->
-    Maybe Pl.StakePubKeyHash ->
-    Maybe a ->
-    Pl.Value ->
-    Constraint
+  -- TODO: something like stepscript below could be nice!
+  -- StepsScript  :: (Pl.ToData a, Pl.ToData redeemer)
+  --              => Pl.Validator -> redeemer -> (SpendableOut, a) -> (a -> a) -> Constraint
+
+  PaysPK :: Pl.PubKeyHash -> Pl.Value -> Constraint
   SpendsPK :: SpendableOut -> Constraint
   Mints ::
     (Pl.ToData a, Show a) =>
@@ -85,9 +83,6 @@ data Constraint where
   After :: Pl.POSIXTime -> Constraint
   ValidateIn :: Pl.POSIXTimeRange -> Constraint
   SignedBy :: [Pl.PubKeyHash] -> Constraint
-
-paysPK :: Pl.PubKeyHash -> Pl.Value -> Constraint
-paysPK pkh = PaysPKWithDatum @() pkh Nothing Nothing
 
 mints :: [Pl.MintingPolicy] -> Pl.Value -> Constraint
 mints = Mints @() Nothing

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -67,6 +67,11 @@ data Constraint where
     Pl.RedeemerType a ->
     (SpendableOut, Pl.DatumType a) ->
     Constraint
+  -- | Creates a UTxO to a specific 'Pl.PubKeyHash' with a potential 'Pl.StakePubKeyHash'.
+  -- and datum. If the stake pk is present, it will call 'Ledger.Constraints.OffChain.ownStakePubKeyHash'
+  -- to update the script lookups, hence, generating a transaction with /two/ 'PaysPKWithDatum' with
+  -- two different staking keys will cause the first staking key to be overriden by calling @ownStakePubKeyHash@
+  -- a second time. If this is an issue for you, please do submit an issue with an explanation on GitHub.
   PaysPKWithDatum ::
     (Pl.ToData a, Show a) =>
     Pl.PubKeyHash ->

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -67,11 +67,13 @@ data Constraint where
     Pl.RedeemerType a ->
     (SpendableOut, Pl.DatumType a) ->
     Constraint
-  -- TODO: something like stepscript below could be nice!
-  -- StepsScript  :: (Pl.ToData a, Pl.ToData redeemer)
-  --              => Pl.Validator -> redeemer -> (SpendableOut, a) -> (a -> a) -> Constraint
-
-  PaysPK :: Pl.PubKeyHash -> Pl.Value -> Constraint
+  PaysPKWithDatum ::
+    (Pl.ToData a, Show a) =>
+    Pl.PubKeyHash ->
+    Maybe Pl.StakePubKeyHash ->
+    Maybe a ->
+    Pl.Value ->
+    Constraint
   SpendsPK :: SpendableOut -> Constraint
   Mints ::
     (Pl.ToData a, Show a) =>
@@ -83,6 +85,9 @@ data Constraint where
   After :: Pl.POSIXTime -> Constraint
   ValidateIn :: Pl.POSIXTimeRange -> Constraint
   SignedBy :: [Pl.PubKeyHash] -> Constraint
+
+paysPK :: Pl.PubKeyHash -> Pl.Value -> Constraint
+paysPK pkh = PaysPKWithDatum @() pkh Nothing Nothing
 
 mints :: [Pl.MintingPolicy] -> Pl.Value -> Constraint
 mints = Mints @() Nothing

--- a/cooked-validators/src/Example.hs
+++ b/cooked-validators/src/Example.hs
@@ -16,4 +16,4 @@ example = runMockChain $ do
   void $
     validateTxSkel $
       txSkel
-        [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
+        [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]

--- a/cooked-validators/src/Example.hs
+++ b/cooked-validators/src/Example.hs
@@ -16,4 +16,4 @@ example = runMockChain $ do
   void $
     validateTxSkel $
       txSkel
-        [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
+        [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]

--- a/cooked-validators/tests/Cooked/BalanceSpec.hs
+++ b/cooked-validators/tests/Cooked/BalanceSpec.hs
@@ -115,19 +115,19 @@ spec = do
     -- It would leave it with a 0.4 ada UTxO which is less than min ada.
     it "Fails for unbalanceable transactions" $
       let tr =
-            validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> signs (wallet 11) (validateTxConstr [paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
+            validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
        in runMockChain tr `shouldSatisfy` isLeft
 
     -- Unlike the test above, we now want to see this being possible, but the transaction will need
     -- to consume the additional utxo of wallet 11.
     it "Uses additional utxos on demand" $
       let tr =
-            validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 3_700_000)]
-              >> signs (wallet 11) (validateTxConstr [paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
+            validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 3_700_000)]
+              >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
        in runMockChain tr `shouldSatisfy` isRight
 
 outsOf :: Int -> Pl.UtxoIndex -> [(Pl.TxOutRef, Pl.TxOut)]
@@ -148,9 +148,9 @@ tracePayWallet11 :: Either MockChainError (MockChainSt, UtxoState)
 tracePayWallet11 =
   runMockChain $ do
     validateTxConstr
-      [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+      [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
     validateTxConstr
-      [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+      [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
     MockChainT get
 
 -- * Helper Instances

--- a/cooked-validators/tests/Cooked/BalanceSpec.hs
+++ b/cooked-validators/tests/Cooked/BalanceSpec.hs
@@ -115,19 +115,19 @@ spec = do
     -- It would leave it with a 0.4 ada UTxO which is less than min ada.
     it "Fails for unbalanceable transactions" $
       let tr =
-            validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
+            validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> signs (wallet 11) (validateTxConstr [paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
        in runMockChain tr `shouldSatisfy` isLeft
 
     -- Unlike the test above, we now want to see this being possible, but the transaction will need
     -- to consume the additional utxo of wallet 11.
     it "Uses additional utxos on demand" $
       let tr =
-            validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 3_700_000)]
-              >> signs (wallet 11) (validateTxConstr [PaysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
+            validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 3_700_000)]
+              >> signs (wallet 11) (validateTxConstr [paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
        in runMockChain tr `shouldSatisfy` isRight
 
 outsOf :: Int -> Pl.UtxoIndex -> [(Pl.TxOutRef, Pl.TxOut)]
@@ -148,9 +148,9 @@ tracePayWallet11 :: Either MockChainError (MockChainSt, UtxoState)
 tracePayWallet11 =
   runMockChain $ do
     validateTxConstr
-      [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+      [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
     validateTxConstr
-      [PaysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+      [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
     MockChainT get
 
 -- * Helper Instances

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -25,10 +25,10 @@ assertAll space f = mapM_ f space
 possibleTraces :: [StagedMockChain ()]
 possibleTraces =
   [ return (),
-    void $ validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)],
+    void $ validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)],
     void $ do
-      validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)]
-      validateTxConstr [paysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200000)]
+      validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)]
+      validateTxConstr [PaysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200000)]
   ]
 
 spec :: Spec
@@ -58,8 +58,8 @@ spec = do
     -- If we execute @somewhere k tr'@ instead, we should expect to see 8 branches.
     -- Because we're choosing @f = g = k = id@, we exept the eight traces to be equal to tr.
     let tr =
-          validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)]
-            >> validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)]
+          validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)]
+            >> validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)]
      in interpret (somewhere Just $ somewhere Just $ somewhere Just tr)
           `imcEq` asum (replicate 8 $ interpret tr)
 
@@ -67,13 +67,12 @@ spec = do
     let -- Sample trace
         tr f g =
           validateTxConstr
-            [ paysPK
+            [ PaysPK
                 (walletPKHash $ wallet 2)
                 (f $ g $ Pl.lovelaceValueOf 4_200_000)
             ]
         -- Function to modify some specific skeletons
-        app f (TxSkel l opts [PaysPKWithDatum pk stak dat val]) =
-          Just $ TxSkel l opts [PaysPKWithDatum pk stak dat (f val)]
+        app f (TxSkel l opts [PaysPK tgt val]) = Just $ TxSkel l opts [PaysPK tgt (f val)]
         app f _ = Nothing
         -- Two transformations
         f x = Pl.lovelaceValueOf 3_000_000

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -25,10 +25,10 @@ assertAll space f = mapM_ f space
 possibleTraces :: [StagedMockChain ()]
 possibleTraces =
   [ return (),
-    void $ validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)],
+    void $ validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)],
     void $ do
-      validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)]
-      validateTxConstr [PaysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200000)]
+      validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)]
+      validateTxConstr [paysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200000)]
   ]
 
 spec :: Spec
@@ -58,8 +58,8 @@ spec = do
     -- If we execute @somewhere k tr'@ instead, we should expect to see 8 branches.
     -- Because we're choosing @f = g = k = id@, we exept the eight traces to be equal to tr.
     let tr =
-          validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)]
-            >> validateTxConstr [PaysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)]
+          validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)]
+            >> validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)]
      in interpret (somewhere Just $ somewhere Just $ somewhere Just tr)
           `imcEq` asum (replicate 8 $ interpret tr)
 
@@ -67,12 +67,13 @@ spec = do
     let -- Sample trace
         tr f g =
           validateTxConstr
-            [ PaysPK
+            [ paysPK
                 (walletPKHash $ wallet 2)
                 (f $ g $ Pl.lovelaceValueOf 4_200_000)
             ]
         -- Function to modify some specific skeletons
-        app f (TxSkel l opts [PaysPK tgt val]) = Just $ TxSkel l opts [PaysPK tgt (f val)]
+        app f (TxSkel l opts [PaysPKWithDatum pk stak dat val]) =
+          Just $ TxSkel l opts [PaysPKWithDatum pk stak dat (f val)]
         app f _ = Nothing
         -- Two transformations
         f x = Pl.lovelaceValueOf 3_000_000

--- a/cooked-validators/tests/Cooked/MockChain/WalletSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/WalletSpec.hs
@@ -1,0 +1,21 @@
+module Cooked.MockChain.WalletSpec where
+
+import qualified Cardano.Crypto.Wallet as Crypto
+import Cooked.MockChain.Wallet
+import qualified Ledger.CardanoWallet as CW
+import Test.Hspec
+
+-- these instances are needed by `shouldBe` below.
+
+instance Eq Crypto.XPrv where
+  x == y = Crypto.toXPub x == Crypto.toXPub y
+
+instance Show Crypto.XPrv where
+  show = show . Crypto.toXPub
+
+spec :: SpecWith ()
+spec = do
+  describe "Hack: unwrapping a MockPrivateKey into a XPrv" $ do
+    it "Works" $
+      hackUnMockPrivateKey (CW.mwPaymentKey $ wallet 1)
+        `shouldBe` walletSK (wallet 1)

--- a/cooked-validators/tests/Cooked/QuickValueSpec.hs
+++ b/cooked-validators/tests/Cooked/QuickValueSpec.hs
@@ -28,7 +28,7 @@ paymentAfterCustomInitialization =
     validateTxConstrOpts
       -- we have to adjust the tx in order for it not to fail with ValueLessThanMinAda
       (def {adjustUnbalTx = True})
-      [paysPK (walletPKHash $ wallet 2) (quickValue "goldenCoins" 12)]
+      [PaysPK (walletPKHash $ wallet 2) (quickValue "goldenCoins" 12)]
     return ()
 
 quickValuesInitialisation :: Either MockChainError ((), UtxoState)

--- a/cooked-validators/tests/Cooked/QuickValueSpec.hs
+++ b/cooked-validators/tests/Cooked/QuickValueSpec.hs
@@ -28,7 +28,7 @@ paymentAfterCustomInitialization =
     validateTxConstrOpts
       -- we have to adjust the tx in order for it not to fail with ValueLessThanMinAda
       (def {adjustUnbalTx = True})
-      [PaysPK (walletPKHash $ wallet 2) (quickValue "goldenCoins" 12)]
+      [paysPK (walletPKHash $ wallet 2) (quickValue "goldenCoins" 12)]
     return ()
 
 quickValuesInitialisation :: Either MockChainError ((), UtxoState)

--- a/cooked-validators/tests/Spec.hs
+++ b/cooked-validators/tests/Spec.hs
@@ -1,6 +1,7 @@
 import qualified Cooked.BalanceSpec as Ba
 import qualified Cooked.MockChain.Monad.StagedSpec as StagedSpec
 import qualified Cooked.MockChain.UtxoStateSpec as UtxoStateSpec
+import qualified Cooked.MockChain.WalletSpec as WalletSpec
 import qualified Cooked.QuickValueSpec as QuickValueSpec
 import Test.Hspec
 
@@ -13,3 +14,4 @@ spec = do
   describe "Quick values" QuickValueSpec.spec
   describe "Staged monad" StagedSpec.spec
   describe "UtxoState" UtxoStateSpec.spec
+  describe "Wallet" WalletSpec.spec

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -13,6 +13,7 @@ import Control.Monad
 import Cooked.MockChain
 import Cooked.Tx.Constraints
 import qualified Ledger as Pl
+import qualified Ledger.Credential as Pl
 import qualified Ledger.Typed.Scripts as Pl
 import Playground.Contract hiding (ownPaymentPubKeyHash)
 import qualified Plutus.Contract as C
@@ -60,8 +61,8 @@ txUnlock script = do
     validateTxConstrLbl
       TxUnlock
       [ SpendsScript script () (output, datum),
-        PaysPK r1 (Pl.lovelaceValueOf share1),
-        PaysPK r2 (Pl.lovelaceValueOf share2)
+        paysPK r1 (Pl.lovelaceValueOf share1),
+        paysPK r2 (Pl.lovelaceValueOf share2)
       ]
 
 -- | Label for 'txUnlock' skeleton

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -13,7 +13,6 @@ import Control.Monad
 import Cooked.MockChain
 import Cooked.Tx.Constraints
 import qualified Ledger as Pl
-import qualified Ledger.Credential as Pl
 import qualified Ledger.Typed.Scripts as Pl
 import Playground.Contract hiding (ownPaymentPubKeyHash)
 import qualified Plutus.Contract as C

--- a/examples/tests/ForgeSpec.hs
+++ b/examples/tests/ForgeSpec.hs
@@ -76,7 +76,7 @@ smiths bbId val = do
       [ SpendsScript (smithVal bbId) Adjust (outSmith, datSmith),
         mints [smithingPolicy bbId] (Value.assetClassValue (smithed bbId) val),
         PaysScript (smithVal bbId) [(Forge owner (forged + val), sOutValue outSmith)],
-        PaysPK pkh (Value.assetClassValue (smithed bbId) val <> minAda)
+        paysPK pkh (Value.assetClassValue (smithed bbId) val <> minAda)
       ]
   where
     belongsTo (Forge owner _) pkh = owner == pkh

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -37,8 +37,8 @@ txUnlock' mRecipient1 mRecipient2 mAmountChanger issuer = do
       share2 = fromMaybe id mAmountChanger (amount - half)
       constraints =
         [ SpendsScript Split.splitValidator () (output, datum),
-          PaysPK (maybe r1 walletPKHash mRecipient1) (Pl.lovelaceValueOf share1),
-          PaysPK (maybe r2 walletPKHash mRecipient2) (Pl.lovelaceValueOf share2)
+          paysPK (maybe r1 walletPKHash mRecipient1) (Pl.lovelaceValueOf share1),
+          paysPK (maybe r2 walletPKHash mRecipient2) (Pl.lovelaceValueOf share2)
         ]
       remainder = amount - share1 - share2
       remainderConstraint =
@@ -73,9 +73,9 @@ txUnlockAttack issuer = do
       constraints =
         [ SpendsScript Split.splitValidator () (output1, datum1),
           SpendsScript Split.splitValidator () (output2, datum2),
-          PaysPK r11 half1,
-          PaysPK r12 (if amount1 > amount2 then half1 else half2),
-          PaysPK r21 half2
+          paysPK r11 half1,
+          paysPK r12 (if amount1 > amount2 then half1 else half2),
+          paysPK r21 half2
         ]
   void $ validateTxConstrLbl TxUnlockAttack constraints `as` issuer
 

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -85,7 +85,7 @@ retrieveFunds t c owner = do
       validateTxConstrOpts
         (def {autoSlotIncrease = False})
         ( map (SpendsScript (typedValidator c) Collect) funds
-            ++ [ PaysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds),
+            ++ [ paysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds),
                  ValidateIn $ collectionRange c
                ]
         )


### PR DESCRIPTION
@etiennejf requested that `cooked-validators` started dealing with staking credentials. 
The main subject of this PR is changing the old `PaysPK` constraint into:
```haskell
  PaysPKWithDatum ::
    (Pl.ToData a, Show a) =>
    Pl.PubKeyHash ->
    Maybe Pl.StakePubKeyHash ->
    Maybe a ->
    Pl.Value ->
    Constraint
```
Yet, we should also make the rest of cooked work well with staking credentials, which raises a few questions that I need help with I'd appreciate the opinions of @etiennejf or @sjoerdvisscher or @ak3n on them, thank you!

1. What's the interface to staking with the Plutus `Contract` monad? I'd like to copy that as much as possible to remain as compatible as possible. In particular: does every wallet start with a staking credential from scratch? Maybe it shouldn't. In that case, how is that created? Can the same `Credential` posses UTxOs with different `StakingCredentials`?
2. What should be the semantics of `utxosSuchThat`? Currently, it has type:
    ```haskell
      utxosSuchThat ::
        (MonadBlockChain m, Pl.FromData a) =>
        Pl.Address ->
        (Maybe a -> Pl.Value -> Bool) ->
        m [(SpendableOut, Maybe a)]
    ```
    I'm thinking that perhaps, it should have type:
    ```haskell
      utxosSuchThat ::
        (MonadBlockChain m, Pl.FromData a) =>
        Pl.Credential ->
        (Maybe Pl.StakingCredential -> Maybe a -> Pl.Value -> Bool) ->
        m [(SpendableOut, Maybe a)]
    ```
    This way we can select all UTxOs that belong to a given key and use the user-supplied predicate to filter out those
    that contain a certain staking credential or not. Would that make sense?
3. What are the semantics of the [`ownStakePubKeyHash`](https://github.com/input-output-hk/plutus-apps/blob/46e831e49287c3a04f83497b9dd9e70718092cde/plutus-ledger-constraints/src/Ledger/Constraints/OffChain.hs#L179) script lookup? What should we use it for?
