### PR TITLE
Solve #95

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -223,7 +223,7 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
 
   currentSlot = gets mcstCurrentSlot
 
-  currentTime = asks (Pl.slotToBeginPOSIXTime . mceSlotConfig) <*> gets mcstCurrentSlot
+  currentTime = asks (Pl.slotToEndPOSIXTime . mceSlotConfig) <*> gets mcstCurrentSlot
 
   awaitSlot s = modify' (\st -> st {mcstCurrentSlot = max s (mcstCurrentSlot st)}) >> currentSlot
 


### PR DESCRIPTION
To conform the specification of  https://playground.plutus.iohkdev.io/doc/haddock/plutus-contract/html/Plutus-Contract-Request.html#v:currentTime "Get the latest time of the current slot."