### PR TITLE
Adding a slotConfig in MonadMockChain and the function validateNow

### DIFF
--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -13,6 +13,7 @@ extra-source-files:
 library
   exposed-modules:
       Cooked.MockChain
+      Cooked.MockChain.Constraints
       Cooked.MockChain.Monad
       Cooked.MockChain.Monad.Contract
       Cooked.MockChain.Monad.Direct

--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -14,11 +14,9 @@ module Cooked.MockChain
     module Cooked.MockChain.RawUPLC,
     module Cooked.MockChain.Testing,
     SpendableOut,
-    spentByPK,
   )
 where
 
-import Control.Arrow (second)
 import Cooked.MockChain.Monad
 import Cooked.MockChain.Monad.Contract ()
 import Cooked.MockChain.Monad.Direct
@@ -29,16 +27,4 @@ import Cooked.MockChain.Time
 import Cooked.MockChain.UtxoState
 import Cooked.MockChain.UtxoState.Testing
 import Cooked.MockChain.Wallet
-import Cooked.Tx.Balance
-import Cooked.Tx.Constraints (Constraint (..), SpendableOut, paysPK)
-import qualified Ledger as Pl
-
--- | Spends some value from a pubkey by selecting the needed utxos belonging
---  to that pubkey and returning the leftover to the same pubkey.
---  This function is here to avoid an import cycle.
-spentByPK :: MonadBlockChain m => Pl.PubKeyHash -> Pl.Value -> m [Constraint]
-spentByPK pkh val = do
-  -- TODO: maybe turn spentByPK into a pure function: spentByPK val <$> pkUtxos
-  allOuts <- pkUtxos pkh
-  let (toSpend, leftOver, _) = spendValueFrom val $ map (second Pl.toTxOut) allOuts
-  (paysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend
+import Cooked.Tx.Constraints.Type (SpendableOut)

--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -3,7 +3,8 @@
 -- | Exports all the machinery necessary for using 'MonadBlockChain' and
 --  'MonadMockChain' for writing and testing contracts.
 module Cooked.MockChain
-  ( module Cooked.MockChain.Time,
+  ( module Cooked.MockChain.Constraints,
+    module Cooked.MockChain.Time,
     module Cooked.MockChain.UtxoState,
     module Cooked.MockChain.UtxoState.Testing,
     module Cooked.MockChain.Wallet,
@@ -17,6 +18,7 @@ module Cooked.MockChain
   )
 where
 
+import Cooked.MockChain.Constraints
 import Cooked.MockChain.Monad
 import Cooked.MockChain.Monad.Contract ()
 import Cooked.MockChain.Monad.Direct

--- a/cooked-validators/src/Cooked/MockChain/Constraints.hs
+++ b/cooked-validators/src/Cooked/MockChain/Constraints.hs
@@ -1,0 +1,32 @@
+module Cooked.MockChain.Constraints where
+
+import Control.Arrow (second)
+import Cooked.MockChain.Monad
+import Cooked.Tx.Balance (spendValueFrom)
+import Cooked.Tx.Constraints.Type
+import qualified Ledger as Pl hiding (singleton, unspentOutputs)
+import qualified Ledger.TimeSlot as Pl
+
+-- ** Some supplementary constraints, relying on being in the monad.
+
+-- | Spends some value from a pubkey by selecting the needed utxos belonging
+--  to that pubkey and returning the leftover to the same pubkey.
+spentByPK :: MonadBlockChain m => Pl.PubKeyHash -> Pl.Value -> m [Constraint]
+spentByPK pkh val = do
+  -- TODO: maybe turn spentByPK into a pure function: spentByPK val <$> pkUtxos
+  allOuts <- pkUtxos pkh
+  let (toSpend, leftOver, _) = spendValueFrom val $ map (second Pl.toTxOut) allOuts
+  (paysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend
+
+-- | Enforces the transaction to be vadiated at a precise slot.
+-- It requires to be in the mock chain monad, since slots can be translated to an explicit time range
+-- only after inspecting the slot configuration.
+validateAtSlot :: MonadMockChain m => Pl.Slot -> m Constraint
+validateAtSlot s = do
+  slotConf <- slotConfig
+  return $ ValidateIn $ Pl.slotToPOSIXTimeRange slotConf s
+
+-- | Validates the transaction in the current time slot of the mock chain.
+validateNow :: MonadMockChain m => m Constraint
+validateNow =
+  validateAtSlot =<< currentSlot

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -16,7 +16,7 @@ import Control.Arrow (second)
 import Control.Monad.Reader
 import Control.Monad.Trans.Control
 import Cooked.MockChain.Wallet
-import Cooked.Tx.Constraints.Type
+import Cooked.Tx.Constraints
 import Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromJust)

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -238,6 +238,8 @@ instance (Monad m) => MonadMockChain (MockChainT m) where
 
   askSigners = asks mceSigners
 
+  slotConfig = asks mceSlotConfig
+
 -- | Check 'validateTx' for details
 validateTx' :: (Monad m) => Pl.Tx -> MockChainT m Pl.TxId
 validateTx' tx = do

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -9,16 +9,23 @@ module Cooked.Tx.Constraints
     signedByWallets,
     toLedgerConstraint,
     toLedgerConstraints,
+    spentByPK,
+    validateAtSlot,
+    validateNow,
   )
 where
 
+import Control.Arrow (second)
+import Cooked.MockChain.Monad
 import Cooked.MockChain.Wallet
+import Cooked.Tx.Balance (spendValueFrom)
 import Cooked.Tx.Constraints.Pretty
 import Cooked.Tx.Constraints.Type
 import qualified Data.Map.Strict as M
 import qualified Ledger as Pl hiding (singleton, unspentOutputs)
 import qualified Ledger.Constraints as Pl
 import qualified Ledger.Constraints.TxConstraints as Pl
+import qualified Ledger.TimeSlot as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, validatorScript)
 import qualified PlutusTx as Pl
 
@@ -102,3 +109,24 @@ toLedgerConstraints cs = (mconcat lkups, mconcat constrs)
 -- | @signedByWallets ws == SignedBy $ map walletPKHash ws@
 signedByWallets :: [Wallet] -> Constraint
 signedByWallets = SignedBy . map walletPKHash
+
+-- ** Some supplementary constraints, relying on being in the monad.
+
+-- | Spends some value from a pubkey by selecting the needed utxos belonging
+--  to that pubkey and returning the leftover to the same pubkey.
+--  This function is here to avoid an import cycle.
+spentByPK :: MonadBlockChain m => Pl.PubKeyHash -> Pl.Value -> m [Constraint]
+spentByPK pkh val = do
+  -- TODO: maybe turn spentByPK into a pure function: spentByPK val <$> pkUtxos
+  allOuts <- pkUtxos pkh
+  let (toSpend, leftOver, _) = spendValueFrom val $ map (second Pl.toTxOut) allOuts
+  (paysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend
+
+validateAtSlot :: MonadMockChain m => Pl.Slot -> m Constraint
+validateAtSlot s = do
+  slotConf <- slotConfig
+  return $ ValidateIn $ Pl.slotToPOSIXTimeRange slotConf s
+
+validateNow :: MonadMockChain m => m Constraint
+validateNow =
+  validateAtSlot =<< currentSlot


### PR DESCRIPTION
This addresses #49 by creating the constraints `validateAt` and `validateNow`.
It required to add the `slotConfig` inside `MonadMockChain` rather than having it only in its "direct" instance.