### PR TITLE
Order transaction outputs according to the list of output constraints

### DIFF
--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -81,6 +81,7 @@ test-suite spec
       Cooked.MockChain.Monad.StagedSpec
       Cooked.MockChain.UtxoStateSpec
       Cooked.MockChain.WalletSpec
+      Cooked.OutputReorderingSpec
       Cooked.QuickValueSpec
       Paths_cooked_validators
   hs-source-dirs:

--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.4
 -- see: https://github.com/sol/hpack
 
 name:           cooked-validators
-version:        0.1.0
+version:        0.2.0
 build-type:     Simple
 extra-source-files:
     README.md

--- a/cooked-validators/package.yaml
+++ b/cooked-validators/package.yaml
@@ -2,7 +2,7 @@ verbatim:
   cabal-version: 3.4
 
 name: cooked-validators
-version: 0.1.0
+version: 0.2.0
 extra-source-files:
   - README.md
 

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -87,15 +87,15 @@ class (MonadFail m) => MonadBlockChain m where
   awaitTime :: Pl.POSIXTime -> m Pl.POSIXTime
 
 -- | Calls 'validateTxSkel' with a skeleton that is set with some specific options.
-validateTxConstrOpts :: (MonadBlockChain m) => TxOpts -> [Constraint] -> m Pl.TxId
+validateTxConstrOpts :: (MonadBlockChain m, ConstraintsSpec constraints) => TxOpts -> constraints -> m Pl.TxId
 validateTxConstrOpts opts = validateTxSkel . txSkelOpts opts
 
 -- | Calls 'validateTx' with the default set of options and no label.
-validateTxConstr :: (MonadBlockChain m) => [Constraint] -> m Pl.TxId
+validateTxConstr :: (MonadBlockChain m, ConstraintsSpec constraints) => constraints -> m Pl.TxId
 validateTxConstr = validateTxSkel . txSkel
 
 -- | Calls 'validateTxSkel' with the default set of options but passes an arbitrary showable label to it.
-validateTxConstrLbl :: (Show lbl, MonadBlockChain m) => lbl -> [Constraint] -> m Pl.TxId
+validateTxConstrLbl :: (Show lbl, MonadBlockChain m, ConstraintsSpec constraints) => lbl -> constraints -> m Pl.TxId
 validateTxConstrLbl lbl = validateTxSkel . txSkelLbl lbl
 
 spendableRef :: (MonadBlockChain m) => Pl.TxOutRef -> m SpendableOut

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -21,10 +22,10 @@ instance (C.AsContractError e) => MonadFail (C.Contract w s e) where
   fail = C.throwError . review C._OtherError . T.pack
 
 instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
-  validateTxSkel txSkel0 = do
-    let (lkups, constrs) = toLedgerConstraints @Void (txConstraints txSkel0)
+  validateTxSkel TxSkel {txConstraints, txOpts} = do
+    let (lkups, constrs) = toLedgerConstraint @Constraints @Void (toConstraints txConstraints)
     txId <- Pl.getCardanoTxId <$> C.submitTxConstraintsWith lkups constrs
-    when (awaitTxConfirmed $ txOpts txSkel0) $ C.awaitTxConfirmed txId
+    when (awaitTxConfirmed txOpts) $ C.awaitTxConfirmed txId
     return txId
 
   utxosSuchThat addr datumPred = do

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -329,10 +329,10 @@ generateTx' skel@(TxSkel _ _ constraintsSpec) = do
     Right ubtx -> do
       let adjust = if adjustUnbalTx opts then Pl.adjustUnbalancedTx else id
       let (_ :=>: outputConstraints) = toConstraints constraintsSpec
-      reorderedUbtx <-
-        if forceOutputOrdering opts
-          then applyTxOutConstraintOrder outputConstraints ubtx
-          else return ubtx
+      let reorderedUbtx =
+            if forceOutputOrdering opts
+              then applyTxOutConstraintOrder outputConstraints ubtx
+              else ubtx
       signers <- askSigners
       balancedTx <- balanceTxFrom (not $ balance opts) (NE.head signers) (adjust reorderedUbtx)
       return $
@@ -353,10 +353,10 @@ generateTx' skel@(TxSkel _ _ constraintsSpec) = do
         }
 
     -- Order outputs according to the order of output constraints
-    applyTxOutConstraintOrder :: MonadFail m => [OutConstraint] -> Pl.UnbalancedTx -> m Pl.UnbalancedTx
-    applyTxOutConstraintOrder ocs tx = do
-      txOuts' <- orderTxOutputs ocs . Pl.txOutputs . Pl.unBalancedTxTx $ tx
-      return tx {Pl.unBalancedTxTx = (Pl.unBalancedTxTx tx) {Pl.txOutputs = txOuts'}}
+    applyTxOutConstraintOrder :: [OutConstraint] -> Pl.UnbalancedTx -> Pl.UnbalancedTx
+    applyTxOutConstraintOrder ocs tx =
+      let txOuts' = orderTxOutputs ocs . Pl.txOutputs . Pl.unBalancedTxTx $ tx
+       in tx {Pl.unBalancedTxTx = (Pl.unBalancedTxTx tx) {Pl.txOutputs = txOuts'}}
 
 -- | Sets the 'Pl.txFee' and 'Pl.txValidRange' according to our environment.
 -- TODO: bring in FeeConfig: https://github.com/tweag/plutus-libs/issues/10

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -5,20 +5,22 @@ module Cooked.Tx.Constraints
   ( module Cooked.Tx.Constraints.Type,
     module Cooked.Tx.Constraints.Pretty,
     LedgerConstraint,
-    extractDatumStrFromConstraint,
+    extractDatumStr,
     signedByWallets,
     toLedgerConstraint,
-    toLedgerConstraints,
+    orderTxOutputs,
   )
 where
 
 import Cooked.MockChain.Wallet
 import Cooked.Tx.Constraints.Pretty
 import Cooked.Tx.Constraints.Type
+import qualified Data.List as List
 import qualified Data.Map.Strict as M
 import qualified Ledger as Pl hiding (singleton, unspentOutputs)
 import qualified Ledger.Constraints as Pl
 import qualified Ledger.Constraints.TxConstraints as Pl
+import qualified Ledger.Credential as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, validatorScript)
 import qualified PlutusTx as Pl
 
@@ -27,78 +29,132 @@ import qualified PlutusTx as Pl
 type LedgerConstraint a =
   (Pl.ScriptLookups a, Pl.TxConstraints (Pl.RedeemerType a) (Pl.DatumType a))
 
--- | Map from datum hashes to string representation of all the datums carried.
--- We use this in order to display data to the use when testing. Its often
--- easier to read the original datatype that was placed into a UTxO
--- instead of its respective @toBuilinData@ image.
-extractDatumStrFromConstraint :: Constraint -> M.Map Pl.DatumHash String
-extractDatumStrFromConstraint (PaysScript _validator datumsAndValues) =
-  M.fromList
-    . map ((\d -> (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d, show d)) . fst)
-    $ datumsAndValues
-extractDatumStrFromConstraint (SpendsScript _validator _redeemer (_out, datum)) =
-  M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData datum) (show datum)
-extractDatumStrFromConstraint (PaysPKWithDatum _pk _stak mdat _v) =
-  maybe M.empty (\d -> M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d) (show d)) mdat
-extractDatumStrFromConstraint _ = M.empty
+-- | Class for common operations on output and misc constraints.
+class Constraint constraint where
+  -- | Map from datum hashes to string representation of all the datums carried.
+  -- We use this in order to display data to the use when testing. Its often
+  -- easier to read the original datatype that was placed into a UTxO
+  -- instead of its respective @toBuilinData@ image.
+  extractDatumStr :: constraint -> M.Map Pl.DatumHash String
 
--- | Converts our constraint into a 'LedgerConstraint',
---  which later can be used to generate a transaction. The universally
---  quantified type-variable is there on purpose, to enable us to
---  easily spend from multiple scripts at the same time.
-toLedgerConstraint :: Constraint -> LedgerConstraint a
-toLedgerConstraint (SpendsScript v r ((oref, o), _a)) = (lkups, constr)
-  where
-    lkups =
-      Pl.otherScript (Pl.validatorScript v)
-        <> Pl.unspentOutputs (M.singleton oref o)
-    constr = Pl.mustSpendScriptOutput oref (Pl.Redeemer $ Pl.toBuiltinData r)
-toLedgerConstraint (PaysScript v outs) = (lkups, constr)
-  where
-    lkups = Pl.otherScript (Pl.validatorScript v)
-    constr = mconcat $
-      flip map outs $ \(d, val) ->
-        Pl.mustPayToOtherScript
-          (Pl.validatorHash $ Pl.validatorScript v)
-          (Pl.Datum $ Pl.toBuiltinData d)
-          val
-toLedgerConstraint (PaysPKWithDatum p stak dat v) = (lkups, constr)
-  where
-    mData = fmap (Pl.Datum . Pl.toBuiltinData) dat
+  -- | Converts our constraint into a 'LedgerConstraint',
+  --  which later can be used to generate a transaction. The universally
+  --  quantified type-variable is there on purpose, to enable us to
+  --  easily spend from multiple scripts at the same time.
+  toLedgerConstraint :: constraint -> LedgerConstraint a
 
-    lkups =
-      maybe mempty Pl.otherData mData
-        -- TODO: do we want to akk ownStakePubKeyHash on 'PaysPKWithDatum'? Would we rather have
-        -- a different 'WithOwnStakePubKeyHash' constraint?
-        <> maybe mempty Pl.ownStakePubKeyHash stak
-    constr = Pl.singleton $ Pl.MustPayToPubKeyAddress (Pl.PaymentPubKeyHash p) stak mData v
-toLedgerConstraint (SpendsPK (oref, o)) = (lkups, constr)
-  where
-    lkups = Pl.unspentOutputs (M.singleton oref o)
-    constr = Pl.mustSpendPubKeyOutput oref
-toLedgerConstraint (Mints Nothing pols v) = (lkups, constr)
-  where
-    lkups = foldMap Pl.mintingPolicy pols
-    constr = Pl.mustMintValue v
-toLedgerConstraint (Mints (Just r) pols v) = (lkups, constr)
-  where
-    lkups = foldMap Pl.mintingPolicy pols
-    constr = Pl.mustMintValueWithRedeemer (Pl.Redeemer (Pl.toBuiltinData r)) v
-toLedgerConstraint (Before t) = (mempty, constr)
-  where
-    constr = Pl.mustValidateIn (Pl.to t)
-toLedgerConstraint (After t) = (mempty, constr)
-  where
-    constr = Pl.mustValidateIn (Pl.from t)
-toLedgerConstraint (ValidateIn r) = (mempty, Pl.mustValidateIn r)
-toLedgerConstraint (SignedBy hashes) = (mempty, foldMap (Pl.mustBeSignedBy . Pl.PaymentPubKeyHash) hashes)
+instance Constraint MiscConstraint where
+  extractDatumStr (SpendsScript _validator _redeemer (_out, datum)) =
+    M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData datum) (show datum)
+  extractDatumStr _ = M.empty
 
--- | Converts a list of constraints into a 'LedgerConstraint'
-toLedgerConstraints :: [Constraint] -> LedgerConstraint a
-toLedgerConstraints cs = (mconcat lkups, mconcat constrs)
+  toLedgerConstraint (SpendsScript v r ((oref, o), _a)) = (lkups, constr)
+    where
+      lkups =
+        Pl.otherScript (Pl.validatorScript v)
+          <> Pl.unspentOutputs (M.singleton oref o)
+      constr = Pl.mustSpendScriptOutput oref (Pl.Redeemer $ Pl.toBuiltinData r)
+  toLedgerConstraint (SpendsPK (oref, o)) = (lkups, constr)
+    where
+      lkups = Pl.unspentOutputs (M.singleton oref o)
+      constr = Pl.mustSpendPubKeyOutput oref
+  toLedgerConstraint (Mints Nothing pols v) = (lkups, constr)
+    where
+      lkups = foldMap Pl.mintingPolicy pols
+      constr = Pl.mustMintValue v
+  toLedgerConstraint (Mints (Just r) pols v) = (lkups, constr)
+    where
+      lkups = foldMap Pl.mintingPolicy pols
+      constr = Pl.mustMintValueWithRedeemer (Pl.Redeemer (Pl.toBuiltinData r)) v
+  toLedgerConstraint (Before t) = (mempty, constr)
+    where
+      constr = Pl.mustValidateIn (Pl.to t)
+  toLedgerConstraint (After t) = (mempty, constr)
+    where
+      constr = Pl.mustValidateIn (Pl.from t)
+  toLedgerConstraint (ValidateIn r) = (mempty, Pl.mustValidateIn r)
+  toLedgerConstraint (SignedBy hashes) = (mempty, foldMap (Pl.mustBeSignedBy . Pl.PaymentPubKeyHash) hashes)
+
+instance Constraint OutConstraint where
+  extractDatumStr (PaysScript _validator datumsAndValues) =
+    M.fromList
+      . map ((\d -> (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d, show d)) . fst)
+      $ datumsAndValues
+  extractDatumStr (PaysPKWithDatum _pk _stak mdat _v) =
+    maybe M.empty (\d -> M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData d) (show d)) mdat
+
+  toLedgerConstraint (PaysPKWithDatum p stak dat v) = (lkups, constr)
+    where
+      mData = fmap (Pl.Datum . Pl.toBuiltinData) dat
+
+      lkups =
+        maybe mempty Pl.otherData mData
+          -- TODO: do we want to akk ownStakePubKeyHash on 'PaysPKWithDatum'? Would we rather have
+          -- a different 'WithOwnStakePubKeyHash' constraint?
+          <> maybe mempty Pl.ownStakePubKeyHash stak
+      constr = Pl.singleton $ Pl.MustPayToPubKeyAddress (Pl.PaymentPubKeyHash p) stak mData v
+  toLedgerConstraint (PaysScript v outs) = (lkups, constr)
+    where
+      lkups = Pl.otherScript (Pl.validatorScript v)
+      constr = mconcat $
+        flip map outs $ \(d, val) ->
+          Pl.mustPayToOtherScript
+            (Pl.validatorHash $ Pl.validatorScript v)
+            (Pl.Datum $ Pl.toBuiltinData d)
+            val
+
+instance Constraint Constraints where
+  extractDatumStr (miscConstraints :=>: outConstraints) =
+    M.union
+      (M.unions (extractDatumStr <$> miscConstraints))
+      (M.unions (extractDatumStr <$> outConstraints))
+
+  toLedgerConstraint (miscConstraints :=>: outConstraints) =
+    (mconcat lkups, mconcat constrs)
+    where
+      (lkups, constrs) =
+        unzip $
+          (toLedgerConstraint <$> miscConstraints)
+            <> (toLedgerConstraint <$> outConstraints)
+
+-- | Look for the 'Pl.TxOut' corresponding to an output constraint
+-- 'OutConstraint' among the outputs of a transaction.
+findGeneratedTxOutput :: OutConstraint -> [Pl.TxOut] -> Maybe Pl.TxOut
+-- TODO Also check staking credentials
+findGeneratedTxOutput (PaysPKWithDatum targetPkh _mTargetStakePkh mTargetDatum targetVal) =
+  List.find aux
   where
-    (lkups, constrs) = unzip $ map toLedgerConstraint cs
+    aux :: Pl.TxOut -> Bool
+    aux (Pl.TxOut (Pl.Address (Pl.PubKeyCredential pkh) _mStakeCredential) val mDatumHash) =
+      pkh == targetPkh
+        && val == targetVal
+        && mDatumHash == (Pl.datumHash . Pl.Datum . Pl.toBuiltinData <$> mTargetDatum)
+    aux _ = False
+findGeneratedTxOutput (PaysScript targetTypedValidator [(targetTypedDatum, targetVal)]) =
+  List.find aux
+  where
+    aux :: Pl.TxOut -> Bool
+    aux (Pl.TxOut (Pl.Address (Pl.ScriptCredential validatorHash) _) val (Just datumHash)) =
+      validatorHash == Pl.validatorHash (Pl.validatorScript targetTypedValidator)
+        && val == targetVal
+        && datumHash == (Pl.datumHash . Pl.Datum . Pl.toBuiltinData $ targetTypedDatum)
+    aux _ = False
+findGeneratedTxOutput (PaysScript _ _) = const Nothing
+
+-- | Reorders the outputs of a transaction according to the ordered list of
+-- output constraints that generate them. Fails in case of mismatch. The
+-- reordered outputs are put at the beginning of the list.
+orderTxOutputs :: MonadFail m => [OutConstraint] -> [Pl.TxOut] -> m [Pl.TxOut]
+-- TODO Check staking credentials
+orderTxOutputs [] txOuts = return txOuts
+orderTxOutputs (oc : ocs) txOuts =
+  case findGeneratedTxOutput oc txOuts of
+    Nothing ->
+      fail $
+        "Could not locate output corresponding to constraint "
+          <> show (prettyOutConstraint oc)
+    Just txOut -> (txOut :) <$> orderTxOutputs ocs (List.delete txOut txOuts)
 
 -- | @signedByWallets ws == SignedBy $ map walletPKHash ws@
-signedByWallets :: [Wallet] -> Constraint
+signedByWallets :: [Wallet] -> MiscConstraint
 signedByWallets = SignedBy . map walletPKHash

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -120,12 +120,12 @@ instance Constraint Constraints where
 -- | Generate the 'Pl.TxOut' transaction output associated to a given output
 -- constraint 'OutConstraint'.
 outConstraintToTxOut :: OutConstraint -> Pl.TxOut
-outConstraintToTxOut (PaysPKWithDatum pkh mStakePkh mDatum value) =
+outConstraintToTxOut (PaysPKWithDatum pkh _mStakePkh mDatum value) =
   Pl.TxOut
     { Pl.txOutAddress =
         Pl.Address
           (Pl.PubKeyCredential pkh)
-          (Pl.StakingHash . Pl.PubKeyCredential . Pl.unStakePubKeyHash <$> mStakePkh),
+          Nothing,
       Pl.txOutValue = value,
       Pl.txOutDatumHash = Pl.datumHash . Pl.Datum . Pl.toBuiltinData <$> mDatum
     }

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -120,12 +120,12 @@ instance Constraint Constraints where
 -- | Generate the 'Pl.TxOut' transaction output associated to a given output
 -- constraint 'OutConstraint'.
 outConstraintToTxOut :: OutConstraint -> Pl.TxOut
-outConstraintToTxOut (PaysPKWithDatum pkh _mStakePkh mDatum value) =
+outConstraintToTxOut (PaysPKWithDatum pkh mStakePkh mDatum value) =
   Pl.TxOut
     { Pl.txOutAddress =
         Pl.Address
           (Pl.PubKeyCredential pkh)
-          Nothing,
+          (Pl.StakingHash . Pl.PubKeyCredential . Pl.unStakePubKeyHash <$> mStakePkh),
       Pl.txOutValue = value,
       Pl.txOutDatumHash = Pl.datumHash . Pl.Datum . Pl.toBuiltinData <$> mDatum
     }

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -39,8 +39,8 @@ prettyWallet pkh =
     phash = prettyHash pkh
 
 prettyOutConstraint :: OutConstraint -> Doc ann
-prettyOutConstraint (PaysScript val outs) =
-  prettyEnum ("PaysScript" <+> prettyTypedValidator val) "-" (map (uncurry (prettyDatumVal val)) outs)
+prettyOutConstraint (PaysScript val datum value) =
+  prettyEnum ("PaysScript" <+> prettyTypedValidator val) "-" (map (uncurry (prettyDatumVal val)) [(datum, value)])
 prettyOutConstraint (PaysPKWithDatum pkh stak dat val) =
   prettyEnum
     ("PaysPK" <+> prettyWallet pkh)

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -94,7 +94,8 @@ data OutConstraint where
   PaysScript ::
     (Pl.ToData (Pl.DatumType a), Show (Pl.DatumType a), Typeable a) =>
     Pl.TypedValidator a ->
-    [(Pl.DatumType a, Pl.Value)] ->
+    Pl.DatumType a ->
+    Pl.Value ->
     OutConstraint
   -- | Creates a UTxO to a specific 'Pl.PubKeyHash' with a potential 'Pl.StakePubKeyHash'.
   -- and datum. If the stake pk is present, it will call 'Ledger.Constraints.OffChain.ownStakePubKeyHash'

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -57,6 +57,18 @@ type SpendsConstrs a =
 -- Our own first-class constraint types. The advantage over the regular plutus constraint
 -- type is that we get to add whatever we need and we hide away the type variables in existentials.
 
+-- | The main constraints datatype. It combines output constraints
+-- ('OutConstraint') in a specific order that is respected by the generated
+-- transaction, and miscellaneous constraints 'MiscConstraint' including input
+-- constraints, time constraints, or signature requirements.
+data Constraints = [MiscConstraint] :=>: [OutConstraint]
+
+instance Semigroup Constraints where
+  (c1 :=>: oc1) <> (c2 :=>: oc2) = (c1 <> c2) :=>: (oc1 <> oc2)
+
+instance Monoid Constraints where
+  mempty = [] :=>: []
+
 -- | Constraints which do not specify new transaction outputs
 data MiscConstraint where
   SpendsScript ::
@@ -96,15 +108,6 @@ data OutConstraint where
     Maybe a ->
     Pl.Value ->
     OutConstraint
-
--- | Combination of output and misc constraints.
-data Constraints = [MiscConstraint] :=>: [OutConstraint]
-
-instance Semigroup Constraints where
-  (c1 :=>: oc1) <> (c2 :=>: oc2) = (c1 <> c2) :=>: (oc1 <> oc2)
-
-instance Monoid Constraints where
-  mempty = [] :=>: []
 
 -- | This typeclass provides user-friendly convenience to overload the
 -- 'txConstraints' field of 'TxSkel'. For instance, this makes it optional to

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -53,20 +54,36 @@ type SpendsConstrs a =
     Typeable a
   )
 
--- | Our own first-class constraint type. The advantage over the regular plutus constraint
---  type is that we get to add whatever we need and we hide away the type variables in existentials.
-data Constraint where
-  PaysScript ::
-    (Pl.ToData (Pl.DatumType a), Show (Pl.DatumType a), Typeable a) =>
-    Pl.TypedValidator a ->
-    [(Pl.DatumType a, Pl.Value)] ->
-    Constraint
+-- Our own first-class constraint types. The advantage over the regular plutus constraint
+-- type is that we get to add whatever we need and we hide away the type variables in existentials.
+
+-- | Constraints which do not specify new transaction outputs
+data MiscConstraint where
   SpendsScript ::
     (SpendsConstrs a) =>
     Pl.TypedValidator a ->
     Pl.RedeemerType a ->
     (SpendableOut, Pl.DatumType a) ->
-    Constraint
+    MiscConstraint
+  SpendsPK :: SpendableOut -> MiscConstraint
+  Mints ::
+    (Pl.ToData a, Show a) =>
+    Maybe a ->
+    [Pl.MintingPolicy] ->
+    Pl.Value ->
+    MiscConstraint
+  Before :: Pl.POSIXTime -> MiscConstraint
+  After :: Pl.POSIXTime -> MiscConstraint
+  ValidateIn :: Pl.POSIXTimeRange -> MiscConstraint
+  SignedBy :: [Pl.PubKeyHash] -> MiscConstraint
+
+-- | Constraints which specify new transaction outputs
+data OutConstraint where
+  PaysScript ::
+    (Pl.ToData (Pl.DatumType a), Show (Pl.DatumType a), Typeable a) =>
+    Pl.TypedValidator a ->
+    [(Pl.DatumType a, Pl.Value)] ->
+    OutConstraint
   -- | Creates a UTxO to a specific 'Pl.PubKeyHash' with a potential 'Pl.StakePubKeyHash'.
   -- and datum. If the stake pk is present, it will call 'Ledger.Constraints.OffChain.ownStakePubKeyHash'
   -- to update the script lookups, hence, generating a transaction with /two/ 'PaysPKWithDatum' with
@@ -78,23 +95,44 @@ data Constraint where
     Maybe Pl.StakePubKeyHash ->
     Maybe a ->
     Pl.Value ->
-    Constraint
-  SpendsPK :: SpendableOut -> Constraint
-  Mints ::
-    (Pl.ToData a, Show a) =>
-    Maybe a ->
-    [Pl.MintingPolicy] ->
-    Pl.Value ->
-    Constraint
-  Before :: Pl.POSIXTime -> Constraint
-  After :: Pl.POSIXTime -> Constraint
-  ValidateIn :: Pl.POSIXTimeRange -> Constraint
-  SignedBy :: [Pl.PubKeyHash] -> Constraint
+    OutConstraint
 
-paysPK :: Pl.PubKeyHash -> Pl.Value -> Constraint
+-- | Combination of output and misc constraints.
+data Constraints = [MiscConstraint] :=>: [OutConstraint]
+
+instance Semigroup Constraints where
+  (c1 :=>: oc1) <> (c2 :=>: oc2) = (c1 <> c2) :=>: (oc1 <> oc2)
+
+instance Monoid Constraints where
+  mempty = [] :=>: []
+
+-- | This typeclass provides user-friendly convenience to overload the
+-- 'txConstraints' field of 'TxSkel'. For instance, this makes it optional to
+-- use the '(:=>:)' operator when using only misc or output constraints (much
+-- like the legacy behavior).
+-- It also opens up future alternative of constraint specification.
+class ConstraintsSpec a where
+  toConstraints :: a -> Constraints
+
+instance ConstraintsSpec Constraints where
+  toConstraints = id
+
+instance ConstraintsSpec [MiscConstraint] where
+  toConstraints = (:=>: [])
+
+instance ConstraintsSpec MiscConstraint where
+  toConstraints = toConstraints . (: [])
+
+instance ConstraintsSpec [OutConstraint] where
+  toConstraints = ([] :=>:)
+
+instance ConstraintsSpec OutConstraint where
+  toConstraints = toConstraints . (: [])
+
+paysPK :: Pl.PubKeyHash -> Pl.Value -> OutConstraint
 paysPK pkh = PaysPKWithDatum @() pkh Nothing Nothing
 
-mints :: [Pl.MintingPolicy] -> Pl.Value -> Constraint
+mints :: [Pl.MintingPolicy] -> Pl.Value -> MiscConstraint
 mints = Mints @() Nothing
 
 -- | A Transaction skeleton is a set of our constraints,
@@ -111,24 +149,24 @@ mints = Mints @() Nothing
 -- A TxSkel does /NOT/ include a Wallet since wallets only exist in mock mode.
 data TxSkel where
   TxSkel ::
-    (Show x) =>
+    (Show x, ConstraintsSpec constraints) =>
     { txLabel :: Maybe x,
       -- | Set of options to use when generating this transaction.
       txOpts :: TxOpts,
-      txConstraints :: [Constraint]
+      txConstraints :: constraints
     } ->
     TxSkel
 
 -- | Constructs a skeleton without a default label and with default 'TxOpts'
-txSkel :: [Constraint] -> TxSkel
+txSkel :: ConstraintsSpec constraints => constraints -> TxSkel
 txSkel = txSkelOpts def
 
 -- | Constructs a skeleton without a default label, but with custom options
-txSkelOpts :: TxOpts -> [Constraint] -> TxSkel
+txSkelOpts :: ConstraintsSpec constraints => TxOpts -> constraints -> TxSkel
 txSkelOpts = TxSkel @() Nothing
 
 -- | Constructs a skeleton with a label
-txSkelLbl :: (Show x) => x -> [Constraint] -> TxSkel
+txSkelLbl :: (Show x, ConstraintsSpec constraints) => x -> constraints -> TxSkel
 txSkelLbl x = TxSkel (Just x) def
 
 -- | Set of options to modify the behavior of generating and validating some transaction. Some of these
@@ -156,6 +194,11 @@ data TxOpts = TxOpts
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     --  By default, this is set to @True@.
     autoSlotIncrease :: Bool,
+    -- | Reorders the transaction outputs to fit the ordering of output
+    -- constraints. Those outputs are put at the very beginning of the list.
+    -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
+    --  By default, this is set to @True@.
+    forceOutputOrdering :: Bool,
     -- | Applies an arbitrary modification to a transaction after it has been pottentially adjusted ('adjustUnbalTx')
     -- and balanced. This is prefixed with /unsafe/ to draw attention that modifying a transaction at
     -- that stage might make it invalid. Still, this offers a hook for being able to alter a transaction
@@ -198,6 +241,7 @@ instance Default TxOpts where
       { adjustUnbalTx = False,
         awaitTxConfirmed = True,
         autoSlotIncrease = True,
+        forceOutputOrdering = True,
         unsafeModTx = Id,
         balance = True
       }

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -72,9 +72,11 @@ spec = do
                 (f $ g $ Pl.lovelaceValueOf 4_200_000)
             ]
         -- Function to modify some specific skeletons
-        app f (TxSkel l opts [PaysPKWithDatum pk stak dat val]) =
-          Just $ TxSkel l opts [PaysPKWithDatum pk stak dat (f val)]
-        app f _ = Nothing
+        app f (TxSkel l opts constraintsSpec) =
+          case toConstraints constraintsSpec of
+            [] :=>: [PaysPKWithDatum pk stak dat val] ->
+              Just $ TxSkel l opts [PaysPKWithDatum pk stak dat (f val)]
+            _ -> Nothing
         -- Two transformations
         f x = Pl.lovelaceValueOf 3_000_000
         g x = Pl.lovelaceValueOf (2 * Pl.getLovelace (Pl.fromValue x))

--- a/cooked-validators/tests/Cooked/OutputReorderingSpec.hs
+++ b/cooked-validators/tests/Cooked/OutputReorderingSpec.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cooked.OutputReorderingSpec (spec) where
+
+import Cooked.MockChain
+import Cooked.Tx.Constraints
+import Data.Default
+import Data.Either.Combinators (rightToMaybe)
+import qualified Ledger as Pl
+import qualified Ledger.Ada as Pl
+import qualified Ledger.Credential as Pl
+import Test.Hspec
+
+spec :: SpecWith ()
+spec = do
+  describe "outputs follow the order of the 'paysPK' constraints" $ do
+    it "ordering two outputs" $
+      genTx (skel (wallet 2) (wallet 3))
+        `shouldSatisfy` maybe False (firstRecipientsAre (wallet 2) (wallet 3))
+    it "reversing the ordering of two outputs" $
+      genTx (skel (wallet 3) (wallet 2))
+        `shouldNotSatisfy` maybe False (firstRecipientsAre (wallet 2) (wallet 3))
+
+-- | Generates the transaction corresponding to a 'TxSkel' under the default
+-- distribution
+genTx :: TxSkel -> Maybe Pl.Tx
+genTx = fmap fst . rightToMaybe . runMockChain . generateTx'
+
+-- | Pays 1_000 lovelace to 2 given wallets in a transaction that forces
+-- the ordering of the outputs
+skel :: Wallet -> Wallet -> TxSkel
+skel w1 w2 =
+  TxSkel
+    { txLabel = Nothing @(),
+      txOpts = def {forceOutputOrdering = True},
+      txConstraints =
+        [ paysPK (walletPKHash w1) (Pl.lovelaceValueOf 1_000),
+          paysPK (walletPKHash w2) (Pl.lovelaceValueOf 1_000)
+        ]
+    }
+
+-- | Checks that the first two outputs in a transaction are payments to the two
+-- given wallets
+firstRecipientsAre :: Wallet -> Wallet -> Pl.Tx -> Bool
+firstRecipientsAre w1 w2 tx =
+  case Pl.txOutputs tx of
+    (Pl.TxOut (Pl.Address (Pl.PubKeyCredential pkh1) _) _ _)
+      : (Pl.TxOut (Pl.Address (Pl.PubKeyCredential pkh2) _) _ _)
+      : _ -> walletPKHash w1 == pkh1 && walletPKHash w2 == pkh2
+    _ -> False

--- a/cooked-validators/tests/Spec.hs
+++ b/cooked-validators/tests/Spec.hs
@@ -2,6 +2,7 @@ import qualified Cooked.BalanceSpec as Ba
 import qualified Cooked.MockChain.Monad.StagedSpec as StagedSpec
 import qualified Cooked.MockChain.UtxoStateSpec as UtxoStateSpec
 import qualified Cooked.MockChain.WalletSpec as WalletSpec
+import qualified Cooked.OutputReorderingSpec as OutputReorderingSpec
 import qualified Cooked.QuickValueSpec as QuickValueSpec
 import Test.Hspec
 
@@ -10,6 +11,7 @@ main = hspec spec
 
 spec :: Spec
 spec = do
+  describe "Reordering outputs" OutputReorderingSpec.spec
   describe "Balancing transactions" Ba.spec
   describe "Quick values" QuickValueSpec.spec
   describe "Staged monad" StagedSpec.spec

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -59,10 +59,11 @@ txUnlock script = do
   void $
     validateTxConstrLbl
       TxUnlock
-      [ SpendsScript script () (output, datum),
-        paysPK r1 (Pl.lovelaceValueOf share1),
-        paysPK r2 (Pl.lovelaceValueOf share2)
-      ]
+      ( [SpendsScript script () (output, datum)]
+          :=>: [ paysPK r1 (Pl.lovelaceValueOf share1),
+                 paysPK r2 (Pl.lovelaceValueOf share2)
+               ]
+      )
 
 -- | Label for 'txUnlock' skeleton
 data TxUnlock = TxUnlock deriving (Show)

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -33,10 +33,8 @@ txLock script datum =
       (TxLock datum)
       [ PaysScript
           script
-          [ ( datum,
-              Pl.lovelaceValueOf $ Split.amount datum
-            )
-          ]
+          datum
+          (Pl.lovelaceValueOf (Split.amount datum))
       ]
 
 -- | Label for 'txLock' skeleton, making it immediately recognizable

--- a/examples/tests/ForgeSpec.hs
+++ b/examples/tests/ForgeSpec.hs
@@ -40,7 +40,7 @@ initBigBoss = do
     validateTxConstrLbl
       InitBigBoss
       ( [mints [bigBossPolicy bbId] oneBBNFT]
-          :=>: [PaysScript (bigBossVal bbId) [(BigBoss [], oneBBNFT <> minAda)]]
+          :=>: [PaysScript (bigBossVal bbId) (BigBoss []) (oneBBNFT <> minAda)]
       )
   return bbId
 
@@ -59,8 +59,8 @@ openForge bbId = do
       ( [ SpendsScript (bigBossVal bbId) Open (outBB, datBB),
           mints [authTokenPolicy bbId] oneAuthToken
         ]
-          :=>: [ PaysScript (bigBossVal bbId) [(BigBoss [wPKH], oneBBNFT <> minAda)],
-                 PaysScript (smithVal bbId) [(Forge wPKH 0, oneAuthToken <> minAda)]
+          :=>: [ PaysScript (bigBossVal bbId) (BigBoss [wPKH]) (oneBBNFT <> minAda),
+                 PaysScript (smithVal bbId) (Forge wPKH 0) (oneAuthToken <> minAda)
                ]
       )
 
@@ -78,7 +78,7 @@ smiths bbId val = do
       ( [ SpendsScript (smithVal bbId) Adjust (outSmith, datSmith),
           mints [smithingPolicy bbId] (Value.assetClassValue (smithed bbId) val)
         ]
-          :=>: [ PaysScript (smithVal bbId) [(Forge owner (forged + val), sOutValue outSmith)],
+          :=>: [ PaysScript (smithVal bbId) (Forge owner (forged + val)) (sOutValue outSmith),
                  paysPK pkh (Value.assetClassValue (smithed bbId) val <> minAda)
                ]
       )

--- a/examples/tests/ForgeSpec.hs
+++ b/examples/tests/ForgeSpec.hs
@@ -39,9 +39,9 @@ initBigBoss = do
   void $
     validateTxConstrLbl
       InitBigBoss
-      [ mints [bigBossPolicy bbId] oneBBNFT,
-        PaysScript (bigBossVal bbId) [(BigBoss [], oneBBNFT <> minAda)]
-      ]
+      ( [mints [bigBossPolicy bbId] oneBBNFT]
+          :=>: [PaysScript (bigBossVal bbId) [(BigBoss [], oneBBNFT <> minAda)]]
+      )
   return bbId
 
 data InitBigBoss = InitBigBoss deriving (Show)
@@ -56,11 +56,13 @@ openForge bbId = do
   void $
     validateTxConstrLbl
       OpenForge
-      [ SpendsScript (bigBossVal bbId) Open (outBB, datBB),
-        mints [authTokenPolicy bbId] oneAuthToken,
-        PaysScript (bigBossVal bbId) [(BigBoss [wPKH], oneBBNFT <> minAda)],
-        PaysScript (smithVal bbId) [(Forge wPKH 0, oneAuthToken <> minAda)]
-      ]
+      ( [ SpendsScript (bigBossVal bbId) Open (outBB, datBB),
+          mints [authTokenPolicy bbId] oneAuthToken
+        ]
+          :=>: [ PaysScript (bigBossVal bbId) [(BigBoss [wPKH], oneBBNFT <> minAda)],
+                 PaysScript (smithVal bbId) [(Forge wPKH 0, oneAuthToken <> minAda)]
+               ]
+      )
 
 data OpenForge = OpenForge deriving (Show)
 
@@ -73,11 +75,13 @@ smiths bbId val = do
   void $
     validateTxConstrLbl
       (Smiths val)
-      [ SpendsScript (smithVal bbId) Adjust (outSmith, datSmith),
-        mints [smithingPolicy bbId] (Value.assetClassValue (smithed bbId) val),
-        PaysScript (smithVal bbId) [(Forge owner (forged + val), sOutValue outSmith)],
-        paysPK pkh (Value.assetClassValue (smithed bbId) val <> minAda)
-      ]
+      ( [ SpendsScript (smithVal bbId) Adjust (outSmith, datSmith),
+          mints [smithingPolicy bbId] (Value.assetClassValue (smithed bbId) val)
+        ]
+          :=>: [ PaysScript (smithVal bbId) [(Forge owner (forged + val), sOutValue outSmith)],
+                 paysPK pkh (Value.assetClassValue (smithed bbId) val <> minAda)
+               ]
+      )
   where
     belongsTo (Forge owner _) pkh = owner == pkh
 

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -90,10 +90,8 @@ mkProposal reqSigs pmt = do
                      -- we're working on.
                      PaysScript
                        (pmultisig params)
-                       [ ( Accumulator pmt [],
-                           minAda <> paymentValue pmt <> threadToken
-                         )
-                       ]
+                       (Accumulator pmt [])
+                       (minAda <> paymentValue pmt <> threadToken)
                    ]
           )
       pure (params, fst spendableOut)
@@ -112,7 +110,7 @@ mkSign params pmt sk = do
   void $
     validateTxConstrOpts
       (def {adjustUnbalTx = True})
-      [PaysScript (pmultisig params) [(Sign pkh sig, mkSignLockedCost)]]
+      [PaysScript (pmultisig params) (Sign pkh sig) mkSignLockedCost]
   where
     sig = Pl.sign (Pl.sha2_256 $ packPayment pmt) sk ""
 
@@ -138,10 +136,8 @@ mkCollect thePayment params = signs (wallet 1) $ do
       )
         :=>: [ PaysScript
                  (pmultisig params)
-                 [ ( Accumulator thePayment (signPk . snd <$> signatures),
-                     paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues
-                   )
-                 ]
+                 (Accumulator thePayment (signPk . snd <$> signatures))
+                 (paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues)
              ]
 
 mkPay :: MonadMockChain m => Payment -> Params -> Pl.TxOutRef -> m ()
@@ -347,8 +343,6 @@ mkFakeCollect thePayment params = do
       )
         :=>: [ PaysScript
                  fakeValidator
-                 [ ( HJ.Accumulator (trPayment thePayment) (signPk . snd <$> signatures),
-                     paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues
-                   )
-                 ]
+                 (HJ.Accumulator (trPayment thePayment) (signPk . snd <$> signatures))
+                 (paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues)
              ]

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -83,17 +83,19 @@ mkProposal reqSigs pmt = do
       _ <-
         validateTxConstrLbl
           (ProposalSkel reqSigs pmt)
-          [ mints [threadTokenPolicy (fst spendableOut) threadTokenName] threadToken,
-            -- We don't have SpendsPK or PaysPK wrt the wallet `w`
-            -- because the balancing mechanism chooses the same (first) output
-            -- we're working on.
-            PaysScript
-              (pmultisig params)
-              [ ( Accumulator pmt [],
-                  minAda <> paymentValue pmt <> threadToken
-                )
-              ]
-          ]
+          ( [mints [threadTokenPolicy (fst spendableOut) threadTokenName] threadToken]
+              :=>: [
+                     -- We don't have SpendsPK or PaysPK wrt the wallet `w`
+                     -- because the balancing mechanism chooses the same (first) output
+                     -- we're working on.
+                     PaysScript
+                       (pmultisig params)
+                       [ ( Accumulator pmt [],
+                           minAda <> paymentValue pmt <> threadToken
+                         )
+                       ]
+                   ]
+          )
       pure (params, fst spendableOut)
     _ -> error "No spendable outputs for the wallet"
 
@@ -131,26 +133,28 @@ mkCollect thePayment params = signs (wallet 1) $ do
   let signatureValues = mconcat $ map (sOutValue . fst) signatures
   void $
     validateTxConstr $
-      PaysScript
-        (pmultisig params)
-        [ ( Accumulator thePayment (signPk . snd <$> signatures),
-            paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues
-          )
-        ] :
-      SpendsScript (pmultisig params) () initialProp :
-      (SpendsScript (pmultisig params) () <$> signatures)
+      ( SpendsScript (pmultisig params) () initialProp :
+        (SpendsScript (pmultisig params) () <$> signatures)
+      )
+        :=>: [ PaysScript
+                 (pmultisig params)
+                 [ ( Accumulator thePayment (signPk . snd <$> signatures),
+                     paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues
+                   )
+                 ]
+             ]
 
 mkPay :: MonadMockChain m => Payment -> Params -> Pl.TxOutRef -> m ()
 mkPay thePayment params tokenOutRef = signs (wallet 1) $ do
   [accumulated] <- scriptUtxosSuchThat (pmultisig params) isAccumulator
   void $
-    validateTxConstr
+    validateTxConstr $
       -- We payout all the gathered funds to the receiver of the payment, including the minimum ada
       -- locked in all the sign UTxOs, which was accumulated in the Accumulate datum.
-      [ paysPK (paymentRecipient thePayment) (sOutValue (fst accumulated) <> Pl.negate (paramsToken params)),
-        SpendsScript (pmultisig params) () accumulated,
+      [ SpendsScript (pmultisig params) () accumulated,
         mints [threadTokenPolicy tokenOutRef threadTokenName] $ Pl.negate $ paramsToken params
       ]
+        :=>: [paysPK (paymentRecipient thePayment) (sOutValue (fst accumulated) <> Pl.negate (paramsToken params))]
 
 -- *** Auxiliary Functions
 
@@ -286,14 +290,15 @@ execute tParms (parms, tokenRef) = do
 -- Modifies a transaction skeleton by attempting to mint one more provenance token.
 dupTokenAttack :: SpendableOut -> (Params, Pl.TxOutRef) -> TxSkel -> Maybe TxSkel
 dupTokenAttack sOut (parms, tokenRef) (TxSkel l opts cs) =
-  Just $ TxSkel (Just $ DupTokenAttacked l) opts (cs ++ attack)
+  Just $ TxSkel (Just $ DupTokenAttacked l) opts (toConstraints cs <> attack)
   where
     attack =
       [ mints [threadTokenPolicy tokenRef threadTokenName] (paramsToken parms),
         SpendsPK sOut,
-        signedByWallets [wallet 9],
-        paysPK (walletPKHash $ wallet 9) (paramsToken parms <> sOutValue sOut)
+        signedByWallets [wallet 9]
       ]
+        :=>: [ paysPK (walletPKHash $ wallet 9) (paramsToken parms <> sOutValue sOut)
+             ]
 
 data DupTokenAttacked where
   DupTokenAttacked :: (Show x) => Maybe x -> DupTokenAttacked
@@ -337,11 +342,13 @@ mkFakeCollect thePayment params = do
   let signatureValues = mconcat $ map (sOutValue . fst) signatures
   void $
     validateTxConstr $
-      PaysScript
-        fakeValidator
-        [ ( HJ.Accumulator (trPayment thePayment) (signPk . snd <$> signatures),
-            paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues
-          )
-        ] :
-      SpendsScript (pmultisig params) () initialProp :
-      (SpendsScript (pmultisig params) () <$> signatures)
+      ( SpendsScript (pmultisig params) () initialProp :
+        (SpendsScript (pmultisig params) () <$> signatures)
+      )
+        :=>: [ PaysScript
+                 fakeValidator
+                 [ ( HJ.Accumulator (trPayment thePayment) (signPk . snd <$> signatures),
+                     paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues
+                   )
+                 ]
+             ]

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -44,10 +44,8 @@ txUnlock' mRecipient1 mRecipient2 mAmountChanger issuer = do
       remainderConstraint =
         PaysScript
           Split.splitValidator
-          [ ( Split.SplitDatum r1 r2 remainder,
-              Pl.lovelaceValueOf remainder
-            )
-          ]
+          (Split.SplitDatum r1 r2 remainder)
+          (Pl.lovelaceValueOf remainder)
   void $
     validateTxConstrLbl
       (TxUnlock' mRecipient1 mRecipient2 (fmap ($ 100) mAmountChanger))

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -36,10 +36,10 @@ txUnlock' mRecipient1 mRecipient2 mAmountChanger issuer = do
       share1 = fromMaybe id mAmountChanger half
       share2 = fromMaybe id mAmountChanger (amount - half)
       constraints =
-        [ SpendsScript Split.splitValidator () (output, datum),
-          paysPK (maybe r1 walletPKHash mRecipient1) (Pl.lovelaceValueOf share1),
-          paysPK (maybe r2 walletPKHash mRecipient2) (Pl.lovelaceValueOf share2)
-        ]
+        [SpendsScript Split.splitValidator () (output, datum)]
+          :=>: [ paysPK (maybe r1 walletPKHash mRecipient1) (Pl.lovelaceValueOf share1),
+                 paysPK (maybe r2 walletPKHash mRecipient2) (Pl.lovelaceValueOf share2)
+               ]
       remainder = amount - share1 - share2
       remainderConstraint =
         PaysScript
@@ -51,7 +51,7 @@ txUnlock' mRecipient1 mRecipient2 mAmountChanger issuer = do
   void $
     validateTxConstrLbl
       (TxUnlock' mRecipient1 mRecipient2 (fmap ($ 100) mAmountChanger))
-      (constraints <> [remainderConstraint | remainder > 0])
+      (constraints <> toConstraints [remainderConstraint | remainder > 0])
       `as` issuer
 
 data TxUnlock' = TxUnlock' (Maybe Wallet) (Maybe Wallet) (Maybe Integer) deriving (Show)
@@ -72,11 +72,12 @@ txUnlockAttack issuer = do
       half2 = Pl.lovelaceValueOf (amount2 `div` 2)
       constraints =
         [ SpendsScript Split.splitValidator () (output1, datum1),
-          SpendsScript Split.splitValidator () (output2, datum2),
-          paysPK r11 half1,
-          paysPK r12 (if amount1 > amount2 then half1 else half2),
-          paysPK r21 half2
+          SpendsScript Split.splitValidator () (output2, datum2)
         ]
+          :=>: [ paysPK r11 half1,
+                 paysPK r12 (if amount1 > amount2 then half1 else half2),
+                 paysPK r21 half2
+               ]
   void $ validateTxConstrLbl TxUnlockAttack constraints `as` issuer
 
 data TxUnlockAttack = TxUnlockAttack deriving (Show)

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -84,10 +84,8 @@ retrieveFunds t c owner = do
     signs owner $
       validateTxConstrOpts
         (def {autoSlotIncrease = False})
-        ( map (SpendsScript (typedValidator c) Collect) funds
-            ++ [ paysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds),
-                 ValidateIn $ collectionRange c
-               ]
+        ( (ValidateIn (collectionRange c) : map (SpendsScript (typedValidator c) Collect) funds)
+            :=>: [paysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds)]
         )
 
 -- * Tests

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -74,7 +74,7 @@ paysCampaign c w val =
     signs w $
       validateTxConstrOpts
         (def {autoSlotIncrease = False})
-        [PaysScript (typedValidator c) [(Ledger.PaymentPubKeyHash $ walletPKHash w, val)]]
+        [PaysScript (typedValidator c) (Ledger.PaymentPubKeyHash (walletPKHash w)) val]
 
 -- | Retrieve funds as being the owner
 retrieveFunds :: (MonadMockChain m) => Ledger.POSIXTime -> Campaign -> Wallet -> m ()


### PR DESCRIPTION
This is a new take on the feature that is more conservative of existing codebase and usage than #85
Instead of generating all the tx ourselves, we still delegate it to Plutus and reorder the outputs right after the `UnbalancedTx` generation, before adjustment (adding `minAda` everywhere) and balancing that we assume 
1. do not mess up the ordering
2. only append additional outputs at the end of the list of outputs

### Changes

- new `forceOutputOrdering` option in `TxOpts`. By default `True` (mostly to ensure all the existing tests still pass but may be wiser to disable by default before merging)
- slightly modified way to specify constraints in a `TxSkel`. Nothing changes if we only have payments, or only have non payments. If we mix the two, we split it in two lists with the `:=>:` operator.
- simplification of `PaysScript`: now takes one datum and value instead of a list

### Remaining work

This is just remaining details. Not challenges.

- [ ] test cases involving `PaysScript`
- [x] take staking into account when looking for outputs to reorder
- [ ] default to disabling the feature?