### PR TITLE
Last touches before creating a `v0.1.0` tag

### DIFF
--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.4
 -- see: https://github.com/sol/hpack
 
 name:           cooked-validators
-version:        0.0.0
+version:        0.1.0
 build-type:     Simple
 extra-source-files:
     README.md

--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -20,6 +20,7 @@ library
       Cooked.MockChain.RawUPLC
       Cooked.MockChain.Testing
       Cooked.MockChain.Time
+      Cooked.MockChain.UtxoPredicate
       Cooked.MockChain.UtxoState
       Cooked.MockChain.UtxoState.Testing
       Cooked.MockChain.Wallet

--- a/cooked-validators/package.yaml
+++ b/cooked-validators/package.yaml
@@ -2,10 +2,9 @@ verbatim:
   cabal-version: 3.4
 
 name: cooked-validators
-version: 0.0.0
+version: 0.1.0
 extra-source-files:
   - README.md
-
 
 dependencies:
   - base >= 4.9 && < 5

--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -4,6 +4,7 @@
 --  'MonadMockChain' for writing and testing contracts.
 module Cooked.MockChain
   ( module Cooked.MockChain.Time,
+    module Cooked.MockChain.UtxoPredicate,
     module Cooked.MockChain.UtxoState,
     module Cooked.MockChain.UtxoState.Testing,
     module Cooked.MockChain.Wallet,
@@ -26,6 +27,7 @@ import Cooked.MockChain.Monad.Staged
 import Cooked.MockChain.RawUPLC
 import Cooked.MockChain.Testing
 import Cooked.MockChain.Time
+import Cooked.MockChain.UtxoPredicate
 import Cooked.MockChain.UtxoState
 import Cooked.MockChain.UtxoState.Testing
 import Cooked.MockChain.Wallet

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -15,12 +15,12 @@ module Cooked.MockChain.Monad where
 import Control.Arrow (second)
 import Control.Monad.Reader
 import Control.Monad.Trans.Control
+import Cooked.MockChain.UtxoPredicate
 import Cooked.MockChain.Wallet
 import Cooked.Tx.Constraints
 import Data.Kind (Type)
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromJust)
-import Data.Void
 import qualified Ledger as Pl
 import qualified Ledger.Credential as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, TypedValidator, validatorAddress)
@@ -56,7 +56,7 @@ class (MonadFail m) => MonadBlockChain m where
   utxosSuchThat ::
     (Pl.FromData a) =>
     Pl.Address ->
-    (Maybe a -> Pl.Value -> Bool) ->
+    UtxoPredicate a ->
     m [(SpendableOut, Maybe a)]
 
   -- | Returns an output given a reference to it
@@ -106,11 +106,22 @@ spendableRef txORef = do
 -- This is just a simpler variant of 'utxosSuchThat'. If you care about staking credentials
 -- you must use 'utxosSuchThat' directly.
 pkUtxosSuchThat ::
+  forall a m.
   (MonadBlockChain m, Pl.FromData a) =>
   Pl.PubKeyHash ->
-  (Maybe a -> Pl.Value -> Bool) ->
+  UtxoPredicate a ->
   m [(SpendableOut, Maybe a)]
 pkUtxosSuchThat pkh = utxosSuchThat (Pl.Address (Pl.PubKeyCredential pkh) Nothing)
+
+-- | Select public-key UTxO's that do not contain some datum nor staking address.
+-- This is just a simpler variant of 'pkUtxosSuchThat'.
+pkUtxosSuchThatValue ::
+  (MonadBlockChain m) =>
+  Pl.PubKeyHash ->
+  (Pl.Value -> Bool) ->
+  m [SpendableOut]
+pkUtxosSuchThatValue pkh predi =
+  map fst <$> pkUtxosSuchThat @() pkh (valueSat predi)
 
 -- | Script UTxO's always have a datum, hence, can be selected easily with
 --  a simpler variant of 'utxosSuchThat'. It is important to pass a value for type variable @a@
@@ -118,6 +129,7 @@ pkUtxosSuchThat pkh = utxosSuchThat (Pl.Address (Pl.PubKeyCredential pkh) Nothin
 scriptUtxosSuchThat ::
   (MonadBlockChain m, Pl.FromData (Pl.DatumType tv)) =>
   Pl.TypedValidator tv ->
+  -- | Slightly different from 'UtxoPredicate': here we're guaranteed to have a datum present.
   (Pl.DatumType tv -> Pl.Value -> Bool) ->
   m [(SpendableOut, Pl.DatumType tv)]
 scriptUtxosSuchThat v predicate =
@@ -136,7 +148,7 @@ outFromOutRef outref = do
 
 -- | Return all utxos belonging to a pubkey
 pkUtxos :: (MonadBlockChain m) => Pl.PubKeyHash -> m [SpendableOut]
-pkUtxos pkh = map fst <$> pkUtxosSuchThat @_ @Void pkh (const $ const True)
+pkUtxos pkh = pkUtxosSuchThatValue pkh (const True)
 
 -- | Return all utxos belonging to a pubkey, but keep them as 'Pl.TxOut'. This is
 --  for internal use.

--- a/cooked-validators/src/Cooked/MockChain/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Testing.hs
@@ -116,9 +116,14 @@ testFailsFrom' ::
 testFailsFrom' predi = testAllSatisfiesFrom (either predi (testFailureMsg . show))
 
 -- | Is satisfied when the given 'MockChainError' is wrapping a @CekEvaluationFailure@.
+-- This is particularly important when writing negative tests. For example, if we are simulating
+-- an attack and writing a test with 'testFailsFrom', we might have made a mistake in the attack,
+-- yielding a test that fails for reasons such as @ValueLessThanMinAda@ or @ValueNotPreserved@, which
+-- does not rule out the attack being caught by the validator script. For these scenarios it is
+-- paramount to rely on @testFailsFrom' isCekEvaluationFailure@ instead.
 isCekEvaluationFailure :: (IsProp prop) => MockChainError -> prop
 isCekEvaluationFailure (MCEValidationError (_, ScriptFailure _)) = testSuccess
-isCekEvaluationFailure e = testFailureMsg $ "not a validation error: " ++ show e
+isCekEvaluationFailure e = testFailureMsg $ "Expected 'CekEvaluationFailure', got: " ++ show e
 
 -- | Ensure that all results produced by the set of traces encoded by the 'StagedMockChain'
 -- satisfy the given predicate. If you wish to build custom predicates

--- a/cooked-validators/src/Cooked/MockChain/UtxoPredicate.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoPredicate.hs
@@ -28,20 +28,19 @@ p .|| q = \md vl -> p md vl || q md vl
 
 -- | Lifts a predicate over values to a 'UtxoPredicate' by ignoring the datum
 valueSat :: (Pl.Value -> Bool) -> UtxoPredicate a
-valueSat = const
+valueSat predi _ = predi
 
 -- | Lifts a predicate over datums to a 'UtxoPredicate' by forcing the datum
 --  to be present and satisfy the predicate.
 datumSat :: (a -> Bool) -> UtxoPredicate a
-datumSat p = maybe (const False) (const . p)
+datumSat _ Nothing _ = False
+datumSat predi (Just a) _ = predi a
 
 -- * Predicatesover Values
 
 -- | Returns whether or not a given value has a currency symbol present.
 hasCurrencySymbol :: Pl.CurrencySymbol -> Pl.Value -> Bool
-hasCurrencySymbol cs (Pl.Value vl) = case Map.lookup cs vl of
-  Just _ -> True
-  _ -> False
+hasCurrencySymbol cs (Pl.Value vl) = Map.member cs vl
 
 -- | Returns whether or not a given value has an asset class present
 hasAssetClass :: Pl.AssetClass -> Pl.Value -> Bool

--- a/cooked-validators/src/Cooked/MockChain/UtxoPredicate.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoPredicate.hs
@@ -1,0 +1,64 @@
+module Cooked.MockChain.UtxoPredicate where
+
+import Cooked.MockChain.Wallet
+import Ledger.Ada (adaSymbol, adaToken)
+import qualified Ledger.Value as Pl
+import qualified PlutusTx.AssocMap as Map
+
+-- * Predicates over Utxos
+
+-- | A 'UtxoPredicate' is a predicate that is used to filter and select utxos
+--  in 'utxosSuchThat'. We declare them through a type synonym to create a convenient
+--  shallow DSL of predicates.
+type UtxoPredicate a = Maybe a -> Pl.Value -> Bool
+
+-- * Basic building blocks
+
+infixr 3 .&&
+
+-- | Conjunction of 'UtxoPredicate's
+(.&&) :: UtxoPredicate a -> UtxoPredicate a -> UtxoPredicate a
+p .&& q = \md vl -> p md vl && q md vl
+
+infixr 2 .||
+
+-- | Disjunction of 'UtxoPredicate's
+(.||) :: UtxoPredicate a -> UtxoPredicate a -> UtxoPredicate a
+p .|| q = \md vl -> p md vl || q md vl
+
+-- | Lifts a predicate over values to a 'UtxoPredicate' by ignoring the datum
+valueSat :: (Pl.Value -> Bool) -> UtxoPredicate a
+valueSat = const
+
+-- | Lifts a predicate over datums to a 'UtxoPredicate' by forcing the datum
+--  to be present and satisfy the predicate.
+datumSat :: (a -> Bool) -> UtxoPredicate a
+datumSat p = maybe (const False) (const . p)
+
+-- * Predicatesover Values
+
+-- | Returns whether or not a given value has a currency symbol present.
+hasCurrencySymbol :: Pl.CurrencySymbol -> Pl.Value -> Bool
+hasCurrencySymbol cs (Pl.Value vl) = case Map.lookup cs vl of
+  Just _ -> True
+  _ -> False
+
+-- | Returns whether or not a given value has an asset class present
+hasAssetClass :: Pl.AssetClass -> Pl.Value -> Bool
+hasAssetClass ac vl = Pl.assetClassValueOf vl ac > 0
+
+-- | Returns whether or not a given value has multiple asset classes present
+hasAssetClasses :: [Pl.AssetClass] -> Pl.Value -> Bool
+hasAssetClasses acs vl = all (`hasAssetClass` vl) acs
+
+-- | Returns whether a value contains a "quick value". Quick values are tokens
+--  belonging to "quick currencies". Check 'quickValue' for more info.
+hasQuickValue :: String -> Pl.Value -> Bool
+hasQuickValue str = hasAssetClass (quickAssetClass str)
+
+-- | Returns whther or not a value has no token except for Ada
+hasOnlyAda :: Pl.Value -> Bool
+hasOnlyAda v = case Pl.flattenValue v of
+  [] -> True
+  [(sym, tok, _)] -> sym == adaSymbol && tok == adaToken
+  _ -> False

--- a/cooked-validators/src/Cooked/MockChain/UtxoState/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoState/Testing.hs
@@ -31,7 +31,7 @@ equalModuloAda a b = testAll (eqModAda . snd) $ M.toList $ utxoStateDiff a b
     hasOnlyAda v = case Pl.flattenValue v of
       [] -> testSuccess
       [(sym, tok, _)] -> sym .==. Ada.adaSymbol .&&. tok .==. Ada.adaToken
-      _ -> testFailureMsg "Value has more than just Ada"
+      _ -> testFailureMsg $ "Value has more than just Ada: " ++ show v
 
 -- | Returns whether the difference in value between two states is at most
 --  a given bound. Note that the difference in value between states can be negative,

--- a/cooked-validators/src/Cooked/MockChain/UtxoState/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoState/Testing.hs
@@ -3,11 +3,11 @@
 module Cooked.MockChain.UtxoState.Testing where
 
 import Cooked.MockChain.Testing
+import Cooked.MockChain.UtxoPredicate (hasOnlyAda)
 import Cooked.MockChain.UtxoState
 import qualified Data.Map.Strict as M
 import qualified Ledger as Pl
 import qualified Ledger.Value as Pl
-import qualified Plutus.V1.Ledger.Ada as Ada
 import qualified PlutusTx.Numeric as Pl
 
 -- * Relations between states
@@ -22,16 +22,13 @@ equalModuloAda a b = testAll (eqModAda . snd) $ M.toList $ utxoStateDiff a b
     -- contain only ada
     eqModAda (Modified del ins _) =
       let valDiff = utxoValueSetTotal ins <> Pl.negate (utxoValueSetTotal del)
-       in hasOnlyAda valDiff
+       in hasOnlyAdaWithMsg valDiff
     -- If the address was deleted or inserted, the states are different in other ways
     -- other than just ada.
     eqModAda _ = testSuccess
 
-    hasOnlyAda :: (IsProp prop) => Pl.Value -> prop
-    hasOnlyAda v = case Pl.flattenValue v of
-      [] -> testSuccess
-      [(sym, tok, _)] -> sym .==. Ada.adaSymbol .&&. tok .==. Ada.adaToken
-      _ -> testFailureMsg $ "Value has more than just Ada: " ++ show v
+    hasOnlyAdaWithMsg val =
+      testCounterexample ("Has more than just Ada: " ++ show val) $ testBool $ hasOnlyAda val
 
 -- | Returns whether the difference in value between two states is at most
 --  a given bound. Note that the difference in value between states can be negative,


### PR DESCRIPTION
With more people starting to depend on `cooked-validators`, I believe its time we start creating tags to make it a little easier to write `cabal.project` files that bring in `cooked-validators`; this also sheds clarity on which version of plutus is supported by which tags of cooked.  

The main difference of this PR is the creation of a module `UtxoPredicate` and a definition of a bunch of useful combinators that are meant to be used with `utxosSuchThat`.