### PR TITLE
Drop HUnit and HSpec dependencies

### DIFF
--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -38,8 +38,7 @@ library
       src
   ghc-options: -Wall -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas -fplugin-opt PlutusTx.Plugin:defer-errors
   build-depends:
-      HUnit
-    , QuickCheck
+      QuickCheck
     , aeson
     , base >=4.9 && <5
     , bytestring
@@ -71,6 +70,8 @@ library
     , scientific
     , streaming
     , tasty
+    , tasty-hunit
+    , tasty-quickcheck
     , text
     , transformers
   default-language: Haskell2010
@@ -89,8 +90,7 @@ test-suite spec
   hs-source-dirs:
       tests/
   build-depends:
-      HUnit
-    , QuickCheck
+      QuickCheck
     , aeson
     , base >=4.9 && <5
     , bytestring
@@ -106,7 +106,6 @@ test-suite spec
     , foldl
     , freer-extras
     , freer-simple
-    , hspec
     , lens
     , memory
     , monad-control
@@ -124,6 +123,8 @@ test-suite spec
     , scientific
     , streaming
     , tasty
+    , tasty-hunit
+    , tasty-quickcheck
     , text
     , transformers
   default-language: Haskell2010

--- a/cooked-validators/package.yaml
+++ b/cooked-validators/package.yaml
@@ -33,10 +33,11 @@ dependencies:
   - prettyprinter
   - scientific
   - streaming
-  - tasty
   - text
   - transformers
-  - HUnit
+  - tasty
+  - tasty-hunit
+  - tasty-quickcheck
   - QuickCheck
   - cardano-api
   - cardano-crypto
@@ -59,4 +60,3 @@ tests:
       - tests/
     dependencies:
       - cooked-validators
-      - hspec

--- a/cooked-validators/src/Cooked/MockChain/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Testing.hs
@@ -14,7 +14,6 @@ import Cooked.MockChain.Wallet
 import Data.Default
 import Debug.Trace
 import Ledger.Index (ValidationError (ScriptFailure))
-import System.IO.Unsafe (unsafePerformIO)
 import qualified Test.QuickCheck as QC
 import qualified Test.Tasty.HUnit as HU
 

--- a/cooked-validators/src/Cooked/MockChain/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Testing.hs
@@ -15,8 +15,8 @@ import Data.Default
 import Debug.Trace
 import Ledger.Index (ValidationError (ScriptFailure))
 import System.IO.Unsafe (unsafePerformIO)
-import qualified Test.HUnit.Lang as HU
 import qualified Test.QuickCheck as QC
+import qualified Test.Tasty.HUnit as HU
 
 -- | This module provides a common interface for HUnit and QuickCheck tests.
 -- We do so by abstracting uses of 'HU.Assertion' and 'QC.Property' for @(IsProp prop) => prop@,
@@ -226,16 +226,11 @@ instance IsProp HU.Assertion where
   testCounterexample msg = maybe testSuccess (E.throw . adjustMsg) <=< assertionToMaybe
     where
       joinMsg :: String -> String
-      joinMsg rest = msg ++ "; " ++ rest
+      joinMsg rest = msg ++ ";\n" ++ rest
 
       adjustMsg :: HU.HUnitFailure -> HU.HUnitFailure
-      adjustMsg (HU.HUnitFailure loc (HU.Reason txt)) =
-        unsafePerformIO $ do
-          putStrLn ('\n' : msg)
-          putStrLn txt
-          return $ HU.HUnitFailure loc (HU.Reason "")
-      adjustMsg (HU.HUnitFailure loc (HU.ExpectedButGot pref x y)) =
-        HU.HUnitFailure loc (HU.ExpectedButGot (maybe (Just msg) (Just . joinMsg) pref) x y)
+      adjustMsg (HU.HUnitFailure loc txt) =
+        HU.HUnitFailure loc (joinMsg txt)
 
   testFailure = HU.assertFailure ""
   testFailureMsg = HU.assertFailure

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 
-module Cooked.MockChain.Monad.StagedSpec (spec) where
+module Cooked.MockChain.Monad.StagedSpec (tests) where
 
 import Control.Applicative
 import Control.Arrow
@@ -11,8 +11,8 @@ import Cooked.Tx.Constraints
 import Data.Default
 import Data.Foldable
 import qualified Ledger.Ada as Pl
-import Test.HUnit
-import Test.Hspec
+import Test.Tasty
+import Test.Tasty.HUnit
 
 imcEq :: (Show a, Eq a) => InterpMockChain a -> InterpMockChain a -> Assertion
 imcEq a b = go a @?= go b
@@ -31,74 +31,75 @@ possibleTraces =
       validateTxConstr [paysPK (walletPKHash $ wallet 3) (Pl.lovelaceValueOf 4200000)]
   ]
 
-spec :: Spec
-spec = do
-  describe "somewhere is lawful" $ do
-    it "somewhere (const Nothing) == const empty" $
-      assertAll possibleTraces $ \tr ->
-        interpret (somewhere (const Nothing) tr) `imcEq` empty
-
-  describe "everywhere is lawful" $ do
-    it "everywhere (const Nothing) == id" $
-      assertAll possibleTraces $ \tr ->
-        interpret (everywhere (const Nothing) tr) `imcEq` interpret tr
-
-  it "Somewhere is exponential in branch number" $
-    -- If we make a trace @tr = a >> b@ with two transactions, Then execute:
-    --
-    -- > tr' = somewhere f $ somewhere g $ tr
-    --
-    -- And we expect there to be four traces as a result:
-    --
-    -- > 1. f (g a) >> b
-    -- > 2. f a >> g b
-    -- > 3. g a >> f b
-    -- > 4. a >> f (g b)
-    --
-    -- If we execute @somewhere k tr'@ instead, we should expect to see 8 branches.
-    -- Because we're choosing @f = g = k = id@, we exept the eight traces to be equal to tr.
-    let tr =
-          validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)]
-            >> validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)]
-     in interpret (somewhere Just $ somewhere Just $ somewhere Just tr)
-          `imcEq` asum (replicate 8 $ interpret tr)
-
-  it "Modality order is respected" $
-    let -- Sample trace
-        tr f g =
-          validateTxConstr
-            [ paysPK
-                (walletPKHash $ wallet 2)
-                (f $ g $ Pl.lovelaceValueOf 4_200_000)
-            ]
-        -- Function to modify some specific skeletons
-        app f (TxSkel l opts constraintsSpec) =
-          case toConstraints constraintsSpec of
-            [] :=>: [PaysPKWithDatum pk stak dat val] ->
-              Just $ TxSkel l opts [PaysPKWithDatum pk stak dat (f val)]
-            _ -> Nothing
-        -- Two transformations
-        f x = Pl.lovelaceValueOf 3_000_000
-        g x = Pl.lovelaceValueOf (2 * Pl.getLovelace (Pl.fromValue x))
-     in interpret (everywhere (app f) $ everywhere (app g) (tr id id)) `imcEq` interpret (tr f g)
-
-  describe "interpModalities unit tests" $ do
-    it "works as expected for two 'Somewhere'" $
-      let f x = x + 5
-          g x = x * 5
-          ms = [Somewhere (Just . f), Somewhere (Just . g)]
-          x = 12
-       in map (second length) (interpModalities ms x)
-            @?= [ (f (g x), 0), -- applied both functions, nothing to consume
-                  (g x, 1), -- applied one, has one to consume
-                  (f x, 1), -- applied one, has one to consume
-                  (x, 2) -- applied none, has two to consume
-                ]
-
-    it "works as expected for two 'Everywhere'" $
-      let f x = 3
-          g x = x * 5
-          ms = [Everywhere (Just . f), Everywhere (Just . g)]
-          x = 12
-       in map (second length) (interpModalities ms x)
-            @?= [(f (g x), 2)] -- applied both, but since they stay there, there's still 2.
+tests :: [TestTree]
+tests =
+  [ testGroup
+      "lawfulness"
+      [ testCase "somewhere (const Nothing) == const empty" $
+          assertAll possibleTraces $ \tr ->
+            interpret (somewhere (const Nothing) tr) `imcEq` empty,
+        testCase "everywhere (const Nothing) == id" $
+          assertAll possibleTraces $ \tr ->
+            interpret (everywhere (const Nothing) tr) `imcEq` interpret tr
+      ],
+    testCase
+      "Somewhere is exponential in branch number"
+      $
+      -- If we make a trace @tr = a >> b@ with two transactions, Then execute:
+      --
+      -- > tr' = somewhere f $ somewhere g $ tr
+      --
+      -- And we expect there to be four traces as a result:
+      --
+      -- > 1. f (g a) >> b
+      -- > 2. f a >> g b
+      -- > 3. g a >> f b
+      -- > 4. a >> f (g b)
+      --
+      -- If we execute @somewhere k tr'@ instead, we should expect to see 8 branches.
+      -- Because we're choosing @f = g = k = id@, we exept the eight traces to be equal to tr.
+      let tr =
+            validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4_200_000)]
+              >> validateTxConstr [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 8_400_000)]
+       in interpret (somewhere Just $ somewhere Just $ somewhere Just tr)
+            `imcEq` asum (replicate 8 $ interpret tr),
+    testCase "Modality order is respected" $
+      let -- Sample trace
+          tr f g =
+            validateTxConstr
+              [ paysPK
+                  (walletPKHash $ wallet 2)
+                  (f $ g $ Pl.lovelaceValueOf 4_200_000)
+              ]
+          -- Function to modify some specific skeletons
+          app f (TxSkel l opts constraintsSpec) =
+            case toConstraints constraintsSpec of
+              [] :=>: [PaysPKWithDatum pk stak dat val] ->
+                Just $ TxSkel l opts [PaysPKWithDatum pk stak dat (f val)]
+              _ -> Nothing
+          -- Two transformations
+          f x = Pl.lovelaceValueOf 3_000_000
+          g x = Pl.lovelaceValueOf (2 * Pl.getLovelace (Pl.fromValue x))
+       in interpret (everywhere (app f) $ everywhere (app g) (tr id id)) `imcEq` interpret (tr f g),
+    testGroup
+      "interpModalities unit tests"
+      [ testCase "works as expected for two 'Somewhere'" $
+          let f x = x + 5
+              g x = x * 5
+              ms = [Somewhere (Just . f), Somewhere (Just . g)]
+              x = 12
+           in map (second length) (interpModalities ms x)
+                @?= [ (f (g x), 0), -- applied both functions, nothing to consume
+                      (g x, 1), -- applied one, has one to consume
+                      (f x, 1), -- applied one, has one to consume
+                      (x, 2) -- applied none, has two to consume
+                    ],
+        testCase "works as expected for two 'Everywhere'" $
+          let f x = 3
+              g x = x * 5
+              ms = [Everywhere (Just . f), Everywhere (Just . g)]
+              x = 12
+           in map (second length) (interpModalities ms x)
+                @?= [(f (g x), 2)] -- applied both, but since they stay there, there's still 2.
+      ]
+  ]

--- a/cooked-validators/tests/Cooked/MockChain/UtxoStateSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/UtxoStateSpec.hs
@@ -9,8 +9,8 @@ import Cooked.MockChain.UtxoState.Testing
 import Cooked.MockChain.Wallet
 import qualified Ledger.Ada as Ada
 import qualified PlutusTx.Numeric as Pl
-import Test.HUnit (Assertion)
-import Test.Hspec
+import Test.Tasty
+import Test.Tasty.HUnit
 
 utxoStateFromID :: InitialDistribution -> UtxoState
 utxoStateFromID = mcstToUtxoState . mockChainSt0From
@@ -39,31 +39,31 @@ stB =
         (wallet 2, [minAda <> quickValue "TOK_B" 1])
       ]
 
-spec :: SpecWith ()
-spec = do
-  describe "utxoStateDiff Unit Tests" $ do
-    it "utxoStateDiffSrc (utxoStateDiff a b) == a" $
-      utxoStateDiffSrc (utxoStateDiff stA stB) `shouldBe` stA
-
-    it "utxoStateDiffTgt (utxoStateDiff a b) == b" $
-      utxoStateDiffTgt (utxoStateDiff stA stB) `shouldBe` stB
-
-  describe "utxoStateDiffTotal" $ do
-    it "utxoStateDiffTotal (utxoStateDiff a b) =~= b - a" $
-      utxoStateDiffTotal (utxoStateDiff stA stB) `shouldBe` (minAda <> minAda <> quickValue "TOK_B" 1)
-
-    it "utxoStateDiffTotal (utxoStateDiff b a) =~= a - b" $
-      utxoStateDiffTotal (utxoStateDiff stB stA) `shouldBe` Pl.negate (minAda <> minAda <> quickValue "TOK_B" 1)
-
-  describe "Relations" $ do
-    it "stA `equalModuloAda` stA0" $
-      equalModuloAda stA stA0 `shouldBe` True
-
-    it "equalModuloAtMost (quickValue \"TOK_B\" 1) stA stB" $
-      equivModuloAtMost (minAda <> minAda <> quickValue "TOK_B" 1) stA stB `shouldBe` True
-
-    it "not $ equalModuloAtMost (Ada.lovelaceValueOf 100) stA0 stA" $
-      equivModuloAtMost (Ada.lovelaceValueOf 100) stA0 stA `shouldBe` False
-
-    it "equalModuloAtMost (Ada.lovelaceValueOf -246000) stA stA0" $
-      equivModuloAtMost (Ada.lovelaceValueOf (-246000)) stA stA0 `shouldBe` True
+tests :: [TestTree]
+tests =
+  [ testGroup
+      "utxoStateDiff"
+      [ testCase "utxoStateDiffSrc (utxoStateDiff a b) == a" $
+          utxoStateDiffSrc (utxoStateDiff stA stB) @?= stA,
+        testCase "utxoStateDiffTgt (utxoStateDiff a b) == b" $
+          utxoStateDiffTgt (utxoStateDiff stA stB) @?= stB
+      ],
+    testGroup
+      "utxoStateDiffTotal"
+      [ testCase "utxoStateDiffTotal (utxoStateDiff a b) =~= b - a" $
+          utxoStateDiffTotal (utxoStateDiff stA stB) @?= (minAda <> minAda <> quickValue "TOK_B" 1),
+        testCase "utxoStateDiffTotal (utxoStateDiff b a) =~= a - b" $
+          utxoStateDiffTotal (utxoStateDiff stB stA) @?= Pl.negate (minAda <> minAda <> quickValue "TOK_B" 1)
+      ],
+    testGroup
+      "Relations"
+      [ testCase "stA `equalModuloAda` stA0" $
+          equalModuloAda stA stA0 @?= True,
+        testCase "equalModuloAtMost (quickValue \"TOK_B\" 1) stA stB" $
+          equivModuloAtMost (minAda <> minAda <> quickValue "TOK_B" 1) stA stB @?= True,
+        testCase "not $ equalModuloAtMost (Ada.lovelaceValueOf 100) stA0 stA" $
+          equivModuloAtMost (Ada.lovelaceValueOf 100) stA0 stA @?= False,
+        testCase "equalModuloAtMost (Ada.lovelaceValueOf -246000) stA stA0" $
+          equivModuloAtMost (Ada.lovelaceValueOf (-246000)) stA stA0 @?= True
+      ]
+  ]

--- a/cooked-validators/tests/Cooked/MockChain/WalletSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/WalletSpec.hs
@@ -1,9 +1,10 @@
-module Cooked.MockChain.WalletSpec where
+module Cooked.MockChain.WalletSpec (tests) where
 
 import qualified Cardano.Crypto.Wallet as Crypto
 import Cooked.MockChain.Wallet
 import qualified Ledger.CardanoWallet as CW
-import Test.Hspec
+import Test.Tasty
+import Test.Tasty.HUnit
 
 -- these instances are needed by `shouldBe` below.
 
@@ -13,9 +14,8 @@ instance Eq Crypto.XPrv where
 instance Show Crypto.XPrv where
   show = show . Crypto.toXPub
 
-spec :: SpecWith ()
-spec = do
-  describe "Hack: unwrapping a MockPrivateKey into a XPrv" $ do
-    it "Works" $
-      hackUnMockPrivateKey (CW.mwPaymentKey $ wallet 1)
-        `shouldBe` walletSK (wallet 1)
+tests :: [TestTree]
+tests =
+  [ testCase "Hack: unwrapping a MockPrivateKey into a XPrv" $
+      hackUnMockPrivateKey (CW.mwPaymentKey $ wallet 1) @?= walletSK (wallet 1)
+  ]

--- a/cooked-validators/tests/Cooked/OutputReorderingSpec.hs
+++ b/cooked-validators/tests/Cooked/OutputReorderingSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cooked.OutputReorderingSpec (spec) where
+module Cooked.OutputReorderingSpec (tests) where
 
 import Cooked.MockChain
 import Cooked.Tx.Constraints
@@ -10,17 +10,23 @@ import Data.Either.Combinators (rightToMaybe)
 import qualified Ledger as Pl
 import qualified Ledger.Ada as Pl
 import qualified Ledger.Credential as Pl
-import Test.Hspec
+import Test.Tasty
+import Test.Tasty.HUnit
 
-spec :: SpecWith ()
-spec = do
-  describe "outputs follow the order of the 'paysPK' constraints" $ do
-    it "ordering two outputs" $
-      genTx (skel (wallet 2) (wallet 3))
-        `shouldSatisfy` maybe False (firstRecipientsAre (wallet 2) (wallet 3))
-    it "reversing the ordering of two outputs" $
-      genTx (skel (wallet 3) (wallet 2))
-        `shouldNotSatisfy` maybe False (firstRecipientsAre (wallet 2) (wallet 3))
+tests :: [TestTree]
+tests =
+  [ testCase "ordering two outputs" $
+      assertBool "doesn't satisfy" $
+        maybe False (firstRecipientsAre (wallet 2) (wallet 3)) $
+          genTx
+            (skel (wallet 2) (wallet 3)),
+    testCase
+      "reversing the ordering of two outputs"
+      $ assertBool "satisfies" $
+        not $
+          maybe False (firstRecipientsAre (wallet 2) (wallet 3)) $
+            genTx (skel (wallet 3) (wallet 2))
+  ]
 
 -- | Generates the transaction corresponding to a 'TxSkel' under the default
 -- distribution

--- a/cooked-validators/tests/Cooked/QuickValueSpec.hs
+++ b/cooked-validators/tests/Cooked/QuickValueSpec.hs
@@ -12,11 +12,13 @@ tests :: [TestTree]
 tests =
   [ testCase "make it possible to provide additional assets in the initial state" $
       assertBool "doesn't satisfy" $
-        isRightAndSatifies (hasQuickValueAmount (wallet 1) "goldenCoins" 20) $
+        isRightAndSatifies
+          (hasQuickValueAmount (wallet 1) "goldenCoins" 20)
           quickValuesInitialisation,
     testCase "are exchangeable like any other asset between wallets" $
       assertBool "doesn't satisfy" $
-        isRightAndSatifies (hasQuickValueAmount (wallet 2) "goldenCoins" 12) $
+        isRightAndSatifies
+          (hasQuickValueAmount (wallet 2) "goldenCoins" 12)
           paymentAfterCustomInitialization
   ]
 

--- a/cooked-validators/tests/Cooked/QuickValueSpec.hs
+++ b/cooked-validators/tests/Cooked/QuickValueSpec.hs
@@ -1,22 +1,24 @@
-module Cooked.QuickValueSpec (spec) where
+module Cooked.QuickValueSpec (tests) where
 
 import Cooked
 import Data.Default
 import qualified Data.Map as Map
 import qualified Ledger.Ada as Pl
 import qualified Ledger.Value as Pl
-import Test.Hspec
+import Test.Tasty
+import Test.Tasty.HUnit
 
-spec :: SpecWith ()
-spec = do
-  it "make it possible to provide additional assets in the initial state" $
-    quickValuesInitialisation
-      `shouldSatisfy` isRightAndSatifies
-        (hasQuickValueAmount (wallet 1) "goldenCoins" 20)
-  it "are exchangeable like any other asset between wallets" $
-    paymentAfterCustomInitialization
-      `shouldSatisfy` isRightAndSatifies
-        (hasQuickValueAmount (wallet 2) "goldenCoins" 12)
+tests :: [TestTree]
+tests =
+  [ testCase "make it possible to provide additional assets in the initial state" $
+      assertBool "doesn't satisfy" $
+        isRightAndSatifies (hasQuickValueAmount (wallet 1) "goldenCoins" 20) $
+          quickValuesInitialisation,
+    testCase "are exchangeable like any other asset between wallets" $
+      assertBool "doesn't satisfy" $
+        isRightAndSatifies (hasQuickValueAmount (wallet 2) "goldenCoins" 12) $
+          paymentAfterCustomInitialization
+  ]
 
 customInitialDistribution :: InitialDistribution
 customInitialDistribution =

--- a/cooked-validators/tests/Spec.hs
+++ b/cooked-validators/tests/Spec.hs
@@ -4,16 +4,19 @@ import qualified Cooked.MockChain.UtxoStateSpec as UtxoStateSpec
 import qualified Cooked.MockChain.WalletSpec as WalletSpec
 import qualified Cooked.OutputReorderingSpec as OutputReorderingSpec
 import qualified Cooked.QuickValueSpec as QuickValueSpec
-import Test.Hspec
+import Test.Tasty
 
 main :: IO ()
-main = hspec spec
+main = defaultMain tests
 
-spec :: Spec
-spec = do
-  describe "Reordering outputs" OutputReorderingSpec.spec
-  describe "Balancing transactions" Ba.spec
-  describe "Quick values" QuickValueSpec.spec
-  describe "Staged monad" StagedSpec.spec
-  describe "UtxoState" UtxoStateSpec.spec
-  describe "Wallet" WalletSpec.spec
+tests :: TestTree
+tests =
+  testGroup
+    "cooked-validators"
+    [ testGroup "Reordering outputs" OutputReorderingSpec.tests,
+      testGroup "Balancing transactions" Ba.tests,
+      testGroup "Quick values" QuickValueSpec.tests,
+      testGroup "Staged monad" StagedSpec.tests,
+      testGroup "UtxoState" UtxoStateSpec.tests,
+      testGroup "Wallet" WalletSpec.tests
+    ]

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -24,8 +24,7 @@ library
       src
   ghc-options: -Wall -fobject-code -fno-ignore-interface-pragmas -fno-omit-interface-pragmas
   build-depends:
-      HUnit
-    , QuickCheck
+      QuickCheck
     , aeson
     , base >=4.9 && <5
     , bytestring
@@ -55,7 +54,6 @@ library
     , streaming
     , tasty
     , tasty-expected-failure
-    , tasty-hspec
     , tasty-hunit
     , tasty-quickcheck
     , text
@@ -75,8 +73,7 @@ test-suite spec
   hs-source-dirs:
       tests
   build-depends:
-      HUnit
-    , QuickCheck
+      QuickCheck
     , aeson
     , base >=4.9 && <5
     , bytestring
@@ -107,7 +104,6 @@ test-suite spec
     , streaming
     , tasty
     , tasty-expected-failure
-    , tasty-hspec
     , tasty-hunit
     , tasty-quickcheck
     , text

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -16,8 +16,6 @@ dependencies:
   - tasty-quickcheck
   - tasty-expected-failure
   - heredoc
-  - HUnit
-  - tasty-hspec # should be removed after rewriting test suite with tasty-hunit and tasty-quickcheck
   # Dependencies of the example contracts, these come from the client
   - aeson
   - bytestring

--- a/examples/tests/Spec.hs
+++ b/examples/tests/Spec.hs
@@ -4,9 +4,7 @@ import qualified ForgeSpec
 import qualified PMultiSigStatefulSpec
 import qualified SplitSpec
 import qualified SplitUPLCSpec
-import Test.Hspec
 import Test.Tasty
-import Test.Tasty.Hspec
 import qualified UseCaseCrowdfundingSpec
 
 main :: IO ()


### PR DESCRIPTION
This PR removes two dependencies from our projects. Our tests are exclusively `tasty`, `tasty-hunit` and `tasty-quickcheck` now.