### PR TITLE
Make TxSkel's equality comparable

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -95,7 +95,7 @@ validateTxConstr :: (MonadBlockChain m, ConstraintsSpec constraints) => constrai
 validateTxConstr = validateTxSkel . txSkel
 
 -- | Calls 'validateTxSkel' with the default set of options but passes an arbitrary showable label to it.
-validateTxConstrLbl :: (Show lbl, MonadBlockChain m, ConstraintsSpec constraints) => lbl -> constraints -> m Pl.TxId
+validateTxConstrLbl :: (LabelConstrs lbl, MonadBlockChain m, ConstraintsSpec constraints) => lbl -> constraints -> m Pl.TxId
 validateTxConstrLbl lbl = validateTxSkel . txSkelLbl lbl
 
 spendableRef :: (MonadBlockChain m) => Pl.TxOutRef -> m SpendableOut

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -5,10 +5,12 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cooked.Tx.Constraints.Type where
 
 import Data.Default
+import Data.Functor.Identity
 import qualified Ledger as Pl hiding (unspentOutputs)
 import qualified Ledger.Credential as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, TypedValidator)
@@ -51,6 +53,15 @@ type SpendsConstrs a =
     Pl.ToData (Pl.RedeemerType a),
     Show (Pl.DatumType a),
     Show (Pl.RedeemerType a),
+    Eq (Pl.DatumType a),
+    Eq (Pl.RedeemerType a),
+    Typeable a
+  )
+
+type PaysScriptConstrs a =
+  ( Pl.ToData (Pl.DatumType a),
+    Show (Pl.DatumType a),
+    Eq (Pl.DatumType a),
     Typeable a
   )
 
@@ -62,6 +73,7 @@ type SpendsConstrs a =
 -- transaction, and miscellaneous constraints 'MiscConstraint' including input
 -- constraints, time constraints, or signature requirements.
 data Constraints = [MiscConstraint] :=>: [OutConstraint]
+  deriving (Eq)
 
 instance Semigroup Constraints where
   (c1 :=>: oc1) <> (c2 :=>: oc2) = (c1 <> c2) :=>: (oc1 <> oc2)
@@ -93,7 +105,7 @@ data MiscConstraint where
   -- 'Pl.mustMintValueWithRedeemer' is used to pass @r@ as a redeemer to the
   -- policies.
   Mints ::
-    (Pl.ToData a, Show a) =>
+    (Pl.ToData a, Eq a, Show a, Typeable a) =>
     Maybe a ->
     [Pl.MintingPolicy] ->
     Pl.Value ->
@@ -107,13 +119,34 @@ data MiscConstraint where
   -- | Ensure that the transaction is signed by the given 'Pl.PubKeyHash'es.
   SignedBy :: [Pl.PubKeyHash] -> MiscConstraint
 
+-- NB don't forget to update the Eq instance when adding new constructors
+
+(~*~?) :: forall ty a1 a2. (Typeable a1, Typeable a2) => ty a1 -> ty a2 -> Maybe (a1 :~~: a2)
+_ ~*~? _ = typeRep @a1 `eqTypeRep` typeRep @a2
+
+instance Eq MiscConstraint where
+  SpendsScript s1 r1 (so1, d1) == SpendsScript s2 r2 (so2, d2) =
+    case s1 ~*~? s2 of
+      Just HRefl -> (s1, r1, so1, d1) == (s2, r2, so2, d2)
+      Nothing -> False
+  SpendsPK so1 == SpendsPK so2 = so1 == so2
+  Mints d1 p1 v1 == Mints d2 p2 v2 =
+    case d1 ~*~? d2 of
+      Just HRefl -> (d1, p1, v1) == (d2, p2, v2)
+      Nothing -> False
+  Before t1 == Before t2 = t1 == t2
+  After t1 == After t2 = t1 == t2
+  ValidateIn r1 == ValidateIn r2 = r1 == r2
+  SignedBy hs1 == SignedBy hs2 = hs1 == hs2
+  _ == _ = False
+
 -- | Constraints which specify new transaction outputs
 data OutConstraint where
   -- | Creates an UTxO to the given validator, with the given datum
   -- and the given value. That is, lets the scirpt lock the given
   -- value.
   PaysScript ::
-    (Pl.ToData (Pl.DatumType a), Show (Pl.DatumType a), Typeable a) =>
+    (PaysScriptConstrs a) =>
     Pl.TypedValidator a ->
     Pl.DatumType a ->
     Pl.Value ->
@@ -124,18 +157,31 @@ data OutConstraint where
   -- two different staking keys will cause the first staking key to be overriden by calling @ownStakePubKeyHash@
   -- a second time. If this is an issue for you, please do submit an issue with an explanation on GitHub.
   PaysPKWithDatum ::
-    (Pl.ToData a, Show a) =>
+    (Pl.ToData a, Eq a, Show a, Typeable a) =>
     Pl.PubKeyHash ->
     Maybe Pl.StakePubKeyHash ->
     Maybe a ->
     Pl.Value ->
     OutConstraint
 
+-- NB don't forget to update the Eq instance when adding new constructors
+
+instance Eq OutConstraint where
+  PaysScript s1 d1 v1 == PaysScript s2 d2 v2 =
+    case s1 ~*~? s2 of
+      Just HRefl -> (s1, d1, v1) == (s2, d2, v2)
+      Nothing -> False
+  PaysPKWithDatum pk1 stake1 d1 v1 == PaysPKWithDatum pk2 stake2 d2 v2 =
+    case d1 ~*~? d2 of
+      Just HRefl -> (pk1, stake1, d1, v1) == (pk2, stake2, d2, v2)
+      Nothing -> False
+  _ == _ = False
+
 -- | This typeclass provides user-friendly convenience to overload the
 -- 'txConstraints' field of 'TxSkel'. For instance, this enables us to ommit the '(:=>:)'
 -- constructor whenever we're using only one kind of constraints.
 -- It also opens up future alternative of constraint specification.
-class ConstraintsSpec a where
+class (Eq a, Typeable a) => ConstraintsSpec a where
   toConstraints :: a -> Constraints
 
 instance ConstraintsSpec Constraints where
@@ -159,6 +205,8 @@ paysPK pkh = PaysPKWithDatum @() pkh Nothing Nothing
 mints :: [Pl.MintingPolicy] -> Pl.Value -> MiscConstraint
 mints = Mints @() Nothing
 
+type LabelConstrs x = (Show x, Typeable x, Eq x)
+
 -- | A Transaction skeleton is a set of our constraints,
 -- and an optional showable label, which is useful when displaying
 -- traces. The label was encoded as an existential to enable us to
@@ -173,13 +221,19 @@ mints = Mints @() Nothing
 -- A TxSkel does /NOT/ include a Wallet since wallets only exist in mock mode.
 data TxSkel where
   TxSkel ::
-    (Show x, ConstraintsSpec constraints) =>
+    (LabelConstrs x, ConstraintsSpec constraints) =>
     { txLabel :: Maybe x,
       -- | Set of options to use when generating this transaction.
       txOpts :: TxOpts,
       txConstraints :: constraints
     } ->
     TxSkel
+
+instance Eq TxSkel where
+  TxSkel l1 o1 c1 == TxSkel l2 o2 c2 =
+    case (l1 ~*~? l2, Identity c1 ~*~? Identity c2) of
+      (Just HRefl, Just HRefl) -> (l1, o1, c1) == (l2, o2, c2)
+      _ -> False
 
 -- | Constructs a skeleton without a default label and with default 'TxOpts'
 txSkel :: ConstraintsSpec constraints => constraints -> TxSkel
@@ -190,7 +244,7 @@ txSkelOpts :: ConstraintsSpec constraints => TxOpts -> constraints -> TxSkel
 txSkelOpts = TxSkel @() Nothing
 
 -- | Constructs a skeleton with a label
-txSkelLbl :: (Show x, ConstraintsSpec constraints) => x -> constraints -> TxSkel
+txSkelLbl :: (Show x, Typeable x, Eq x, ConstraintsSpec constraints) => x -> constraints -> TxSkel
 txSkelLbl x = TxSkel (Just x) def
 
 -- | Set of options to modify the behavior of generating and validating some transaction. Some of these

--- a/examples/src/Auction.hs
+++ b/examples/src/Auction.hs
@@ -101,12 +101,13 @@ data BidderInfo = BidderInfo
     -- | the last bidder's address
     bidder :: L.PubKeyHash
   }
-  deriving (Haskell.Show, Haskell.Eq)
+  deriving (Haskell.Show)
 
 PlutusTx.makeLift ''BidderInfo
 PlutusTx.unstableMakeIsData ''BidderInfo
 
 instance Eq BidderInfo where
+  {-# INLINEABLE (==) #-}
   BidderInfo a b == BidderInfo x y = a == x && b == y
 
 -- | The state of the auction. This will be the 'DatumType'.
@@ -115,13 +116,13 @@ data AuctionState
     NoBids
   | -- | state of an auction that has had at least one bid
     Bidding BidderInfo
-  deriving (Haskell.Show, Haskell.Eq)
+  deriving (Haskell.Show)
 
 PlutusTx.makeLift ''AuctionState
 PlutusTx.unstableMakeIsData ''AuctionState
 
 instance Eq AuctionState where
-  {- INLINEABLE (==) -}
+  {-# INLINEABLE (==) #-}
   NoBids == NoBids = True
   Bidding a == Bidding x = a == x
   _ == _ = False
@@ -132,7 +133,13 @@ data Action
     Bid BidderInfo
   | -- | redeemer to close the auction (after the 'bidDeadline')
     Hammer
-  deriving (Haskell.Show, Haskell.Eq)
+  deriving (Haskell.Show)
+
+instance Eq Action where
+  {-# INLINEABLE (==) #-}
+  Bid bi1 == Bid bi2 = bi1 == bi2
+  Hammer == Hammer = True
+  _ == _ = False
 
 PlutusTx.makeLift ''Action
 PlutusTx.unstableMakeIsData ''Action

--- a/examples/src/Auction.hs
+++ b/examples/src/Auction.hs
@@ -101,7 +101,7 @@ data BidderInfo = BidderInfo
     -- | the last bidder's address
     bidder :: L.PubKeyHash
   }
-  deriving (Haskell.Show)
+  deriving (Haskell.Show, Haskell.Eq)
 
 PlutusTx.makeLift ''BidderInfo
 PlutusTx.unstableMakeIsData ''BidderInfo
@@ -115,7 +115,7 @@ data AuctionState
     NoBids
   | -- | state of an auction that has had at least one bid
     Bidding BidderInfo
-  deriving (Haskell.Show)
+  deriving (Haskell.Show, Haskell.Eq)
 
 PlutusTx.makeLift ''AuctionState
 PlutusTx.unstableMakeIsData ''AuctionState
@@ -132,7 +132,7 @@ data Action
     Bid BidderInfo
   | -- | redeemer to close the auction (after the 'bidDeadline')
     Hammer
-  deriving (Haskell.Show)
+  deriving (Haskell.Show, Haskell.Eq)
 
 PlutusTx.makeLift ''Action
 PlutusTx.unstableMakeIsData ''Action

--- a/examples/src/PMultiSigStateful/DatumHijacking.hs
+++ b/examples/src/PMultiSigStateful/DatumHijacking.hs
@@ -26,6 +26,7 @@ import qualified Ledger
 import qualified Ledger.Contexts as Contexts
 import qualified Ledger.Typed.Scripts as Scripts
 import qualified PlutusTx
+import qualified PlutusTx.Eq as Pl
 import PlutusTx.Prelude hiding (Applicative (..))
 import Schema (ToSchema)
 import qualified Prelude as Haskell
@@ -45,12 +46,22 @@ data StealerDatum
   deriving stock (Haskell.Show, Haskell.Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
+instance Pl.Eq StealerDatum where
+  {-# INLINEABLE (==) #-}
+  Accumulator p1 s1 == Accumulator p2 s2 = p1 Pl.== p2 && s1 Pl.== s2
+  Sign s1 == Sign s2 = s1 == s2
+  _ == _ = False
+
 data Payment = Payment
   { paymentAmount :: Integer,
     paymentRecipient :: Ledger.PubKeyHash
   }
   deriving stock (Haskell.Show, Haskell.Eq, Generic)
   deriving anyclass (ToJSON, FromJSON)
+
+instance Pl.Eq Payment where
+  {-# INLINEABLE (==) #-}
+  Payment a1 r1 == Payment a2 r2 = a1 Pl.== a2 && r1 Pl.== r2
 
 PlutusTx.makeLift ''Payment
 PlutusTx.unstableMakeIsData ''Payment

--- a/examples/src/Split.hs
+++ b/examples/src/Split.hs
@@ -35,8 +35,14 @@ data SplitDatum = SplitDatum
     recipient2 :: Ledger.PubKeyHash,
     amount :: Integer
   }
-  deriving stock (Haskell.Eq, Haskell.Show, Generic)
+  deriving stock (Haskell.Show, Haskell.Eq, Generic)
   deriving anyclass (ToJSON, FromJSON, ToSchema)
+
+instance Eq SplitDatum where
+  SplitDatum r1'1 r2'1 a1 == SplitDatum r1'2 r2'2 a2 =
+    r1'1 == r1'2
+      && r2'1 == r2'2
+      && a1 == a2
 
 type SplitRedeemer = ()
 

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -39,7 +39,7 @@ txLock script datum =
 
 -- | Label for 'txLock' skeleton, making it immediately recognizable
 -- when printing traces.
-newtype TxLock = TxLock SplitDatum deriving (Show)
+newtype TxLock = TxLock SplitDatum deriving (Show, Eq)
 
 -- | Whether a script output concerns a public key hash
 isARecipient :: Pl.PubKeyHash -> SplitDatum -> a -> Bool
@@ -64,7 +64,7 @@ txUnlock script = do
       )
 
 -- | Label for 'txUnlock' skeleton
-data TxUnlock = TxUnlock deriving (Show)
+data TxUnlock = TxUnlock deriving (Show, Eq)
 
 -- * Contract monad endpoints and schema
 

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -17,6 +17,7 @@ import Data.Default
 import Data.Either (isLeft, isRight)
 import Data.Function (on)
 import Data.List (nub, nubBy)
+import Data.Typeable
 import qualified Ledger as Pl
 import qualified Ledger.Ada as Pl
 import qualified Ledger.Typed.Scripts as Pl
@@ -68,7 +69,7 @@ pkTable = AssocMap.fromList $ map (\w -> (walletPKHash w, walletPK w)) knownWall
 --  us identify what that transaction is doing without carefully inspecting its
 --  constraints.
 data ProposalSkel = ProposalSkel Integer Payment
-  deriving (Show)
+  deriving (Show, Eq)
 
 -- | Next, we can create proposals, which are simply an accumulator with no signees
 mkProposal :: MonadBlockChain m => Integer -> Payment -> m (Params, Pl.TxOutRef)
@@ -294,9 +295,15 @@ dupTokenAttack sOut (parms, tokenRef) (TxSkel l opts cs) =
              ]
 
 data DupTokenAttacked where
-  DupTokenAttacked :: (Show x) => Maybe x -> DupTokenAttacked
+  DupTokenAttacked :: (Typeable x, Show x, Eq x) => Maybe x -> DupTokenAttacked
 
 deriving instance Show DupTokenAttacked
+
+instance Eq DupTokenAttacked where
+  DupTokenAttacked m1 == DupTokenAttacked m2 =
+    case m1 ~*~? m2 of
+      Just HRefl -> m1 == m2
+      Nothing -> False
 
 -- ** Datum Hijacking Attack
 

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -52,7 +52,7 @@ txUnlock' mRecipient1 mRecipient2 mAmountChanger issuer = do
       (constraints <> toConstraints [remainderConstraint | remainder > 0])
       `as` issuer
 
-data TxUnlock' = TxUnlock' (Maybe Wallet) (Maybe Wallet) (Maybe Integer) deriving (Show)
+data TxUnlock' = TxUnlock' (Maybe Wallet) (Maybe Wallet) (Maybe Integer) deriving (Show, Eq)
 
 -- | Template for an unlock attack.
 -- Conditions for the attack: 2 split utxos in the ledger, with the same locked
@@ -78,7 +78,7 @@ txUnlockAttack issuer = do
                ]
   void $ validateTxConstrLbl TxUnlockAttack constraints `as` issuer
 
-data TxUnlockAttack = TxUnlockAttack deriving (Show)
+data TxUnlockAttack = TxUnlockAttack deriving (Show, Eq)
 
 -- | Transaction that does not pay enough to the recipients
 txUnlockNotEnough :: MonadMockChain m => Wallet -> m ()

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -54,6 +54,8 @@ instance TScripts.ValidatorTypes Crowdfunding where
 
 deriving instance Show CampaignAction
 
+deriving instance Eq CampaignAction
+
 -- | Generates an aribtrary campaign with a the collection deadline set as
 -- a delta on top of the payment deadline.
 genCampaign :: (MonadBlockChain m) => Integer -> Ledger.POSIXTime -> Wallet -> m (Ledger.POSIXTime, Campaign)

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -30,6 +30,7 @@ import Plutus.Contracts.Crowdfunding
 import qualified Plutus.Contracts.Currency as Currency
 import qualified Plutus.V1.Ledger.Scripts as Scripts
 import qualified PlutusTx (compile)
+import qualified PlutusTx.Eq as Pl
 import Test.Hspec
 import qualified Test.QuickCheck as QC
 import Test.Tasty
@@ -54,7 +55,10 @@ instance TScripts.ValidatorTypes Crowdfunding where
 
 deriving instance Show CampaignAction
 
-deriving instance Eq CampaignAction
+instance Pl.Eq CampaignAction where
+  Collect == Collect = True
+  Refund == Refund = True
+  _ == _ = False
 
 -- | Generates an aribtrary campaign with a the collection deadline set as
 -- a delta on top of the payment deadline.


### PR DESCRIPTION
Per discussion with @carlhammann , since I was doing something very similar earlier, so it wasn't too difficult to recreate.

The downside is that now datums and redeemers need to implement `Prelude.Eq` to be compatible with `cooked-validators`. While we've seen contracts that don't derive that class, this is not a big deal, since `-XStandaloneDeriving` would do for those contracts.

Also, I haven't tested this at all yet. Just wanted to know if this is the direction worth pursuing, and if it is — I'll happily throw up some tests.