### PR TITLE
Refactor constraints and transaction generation

### DIFF
--- a/cooked-validators/src/Cooked/MockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain.hs
@@ -37,8 +37,4 @@ import qualified Ledger as Pl
 --  to that pubkey and returning the leftover to the same pubkey.
 --  This function is here to avoid an import cycle.
 spentByPK :: MonadBlockChain m => Pl.PubKeyHash -> Pl.Value -> m [Constraint]
-spentByPK pkh val = do
-  -- TODO: maybe turn spentByPK into a pure function: spentByPK val <$> pkUtxos
-  allOuts <- pkUtxos pkh
-  let (toSpend, leftOver, _) = spendValueFrom val $ map (second Pl.toTxOut) allOuts
-  (paysPK pkh leftOver :) . map SpendsPK <$> mapM spendableRef toSpend
+spentByPK pkh val = error "not reimplemented yet" -- TODO reimplement

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -86,15 +86,15 @@ class (MonadFail m) => MonadBlockChain m where
   awaitTime :: Pl.POSIXTime -> m Pl.POSIXTime
 
 -- | Calls 'validateTxSkel' with a skeleton that is set with some specific options.
-validateTxConstrOpts :: (MonadBlockChain m) => TxOpts -> [Constraint] -> m Pl.TxId
+validateTxConstrOpts :: (MonadBlockChain m) => TxOpts -> TxSpec -> m Pl.TxId
 validateTxConstrOpts opts = validateTxSkel . txSkelOpts opts
 
 -- | Calls 'validateTx' with the default set of options and no label.
-validateTxConstr :: (MonadBlockChain m) => [Constraint] -> m Pl.TxId
+validateTxConstr :: (MonadBlockChain m) => TxSpec -> m Pl.TxId
 validateTxConstr = validateTxSkel . txSkel
 
 -- | Calls 'validateTxSkel' with the default set of options but passes an arbitrary showable label to it.
-validateTxConstrLbl :: (Show lbl, MonadBlockChain m) => lbl -> [Constraint] -> m Pl.TxId
+validateTxConstrLbl :: (Show lbl, MonadBlockChain m) => lbl -> TxSpec -> m Pl.TxId
 validateTxConstrLbl lbl = validateTxSkel . txSkelLbl lbl
 
 spendableRef :: (MonadBlockChain m) => Pl.TxOutRef -> m SpendableOut

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -21,11 +21,12 @@ instance (C.AsContractError e) => MonadFail (C.Contract w s e) where
   fail = C.throwError . review C._OtherError . T.pack
 
 instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
-  validateTxSkel txSkel0 = do
-    let (lkups, constrs) = toLedgerConstraints @Void (txConstraints txSkel0)
-    txId <- Pl.getCardanoTxId <$> C.submitTxConstraintsWith lkups constrs
-    when (awaitTxConfirmed $ txOpts txSkel0) $ C.awaitTxConfirmed txId
-    return txId
+  validateTxSkel txSkel0 = error "not reimplemented yet" -- TODO
+  -- do
+  --   let (lkups, constrs) = toLedgerConstraints @Void (txConstraints txSkel0)
+  --   txId <- Pl.getCardanoTxId <$> C.submitTxConstraintsWith lkups constrs
+  --   when (awaitTxConfirmed $ txOpts txSkel0) $ C.awaitTxConfirmed txId
+  --   return txId
 
   utxosSuchThat addr datumPred = do
     allUtxos <- M.toList <$> C.utxosAt addr

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -1,104 +1,157 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-deferred-out-of-scope-variables #-}
 
 module Cooked.Tx.Constraints
   ( module Cooked.Tx.Constraints.Type,
     module Cooked.Tx.Constraints.Pretty,
-    LedgerConstraint,
-    extractDatumStrFromConstraint,
-    signedByWallets,
-    toLedgerConstraint,
-    toLedgerConstraints,
+    extractDatumStrFromTxSpec,
+    txFromTxSpec,
   )
 where
 
-import Cooked.MockChain.Wallet
 import Cooked.Tx.Constraints.Pretty
 import Cooked.Tx.Constraints.Type
 import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import Data.Set (Set)
+import qualified Data.Set as Set
 import qualified Ledger as Pl hiding (singleton, unspentOutputs)
 import qualified Ledger.Constraints as Pl
-import qualified Ledger.Constraints.TxConstraints as Pl
-import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, validatorScript)
+import qualified Ledger.Constraints.OffChain as Pl
+import qualified Ledger.Credential as Pl
+import qualified Ledger.Typed.Scripts as Pl (validatorScript)
 import qualified PlutusTx as Pl
-
--- * Converting 'Constraint's to 'Pl.ScriptLookups', 'Pl.TxConstraints'
-
-type LedgerConstraint a =
-  (Pl.ScriptLookups a, Pl.TxConstraints (Pl.RedeemerType a) (Pl.DatumType a))
 
 -- | Map from datum hashes to string representation of all the datums carried.
 -- We use this in order to display data to the use when testing. Its often
 -- easier to read the original datatype that was placed into a UTxO
 -- instead of its respective @toBuilinData@ image.
-extractDatumStrFromConstraint :: Constraint -> M.Map Pl.DatumHash String
-extractDatumStrFromConstraint (PaysScript _validator datumsAndValues) =
-  M.fromList
-    . map ((\d -> (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d, show d)) . fst)
-    $ datumsAndValues
-extractDatumStrFromConstraint (SpendsScript _validator _redeemer (_out, datum)) =
-  M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData datum) (show datum)
-extractDatumStrFromConstraint (PaysPKWithDatum _pk _stak mdat _v) =
-  maybe M.empty (\d -> M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d) (show d)) mdat
-extractDatumStrFromConstraint _ = M.empty
+extractDatumStrFromTxSpec :: TxSpec -> M.Map Pl.DatumHash String
+extractDatumStrFromTxSpec TxSpec {..} =
+  M.unions
+    [ M.unions (extractDatumStrFromSpending <$> txSpendings),
+      M.unions (extractDatumStrFromPayment <$> txPayments),
+      M.unions (extractDatumStrFromMinting <$> txMinting)
+    ]
+  where
+    extractDatumStrFromMinting :: Minting -> M.Map Pl.DatumHash String
+    extractDatumStrFromMinting (Mints datum _ _) =
+      M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData datum) (show datum)
 
--- | Converts our constraint into a 'LedgerConstraint',
---  which later can be used to generate a transaction. The universally
---  quantified type-variable is there on purpose, to enable us to
---  easily spend from multiple scripts at the same time.
-toLedgerConstraint :: Constraint -> LedgerConstraint a
-toLedgerConstraint (SpendsScript v r ((oref, o), _a)) = (lkups, constr)
-  where
-    lkups =
-      Pl.otherScript (Pl.validatorScript v)
-        <> Pl.unspentOutputs (M.singleton oref o)
-    constr = Pl.mustSpendScriptOutput oref (Pl.Redeemer $ Pl.toBuiltinData r)
-toLedgerConstraint (PaysScript v outs) = (lkups, constr)
-  where
-    lkups = Pl.otherScript (Pl.validatorScript v)
-    constr = mconcat $
-      flip map outs $ \(d, val) ->
-        Pl.mustPayToOtherScript
-          (Pl.validatorHash $ Pl.validatorScript v)
-          (Pl.Datum $ Pl.toBuiltinData d)
-          val
-toLedgerConstraint (PaysPKWithDatum p stak dat v) = (lkups, constr)
-  where
-    mData = fmap (Pl.Datum . Pl.toBuiltinData) dat
+    extractDatumStrFromSpending :: Spending -> M.Map Pl.DatumHash String
+    extractDatumStrFromSpending (SpendsScript _validator _redeemer (_out, datum)) =
+      M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData datum) (show datum)
+    extractDatumStrFromSpending _ = M.empty
 
-    lkups =
-      maybe mempty Pl.otherData mData
-        -- TODO: do we want to akk ownStakePubKeyHash on 'PaysPKWithDatum'? Would we rather have
-        -- a different 'WithOwnStakePubKeyHash' constraint?
-        <> maybe mempty Pl.ownStakePubKeyHash stak
-    constr = Pl.singleton $ Pl.MustPayToPubKeyAddress (Pl.PaymentPubKeyHash p) stak mData v
-toLedgerConstraint (SpendsPK (oref, o)) = (lkups, constr)
-  where
-    lkups = Pl.unspentOutputs (M.singleton oref o)
-    constr = Pl.mustSpendPubKeyOutput oref
-toLedgerConstraint (Mints Nothing pols v) = (lkups, constr)
-  where
-    lkups = foldMap Pl.mintingPolicy pols
-    constr = Pl.mustMintValue v
-toLedgerConstraint (Mints (Just r) pols v) = (lkups, constr)
-  where
-    lkups = foldMap Pl.mintingPolicy pols
-    constr = Pl.mustMintValueWithRedeemer (Pl.Redeemer (Pl.toBuiltinData r)) v
-toLedgerConstraint (Before t) = (mempty, constr)
-  where
-    constr = Pl.mustValidateIn (Pl.to t)
-toLedgerConstraint (After t) = (mempty, constr)
-  where
-    constr = Pl.mustValidateIn (Pl.from t)
-toLedgerConstraint (ValidateIn r) = (mempty, Pl.mustValidateIn r)
-toLedgerConstraint (SignedBy hashes) = (mempty, foldMap (Pl.mustBeSignedBy . Pl.PaymentPubKeyHash) hashes)
+    extractDatumStrFromPayment :: Payment -> M.Map Pl.DatumHash String
+    extractDatumStrFromPayment (PaysScript _validator datum _v) =
+      M.singleton (Pl.datumHash . Pl.Datum . Pl.toBuiltinData $ datum) (show datum)
+    extractDatumStrFromPayment (PaysPKWithDatum _pk _stak mdat _v) =
+      maybe M.empty (\d -> M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d) (show d)) mdat
 
--- | Converts a list of constraints into a 'LedgerConstraint'
-toLedgerConstraints :: [Constraint] -> LedgerConstraint a
-toLedgerConstraints cs = (mconcat lkups, mconcat constrs)
-  where
-    (lkups, constrs) = unzip $ map toLedgerConstraint cs
+spendingTxIn :: Spending -> Pl.TxIn
+spendingTxIn (SpendsPK (txOutRef, _chainIndexTxOut)) =
+  Pl.TxIn txOutRef (Just Pl.ConsumePublicKeyAddress)
+spendingTxIn (SpendsScript validator redeemer ((txOutRef, _chainIndexTxOut), datum)) =
+  Pl.TxIn
+    txOutRef
+    ( Just
+        ( Pl.ConsumeScriptAddress
+            (Pl.validatorScript validator)
+            (Pl.Redeemer (Pl.toBuiltinData redeemer))
+            (Pl.Datum (Pl.toBuiltinData datum))
+        )
+    )
 
--- | @signedByWallets ws == SignedBy $ map walletPKHash ws@
-signedByWallets :: [Wallet] -> Constraint
-signedByWallets = SignedBy . map walletPKHash
+paymentTxOut :: Payment -> Pl.TxOut
+paymentTxOut (PaysScript validator datum value) =
+  Pl.TxOut
+    { Pl.txOutAddress =
+        Pl.Address
+          { Pl.addressCredential =
+              Pl.ScriptCredential . Pl.validatorHash . Pl.validatorScript $ validator,
+            -- NOTE scripts can have staking credential
+            -- It is ok to leave it for now until we learn more about whether it is used in contracts
+            Pl.addressStakingCredential = Nothing
+          },
+      Pl.txOutValue = value,
+      Pl.txOutDatumHash = Just . Pl.datumHash . Pl.Datum . Pl.toBuiltinData $ datum
+    }
+paymentTxOut (PaysPKWithDatum pkh mStakePkh mDatum value) =
+  Pl.TxOut
+    { Pl.txOutAddress =
+        Pl.Address
+          { Pl.addressCredential = Pl.PubKeyCredential pkh,
+            -- TO CHECK Is this the expected pkh here?
+            Pl.addressStakingCredential = Pl.StakingHash . Pl.PubKeyCredential . Pl.unStakePubKeyHash <$> mStakePkh
+          },
+      Pl.txOutValue = value,
+      Pl.txOutDatumHash = Pl.datumHash . Pl.Datum . Pl.toBuiltinData <$> mDatum
+    }
+
+datumFromPayment :: Payment -> Maybe (Pl.DatumHash, Pl.Datum)
+-- TODO There may be a datum in SpendsPK now
+datumFromPayment (PaysPKWithDatum _ _ mTypedDatum _) = do
+  datum <- Pl.Datum . Pl.toBuiltinData <$> mTypedDatum
+  return (Pl.datumHash datum, datum)
+datumFromPayment (PaysScript _ typedDatum _) =
+  let datum = Pl.Datum (Pl.toBuiltinData typedDatum)
+   in Just (Pl.datumHash datum, datum)
+
+datumFromSpending :: Spending -> Maybe (Pl.DatumHash, Pl.Datum)
+-- TODO There may be a datum in SpendsPK now
+datumFromSpending (SpendsPK _) = Nothing
+datumFromSpending (SpendsScript _ _ (_, typedDatum)) =
+  let datum = Pl.Datum (Pl.toBuiltinData typedDatum)
+   in Just (Pl.datumHash datum, datum)
+
+redeemerFromMinting :: Integer -> Minting -> Maybe (Pl.RedeemerPtr, Pl.Redeemer)
+redeemerFromMinting _ (Mints Nothing _ _) = Nothing
+redeemerFromMinting index (Mints (Just redeemer) _ _) =
+  Just
+    ( Pl.RedeemerPtr Pl.Mint index,
+      Pl.Redeemer (Pl.toBuiltinData redeemer)
+    )
+
+mintScriptsFromMinting :: Minting -> Set Pl.MintingPolicy
+mintScriptsFromMinting (Mints _ mintingPolicies _) = Set.fromList mintingPolicies
+
+valueFromMinting :: Minting -> Pl.Value
+valueFromMinting (Mints _ _ value) = value
+
+timeConstraintRange :: TimeConstraint -> Pl.POSIXTimeRange
+timeConstraintRange (Before t) = Pl.to t
+timeConstraintRange (After t) = Pl.from t
+timeConstraintRange (ValidateIn trange) = trange
+
+txFromTxSpec :: TxSpec -> Pl.UnbalancedTx
+txFromTxSpec TxSpec {..} =
+  Pl.UnbalancedTx
+    { Pl.unBalancedTxTx =
+        Pl.Tx
+          { Pl.txInputs = Set.fromList (spendingTxIn <$> txSpendings),
+            Pl.txCollateral = Set.empty,
+            Pl.txOutputs = paymentTxOut <$> txPayments,
+            Pl.txMint = mconcat (valueFromMinting <$> txMinting),
+            Pl.txFee = mempty,
+            Pl.txValidRange = Pl.always,
+            Pl.txMintScripts = Set.unions $ mintScriptsFromMinting <$> txMinting,
+            Pl.txSignatures = M.empty,
+            Pl.txRedeemers =
+              -- TODO Not sure how to compute the indexes
+              -- This only works for redeemer-less minting
+              M.singleton (Pl.RedeemerPtr Pl.Mint 0) (Pl.Redeemer . Pl.toBuiltinData $ ()),
+            Pl.txData =
+              M.fromList $
+                mapMaybe datumFromSpending txSpendings <> mapMaybe datumFromPayment txPayments
+          },
+      -- TODO when is "PaymentPubKey" required?
+      Pl.unBalancedTxRequiredSignatories = M.fromList $ (,Nothing) . Pl.PaymentPubKeyHash <$> txSignatories,
+      -- TODO put all the utxos involved in the transaction?
+      -- Either an error or all the utxos
+      Pl.unBalancedTxUtxoIndex = undefined,
+      Pl.unBalancedTxValidityTimeRange = maybe Pl.always timeConstraintRange txTimeConstraint
+    }

--- a/cooked-validators/tests/Cooked/BalanceSpec.hs
+++ b/cooked-validators/tests/Cooked/BalanceSpec.hs
@@ -115,19 +115,19 @@ spec = do
     -- It would leave it with a 0.4 ada UTxO which is less than min ada.
     it "Fails for unbalanceable transactions" $
       let tr =
-            validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> signs (wallet 11) (validateTxConstr [paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
+            validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)])
+              >> validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)])
+              >> signs (wallet 11) (validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)]))
        in runMockChain tr `shouldSatisfy` isLeft
 
     -- Unlike the test above, we now want to see this being possible, but the transaction will need
     -- to consume the additional utxo of wallet 11.
     it "Uses additional utxos on demand" $
       let tr =
-            validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
-              >> validateTxConstr [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 3_700_000)]
-              >> signs (wallet 11) (validateTxConstr [paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)])
+            validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)])
+              >> validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)])
+              >> validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 3_700_000)])
+              >> signs (wallet 11) (validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 1) (Pl.lovelaceValueOf 8_000_000)]))
        in runMockChain tr `shouldSatisfy` isRight
 
 outsOf :: Int -> Pl.UtxoIndex -> [(Pl.TxOutRef, Pl.TxOut)]
@@ -148,9 +148,9 @@ tracePayWallet11 :: Either MockChainError (MockChainSt, UtxoState)
 tracePayWallet11 =
   runMockChain $ do
     validateTxConstr
-      [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+      (txSpecPays [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)])
     validateTxConstr
-      [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)]
+      (txSpecPays [paysPK (walletPKHash $ wallet 11) (Pl.lovelaceValueOf 4_200_000)])
     MockChainT get
 
 -- * Helper Instances

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -25,10 +25,10 @@ assertAll space f = mapM_ f space
 possibleTraces :: [StagedMockChain ()]
 possibleTraces =
   [ return (),
-    void $ validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)],
+    void $ validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)]),
     void $ do
-      validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)]
-      validateTxConstr [paysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200000)]
+      validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200000)])
+      validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200000)])
   ]
 
 spec :: Spec
@@ -58,8 +58,8 @@ spec = do
     -- If we execute @somewhere k tr'@ instead, we should expect to see 8 branches.
     -- Because we're choosing @f = g = k = id@, we exept the eight traces to be equal to tr.
     let tr =
-          validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)]
-            >> validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)]
+          validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)])
+            >> validateTxConstr (txSpecPays [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)])
      in interpret (somewhere Just $ somewhere Just $ somewhere Just tr)
           `imcEq` asum (replicate 8 $ interpret tr)
 
@@ -67,13 +67,15 @@ spec = do
     let -- Sample trace
         tr f g =
           validateTxConstr
-            [ paysPK
-                (walletPKHash $ wallet 2)
-                (f $ g $ Pl.lovelaceValueOf 4_200_000)
-            ]
+            ( txSpecPays
+                [ paysPK
+                    (walletPKHash $ wallet 2)
+                    (f $ g $ Pl.lovelaceValueOf 4_200_000)
+                ]
+            )
         -- Function to modify some specific skeletons
-        app f (TxSkel l opts [PaysPKWithDatum pk stak dat val]) =
-          Just $ TxSkel l opts [PaysPKWithDatum pk stak dat (f val)]
+        app f (TxSkel l opts (TxSpec [] [PaysPKWithDatum pk stak dat val] [] Nothing [] [])) =
+          Just $ TxSkel l opts (TxSpec [] [PaysPKWithDatum pk stak dat (f val)] [] Nothing [] [])
         app f _ = Nothing
         -- Two transformations
         f x = Pl.lovelaceValueOf 3_000_000

--- a/cooked-validators/tests/Cooked/QuickValueSpec.hs
+++ b/cooked-validators/tests/Cooked/QuickValueSpec.hs
@@ -28,7 +28,7 @@ paymentAfterCustomInitialization =
     validateTxConstrOpts
       -- we have to adjust the tx in order for it not to fail with ValueLessThanMinAda
       (def {adjustUnbalTx = True})
-      [paysPK (walletPKHash $ wallet 2) (quickValue "goldenCoins" 12)]
+      (txSpecPays [paysPK (walletPKHash $ wallet 2) (quickValue "goldenCoins" 12)])
     return ()
 
 quickValuesInitialisation :: Either MockChainError ((), UtxoState)

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -31,13 +31,10 @@ txLock script datum =
   void $
     validateTxConstrLbl
       (TxLock datum)
-      [ PaysScript
-          script
-          [ ( datum,
-              Pl.lovelaceValueOf $ Split.amount datum
-            )
+      ( txSpecPays
+          [ PaysScript script datum (Pl.lovelaceValueOf (Split.amount datum))
           ]
-      ]
+      )
 
 -- | Label for 'txLock' skeleton, making it immediately recognizable
 -- when printing traces.
@@ -59,10 +56,12 @@ txUnlock script = do
   void $
     validateTxConstrLbl
       TxUnlock
-      [ SpendsScript script () (output, datum),
-        paysPK r1 (Pl.lovelaceValueOf share1),
-        paysPK r2 (Pl.lovelaceValueOf share2)
-      ]
+      ( txSpecSpendsAndPays
+          [SpendsScript script () (output, datum)]
+          [ paysPK r1 (Pl.lovelaceValueOf share1),
+            paysPK r2 (Pl.lovelaceValueOf share2)
+          ]
+      )
 
 -- | Label for 'txUnlock' skeleton
 data TxUnlock = TxUnlock deriving (Show)

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -74,7 +74,7 @@ paysCampaign c w val =
     signs w $
       validateTxConstrOpts
         (def {autoSlotIncrease = False})
-        [PaysScript (typedValidator c) [(Ledger.PaymentPubKeyHash $ walletPKHash w, val)]]
+        (txSpecPays [PaysScript (typedValidator c) (Ledger.PaymentPubKeyHash $ walletPKHash w) val])
 
 -- | Retrieve funds as being the owner
 retrieveFunds :: (MonadMockChain m) => Ledger.POSIXTime -> Campaign -> Wallet -> m ()
@@ -84,10 +84,11 @@ retrieveFunds t c owner = do
     signs owner $
       validateTxConstrOpts
         (def {autoSlotIncrease = False})
-        ( map (SpendsScript (typedValidator c) Collect) funds
-            ++ [ paysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds),
-                 ValidateIn $ collectionRange c
-               ]
+        ( def
+            { txSpendings = SpendsScript (typedValidator c) Collect <$> funds,
+              txPayments = [paysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds)],
+              txTimeConstraint = Just $ ValidateIn (collectionRange c)
+            }
         )
 
 -- * Tests


### PR DESCRIPTION
This PR proposes to refactor the generation of transactions from Cooked constraints. This brings us more control over the generated transactions: most notably allowing us to ensure a specific order for the outputs which many validators in the wild require. Also, it is significantly simpler that Plutus app tx generation, in a more declarative style. We don't have the `MustSatisfyAnyOf` constraint which makes things more complex in Plutus. It also aims at separating constraints related to the structure of a transaction (inputs/outputs/minting) and constraints related the validation (time constraints/signatures). For consistency, PaysToScript constraints now have only one datum and value.

This is ***work in progress***. Currently, the proposed tx generation is a proof of concept that works for the entire Cooked's test suite.

### Proof of concept

The most visible change is the removal of the all-in-one constraint list in tx skeletons. Constraints are now separated into (temporary naming):
* the spendings (inputs)
* the payments (outputs)
* the mintings
* the optional time constraint
* the list of required signatories

Together, they form a `TxSpec` which replaces the all-in-one list of constraints. There is a `Default` instance for `TxSpec` for convenience (e.g. `def {txSpendings = [...]}`) and smart constructors for transactions with only spendings and/or payments.

Since this PR impacts how we specify transactions, we should decide together on how we want to design types, constructors, and names because it implies refactoring all of our tests and examples.

Right now, this PR generates a good old Plutus `Pl.UnbalancedTx`. The existing balancing workflow then proceeds without change.

### Remaining work

#### Intermediate representation of tx under construction

An `UnbalancedTx` consists of a work in progress `Tx` and additional fields to help complete it. Some fields in the contained `Tx` are not expected to make sense since they will be changed using the additional info (e.g time range -> time slot range, signatories -> signatures). Additionally, we never make use of some fields or parts of the contained values (e.g. `txCollateral`, `txFee` (filled up later) or `unBalancedTxUtxoIndex`).

Therefore we should move to a better intermediate representation of those work in progress transactions. Here is an example of what could be such a `TxBlueprint` (temporary naming).

```haskell
-- | Intermediate representation of a transaction under construction.
-- This serves a similar role as Plutus' `UnbalancedTx`
data TxBlueprint = TxBlueprint
  { txbpInputs :: [Pl.TxIn],
    txbpOutputs :: [Pl.TxOut],
    txbpMint :: Pl.Value,
    txbpMintScripts :: Set Pl.MintingPolicy,
    txbpData :: Map Pl.DatumHash Pl.Datum,
    txbpRedeemers :: Pl.Redeemers,
    txbpSignatories :: [Pl.PubKeyHash],
    txbpValidityTimeRange :: Pl.POSIXTimeRange
  }
```

#### Redeemers of minting scripts

The Tx have a field txRedeemers for "redeemers of the minting scripts" (according to the docs). The type is a map from `(ScriptTag, Integer)` to `Redeemer`. The script tag tells whether a script is a spend script or minting script. The integer is the index in the transaction. From what I understand this means that, given 3 minting scripts in the transaction, the redeemer of the second one is the value corresponding to key `(Mint, 2)` in the `txRedeemers` map. The thing is minting scripts in a transaction are contained in a set `txMintScripts`, hence no ordering in theory. Is it implied that the order is the haskell's sets one and the index in the map correspond to the position of the minting script in `Set.toAscList txMintScripts`?


#### Classification of constraints

For now this PR moved from a `txConstraints` all-in-one list in `TxSkel` to a well structured `TxSpec` record with inputs, outputs, mintings, time constraints, and signatures.

We would like to put back time constraints and signatures under a common constraint list as before and separate what describes the transaction and what describes how it should be validated. I am for the separation. I am not sure about the list structure though: having several "signed by" means concatenating the lists of signatories, and having several time constraints means computing the intersection of the validity ranges. This is why in this first draft, these are two fields: an optional time constraint and a single list of signatories. It is equivalently or slightly less complex when handling the constraints. However it distances us further away from current representation of constraints.

### Misc questions

* Why don't we provide `Pretty Foo` instances when applicable instead of `prettyFoo :: Foo -> Doc ann`?

### TODO

* [ ] Tx blueprint: intermediate representation of tx under construction
* [ ] Move back time and signatures to regular list of constraints
* [ ] Handling of PK datums remains to be implemented in some places
* [ ] Reimplement `spentByPK`
* [ ] Gather feedback on names and type structure then refactor
    * [ ] For constraints
    * [ ] Relevant and intuitive names for all TxSkel/TxSpec/TxBlueprint/TxWhatever
* [ ] Gather feedback about user-friendliness, synonyms, smart constructors, etc, then implement
* [ ] Merge recent main branch changes 
* [ ] Add missing haddock
* [ ] Final touches and readability pass


Thank you for your feedback, especially the points of discussion!
