### PR TITLE
Apply balance tx patch

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -31,8 +31,8 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
   utxosSuchThat addr datumPred = do
     allUtxos <- M.toList <$> C.utxosAt addr
     maybeUtxosWithDatums <- forM allUtxos $ \utxo -> do
-      let (Pl.TxOut _ val datumHash) = Pl.toTxOut $ snd utxo
-      datum <- maybe (pure Nothing) C.datumFromHash datumHash
+      let (Pl.TxOut _ val _) = Pl.toTxOut $ snd utxo
+      datum <- datumFromTxOut $ snd utxo
       let typedDatum = datum >>= Pl.fromBuiltinData . Pl.getDatum
       pure $
         if datumPred typedDatum val
@@ -48,3 +48,11 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
   currentTime = C.currentTime
   awaitSlot = C.awaitSlot
   awaitTime = C.awaitTime
+
+
+datumFromTxOut :: ( C.AsContractError e ) => Pl.ChainIndexTxOut -> C.Contract w s e (Maybe Pl.Datum)
+datumFromTxOut (Pl.PublicKeyChainIndexTxOut { }) = pure Nothing
+datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Right d) _) = pure $ Just d
+-- datum is always present in the nominal case, guaranteed by chain-index
+datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) = C.datumFromHash dh
+

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -334,7 +334,7 @@ generateTx' skel@(TxSkel _ _ constraintsSpec) = do
               then applyTxOutConstraintOrder outputConstraints ubtx
               else ubtx
       signers <- askSigners
-      balancedTx <- balanceTxFrom (adjustOutputPolicy opts) (not $ balance opts) (NE.head signers) (adjust reorderedUbtx)
+      balancedTx <- balanceTxFrom (balanceOutputPolicy opts) (not $ balance opts) (NE.head signers) (adjust reorderedUbtx)
       return $
         foldl
           (flip txAddSignature)
@@ -367,7 +367,7 @@ setFeeAndValidRange (Pl.UnbalancedTx tx0 _reqSigs _uindex slotRange) = do
   return
     tx {Pl.txValidRange = Pl.posixTimeRangeToContainedSlotRange config slotRange}
 
-balanceTxFrom :: (Monad m) => AdjustOutputPolicy -> Bool -> Wallet -> Pl.UnbalancedTx -> MockChainT m Pl.Tx
+balanceTxFrom :: (Monad m) => BalanceOutputPolicy -> Bool -> Wallet -> Pl.UnbalancedTx -> MockChainT m Pl.Tx
 balanceTxFrom utxoPolicy skipBalancing w ubtx = do
   tx <- setFeeAndValidRange ubtx
   if skipBalancing
@@ -418,15 +418,18 @@ calcBalanceTx w tx = do
 -- with "LessThanMinAdaPerUTxO" error. Instead, we need to consume yet another UTxO belonging to @w@ to
 -- then create the output with the proper leftover. If @w@ has no UTxO, then there's no
 -- way to balance this transaction.
-applyBalanceTx :: AdjustOutputPolicy -> Wallet -> BalanceTxRes -> Pl.Tx -> Maybe Pl.Tx
+applyBalanceTx :: BalanceOutputPolicy -> Wallet -> BalanceTxRes -> Pl.Tx -> Maybe Pl.Tx
 applyBalanceTx utxoPolicy w (BalanceTxRes newTxIns leftover remainders) tx = do
   -- Here we'll try a few things, in order, until one of them succeeds:
-  --   1. pick out the best possible output to adjust and adjust it as long as it remains with
-  --      more than 'Pl.minAdaTxOut'. No need for additional inputs.
+  --   1. If allowed by the utxoPolicy, pick out the best possible output to adjust and adjust it as long as it remains with
+  --      more than 'Pl.minAdaTxOut'. No need for additional inputs. The "best possible" here means the ada-only
+  --      utxo with the most ada and without any datum hash. If the policy doesn't allow modifying an
+  --      existing utxo or no such utxo exists, we move on to the next option;
   --   2. if the leftover is more than 'Pl.minAdaTxOut' and (1) wasn't possible, create a new output
   --      to return leftover. No need for additional inputs.
   --   3. Attempt to consume other possible utxos from 'w' in order to combine them
   --      and return the leftover.
+
   let adjustOutputs = case utxoPolicy of
         DontAdjustExistingOutput -> empty
         AdjustExistingOutput -> wOutsBest >>= fmap ([],) . adjustOutputValueAt (<> leftover) (Pl.txOutputs tx)

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -113,7 +113,8 @@ prettyOpts opts = case mapMaybe cmpAgainstDefAndPrint fields of
         Field "awaitTxConfirmed" awaitTxConfirmed,
         Field "autoSlotIncrease" autoSlotIncrease,
         Field "unsafeModTx" unsafeModTx,
-        Field "balance" balance
+        Field "balance" balance,
+        Field "balanceOutputPolicy" balanceOutputPolicy
       ]
 
 data Field record where

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -216,11 +216,11 @@ data TxOpts = TxOpts
     -- By default, this is set to @True@.
     balance :: Bool,
 
-    -- | The 'AdjustOutputPolicy' to apply when balancing the transaction.
+    -- | The 'BalanceOutputPolicy' to apply when balancing the transaction.
     --
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     -- By default, this is set to @AdjustExistingOutput@.
-    adjustOutputPolicy :: AdjustOutputPolicy
+    balanceOutputPolicy :: BalanceOutputPolicy
 
   }
   deriving (Eq, Show)
@@ -229,7 +229,7 @@ data TxOpts = TxOpts
 {-| Whether to adjust existing public key outputs during
 transaction balancing.
 -}
-data AdjustOutputPolicy
+data BalanceOutputPolicy
   = AdjustExistingOutput
   -- ^ Try to adjust an existing public key output with the change. If no
   --   suitable output can be found, create a new change output.
@@ -268,5 +268,5 @@ instance Default TxOpts where
         forceOutputOrdering = True,
         unsafeModTx = Id,
         balance = True,
-        adjustOutputPolicy = AdjustExistingOutput
+        balanceOutputPolicy = AdjustExistingOutput
       }

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -214,9 +214,30 @@ data TxOpts = TxOpts
     --
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     -- By default, this is set to @True@.
-    balance :: Bool
+    balance :: Bool,
+
+    -- | The 'AdjustOutputPolicy' to apply when balancing the transaction.
+    --
+    -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
+    -- By default, this is set to @AdjustExistingOutput@.
+    adjustOutputPolicy :: AdjustOutputPolicy
+
   }
   deriving (Eq, Show)
+
+
+{-| Whether to adjust existing public key outputs during
+transaction balancing.
+-}
+data AdjustOutputPolicy
+  = AdjustExistingOutput
+  -- ^ Try to adjust an existing public key output with the change. If no
+  --   suitable output can be found, create a new change output.
+  | DontAdjustExistingOutput
+  -- ^ Do not change the existing outputs, always create a new change
+  --   output.
+  deriving (Eq, Ord, Show)
+
 
 -- IMPORTANT INTERNAL: If you add or remove fields from 'TxOpts', make sure
 -- to update the internal @fields@ value from 'Cooked.Tx.Constraints.Pretty'
@@ -246,5 +267,6 @@ instance Default TxOpts where
         autoSlotIncrease = True,
         forceOutputOrdering = True,
         unsafeModTx = Id,
-        balance = True
+        balance = True,
+        adjustOutputPolicy = AdjustExistingOutput
       }


### PR DESCRIPTION
The modification introduces in this patch are the following:

-  Adjusting `utxosSuchThat` in `Cooked.MockChain.Monad.Contract `to avoid an additional query on the plutus-chain-index when the datum is already present in `ChainIndexTxOut`. Note that the plutus-chain-index now ensures that the datum is properly supplied when a correspondence for the datum hash exists in the witness map.

- Introduction of option `AdjustOutputPolicy` in `TxOpts` to offer the possibility of not adjusting any existing outputs and to always create a new change output.
- Adjust applyBalanceTx in `Cooked.MockChain.Monad.Direct` to only adjust an existing public key output with the change when:
    - the output only contains ada tokens
    - no datum hash is specified in the output
