### PR TITLE
Optic attacks

### DIFF
--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -15,6 +15,7 @@ library
       Cooked
       Cooked.Currencies
       Cooked.MockChain
+      Cooked.MockChain.Attack
       Cooked.MockChain.Constraints
       Cooked.MockChain.Monad
       Cooked.MockChain.Monad.Contract
@@ -57,6 +58,7 @@ library
     , memory
     , monad-control
     , mtl
+    , optics-core
     , plutus-contract
     , plutus-core
     , plutus-ledger
@@ -110,6 +112,7 @@ test-suite spec
     , memory
     , monad-control
     , mtl
+    , optics-core
     , plutus-contract
     , plutus-core
     , plutus-ledger

--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -30,6 +30,7 @@ library
       Cooked.MockChain.Wallet
       Cooked.Tx.Balance
       Cooked.Tx.Constraints
+      Cooked.Tx.Constraints.Optics
       Cooked.Tx.Constraints.Pretty
       Cooked.Tx.Constraints.Type
       Example

--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -13,9 +13,9 @@ extra-source-files:
 library
   exposed-modules:
       Cooked
+      Cooked.Attack
       Cooked.Currencies
       Cooked.MockChain
-      Cooked.MockChain.Attack
       Cooked.MockChain.Constraints
       Cooked.MockChain.Monad
       Cooked.MockChain.Monad.Contract
@@ -82,6 +82,7 @@ test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Cooked.AttackSpec
       Cooked.BalanceSpec
       Cooked.MockChain.Monad.StagedSpec
       Cooked.MockChain.UtxoStateSpec

--- a/cooked-validators/package.yaml
+++ b/cooked-validators/package.yaml
@@ -43,6 +43,7 @@ dependencies:
   - cardano-crypto
   - cardano-wallet-core
   - memory
+  - optics-core
 
 library:
   source-dirs: src

--- a/cooked-validators/src/Cooked/Attack.hs
+++ b/cooked-validators/src/Cooked/Attack.hs
@@ -122,7 +122,7 @@ datumHijackingAttack ::
     Pl.UnsafeFromData (L.DatumType a),
     Pl.UnsafeFromData (L.RedeemerType a)
   ) =>
-  -- | Function to indicate whether to stal from a validator script.
+  -- | Function to indicate whether to steal from a validator script.
   (L.TypedValidator a -> Bool) ->
   -- | A function indicating whether to try the attack on a 'PaysScript'
   -- constraint with the given datum and value.

--- a/cooked-validators/src/Cooked/Attack.hs
+++ b/cooked-validators/src/Cooked/Attack.hs
@@ -177,7 +177,8 @@ data DupTokenLbl = DupTokenLbl
 -- attack goes through, however, a "proper" datum hijacking attack that modifies
 -- the datum in a way that the (relevant part of) the
 -- 'toBuiltinData'-translation stays the same will also work. A
--- 'DatumHijackingLbl' is added to the labels of the 'TxSkel' using 'addLabel'.
+-- 'DatumHijackingLbl' with the hash of the "thief" validator is added to the
+-- labels of the 'TxSkel' using 'addLabel'.
 datumHijackingAttack ::
   forall a.
   ( Typeable a,
@@ -206,7 +207,7 @@ datumHijackingAttack change select skel =
    in addLabel (DatumHijackingLbl $ L.validatorHash thief)
         <$> mkSelectAttack paysScriptConstraintsT changeRecipient select skel
 
-data DatumHijackingLbl = DatumHijackingLbl L.ValidatorHash
+newtype DatumHijackingLbl = DatumHijackingLbl L.ValidatorHash
   deriving (Show, Eq)
 
 -- | The trivial validator that always succeds; this is a sufficient target for

--- a/cooked-validators/src/Cooked/Attack.hs
+++ b/cooked-validators/src/Cooked/Attack.hs
@@ -134,6 +134,7 @@ datumHijackingAttack valPred change skel =
   where
     changeRecipient :: PaysScriptConstraint -> Maybe PaysScriptConstraint
     changeRecipient (PaysScriptConstraint val dat money) =
+      -- checks whether val _is of the same type as_ the hijacking target, they're obviously different scripts.
       case val ~*~? datumHijackingTarget @a of
         Just HRefl ->
           if valPred val && change dat money

--- a/cooked-validators/src/Cooked/Attack.hs
+++ b/cooked-validators/src/Cooked/Attack.hs
@@ -151,9 +151,5 @@ data DatumHijackingLbl = DatumHijackingLbl
 datumHijackingTarget :: L.TypedValidator a
 datumHijackingTarget = unsafeTypedValidatorFromUPLC (Pl.getPlc $$(Pl.compile [||tgt||]))
   where
-    tgt ::
-      Pl.BuiltinData ->
-      Pl.BuiltinData ->
-      Pl.BuiltinData ->
-      ()
+    tgt :: Pl.BuiltinData -> Pl.BuiltinData -> Pl.BuiltinData -> ()
     tgt _ _ _ = ()

--- a/cooked-validators/src/Cooked/Attack.hs
+++ b/cooked-validators/src/Cooked/Attack.hs
@@ -1,24 +1,20 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Cooked.Attack where
 
 import Cooked.MockChain
 import Cooked.Tx.Constraints
+import Cooked.Tx.Constraints.Optics
 import Data.Maybe
-import Debug.Trace
-import qualified Ledger as Pl hiding (validatorHash)
-import qualified Ledger.Typed.Scripts as Pl
-import qualified Ledger.Value as Pl
-import qualified Ledger.Ada as Pl
+import qualified Ledger as L hiding (validatorHash)
+import qualified Ledger.Typed.Scripts as L
 import Optics.Core
 import qualified PlutusTx as Pl
 import qualified PlutusTx.Numeric as Pl (negate)
@@ -48,225 +44,27 @@ mkAttack optic f skel =
           skel
    in if modified then Just skel' else Nothing
 
--- * Some optics on 'TxSkel's, 'Constraint's, etc.
+-- * General helpers
 
--- There's a recurring pattern here to work around the existential type
--- variables in the constructors in 'Cooked.Tx.Constraints.Type': Define a type
--- that corresponds to the image of the constructor an then use that type as the
--- "codomain" of the optics.
-
--- ** Picking apart 'TxSkel's
-
-data TxLabel where
-  TxLabel :: LabelConstrs x => Maybe x -> TxLabel
-
-txLabelL :: Lens' TxSkel TxLabel
-txLabelL =
-  lens
-    (\(TxSkel l _ _) -> TxLabel l)
-    (\(TxSkel _ o c) (TxLabel l) -> TxSkel l o c)
-
-txOptsL :: Lens' TxSkel TxOpts
-txOptsL = lens txOpts (\(TxSkel l _ c) o -> TxSkel l o c)
-
-txConstraintsL :: Lens' TxSkel Constraints
-txConstraintsL =
-  lens
-    txConstraints
-    (\(TxSkel l o _) c -> TxSkel l o c)
-
-constraintPair :: Iso' Constraints ([MiscConstraint], [OutConstraint])
-constraintPair = iso (\(i :=>: o) -> (i, o)) (uncurry (:=>:))
-
-outConstraintsL :: Lens' TxSkel [OutConstraint]
-outConstraintsL = txConstraintsL % constraintPair % _2
-
-miscConstraintsL :: Lens' TxSkel [MiscConstraint]
-miscConstraintsL = txConstraintsL % constraintPair % _1
-
--- ** Picking apart 'MiscConstraint's
-
-data MintsConstraint where
-  MintsConstraint ::
-    MintsConstrs a =>
-    Maybe a ->
-    [Pl.MintingPolicy] ->
-    Pl.Value ->
-    MintsConstraint
-
-mintsConstraintP :: Prism' MiscConstraint MintsConstraint
-mintsConstraintP =
-  prism'
+-- | Add a label to a 'TxSkel'. If there is already a pre-existing label, the
+-- given label will be added, forming a pair @(newlabel, oldlabel)@.
+addLabel :: LabelConstrs x => x -> TxSkel -> TxSkel
+addLabel newlabel =
+  over
+    txLabelL
     ( \case
-        MintsConstraint r ps v -> Mints r ps v
-    )
-    ( \case
-        Mints r ps v -> Just $ MintsConstraint r ps v
-        _ -> Nothing
+        TxLabel Nothing -> TxLabel $ Just newlabel
+        TxLabel (Just oldlabel) -> TxLabel $ Just (newlabel, oldlabel)
     )
 
-mintsConstraintsT :: Traversal' TxSkel MintsConstraint
-mintsConstraintsT = miscConstraintsL % traversed % mintsConstraintP
-
-data SpendsScriptConstraint where
-  SpendsScriptConstraint ::
-    (SpendsConstrs a) =>
-    Pl.TypedValidator a ->
-    Pl.RedeemerType a ->
-    (SpendableOut, Pl.DatumType a) ->
-    SpendsScriptConstraint
-
-spendsScriptConstraintP :: Prism' MiscConstraint SpendsScriptConstraint
-spendsScriptConstraintP =
-  prism'
-    ( \case
-        SpendsScriptConstraint v r o -> SpendsScript v r o
-    )
-    ( \case
-        SpendsScript v r o -> Just $ SpendsScriptConstraint v r o
-        _ -> Nothing
-    )
-
-spendableOutL :: Lens' SpendsScriptConstraint SpendableOut
-spendableOutL =
-  lens
-    ( \case
-        SpendsScriptConstraint _ _ (o, _) -> o
-    )
-    ( \c o -> case c of
-        SpendsScriptConstraint v r (_, d) -> SpendsScriptConstraint v r (o, d)
-    )
-
-spendsPKConstraintP :: Prism' MiscConstraint SpendableOut
-spendsPKConstraintP =
-  prism'
-    SpendsPK
-    ( \case
-        SpendsPK o -> Just o
-        _ -> Nothing
-    )
-
--- ** Picking apart 'OutConstraint's
-
-data PaysScriptConstraint where
-  PaysScriptConstraint ::
-    PaysScriptConstrs a =>
-    Pl.TypedValidator a ->
-    Pl.DatumType a ->
-    Pl.Value ->
-    PaysScriptConstraint
-
-paysScriptConstraintP :: Prism' OutConstraint PaysScriptConstraint
-paysScriptConstraintP =
-  prism'
-    ( \case
-        PaysScriptConstraint v d x -> PaysScript v d x
-    )
-    ( \case
-        PaysScript v d x -> Just $ PaysScriptConstraint v d x
-        _ -> Nothing
-    )
-
-paysScriptConstraintsT :: Traversal' TxSkel PaysScriptConstraint
-paysScriptConstraintsT = outConstraintsL % traversed % paysScriptConstraintP
-
--- data TypedValidatorWrap where
---   TypedValidatorWrap :: Pl.TypedValidator a -> TypedValidatorWrap
-
--- scriptRecipientL :: Lens' PaysScriptConstraint TypedValidatorWrap
--- scriptRecipientL = lens (\case PaysScriptConstraint v _ _ -> v)
---   (\c v -> case c of
---       PaysScriptConstraint _ d x ->
-
-
--- ** Extracting 'Pl.Value's from different types
-
-class HasValue a where
-  valueL :: Lens' a Pl.Value
-
-instance HasValue Pl.ChainIndexTxOut where
-  valueL =
-    lens
-      ( \case
-          Pl.PublicKeyChainIndexTxOut _ x -> x
-          Pl.ScriptChainIndexTxOut _ _ _ x -> x
-      )
-      ( \o x -> case o of
-          Pl.PublicKeyChainIndexTxOut a _ -> Pl.PublicKeyChainIndexTxOut a x
-          Pl.ScriptChainIndexTxOut a v d _ -> Pl.ScriptChainIndexTxOut a v d x
-      )
-
-instance HasValue SpendableOut where
-  valueL = _2 % valueL
-
-instance HasValue OutConstraint where
-  valueL =
-    lens
-      ( \case
-          PaysScript _ _ v -> v
-          PaysPKWithDatum _ _ _ v -> v
-      )
-      ( \c x -> case c of
-          PaysScript v d _ -> PaysScript v d x
-          PaysPKWithDatum h sh d _ -> PaysPKWithDatum h sh d x
-      )
-
-instance HasValue MintsConstraint where
-  valueL =
-    lens
-      ( \case
-          MintsConstraint _ _ x -> x
-      )
-      ( \c x -> case c of
-          MintsConstraint r ps _ -> MintsConstraint r ps x
-      )
-
-instance HasValue SpendsScriptConstraint where
-  valueL = spendableOutL % valueL
-
--- | Given two 'AffineTraversal's of the same source and target types, which are
--- disjoint in the sense that at most one of them has a focus at any given
--- input, combine them in to one affine traversal. If the disjointness
--- requirement is violated, this will not be a lawful 'AffineTraversal'.
-unsafeOr ::
-  (Is k An_AffineTraversal, Is l An_AffineTraversal) =>
-  Optic' k is s a ->
-  Optic' l js s a ->
-  AffineTraversal' s a
-unsafeOr o1 o2 = withAffineTraversal o1 $ \m1 u1 ->
-  withAffineTraversal o2 $ \m2 u2 ->
-    atraversal
-      ( \s -> case m1 s of
-          Left _ -> case m2 s of
-            Left _ -> Left s
-            Right a -> Right a
-          Right a -> Right a
-      )
-      (\s a -> u2 (u1 s a) a)
-
-infixr 6 `unsafeOr` -- same fixity as <>
-
-valueAT :: AffineTraversal' MiscConstraint Pl.Value
-valueAT =
-  (spendsScriptConstraintP % valueL)
-    `unsafeOr` (mintsConstraintP % valueL)
-    `unsafeOr` (spendsPKConstraintP % valueL)
-
-txSkelInValue :: TxSkel -> Pl.Value
-txSkelInValue = foldOf (miscConstraintsL % traversed % valueAT)
-
-txSkelOutValue :: TxSkel -> Pl.Value
-txSkelOutValue = foldOf (outConstraintsL % traversed % valueL)
-
-flattenValueI :: Iso' Pl.Value [(Pl.AssetClass, Integer)]
-flattenValueI =
-  iso
-    (map (\(cSymbol, tName, amount) -> (Pl.assetClass cSymbol tName, amount)) . Pl.flattenValue)
-    (foldl (\v (ac, amount) -> v <> Pl.assetClassValue ac amount) mempty)
-
-nonAdaValue :: Pl.Value -> Pl.Value
-nonAdaValue = over flattenValueI (map $ \(ac, i) -> if ac == adaAssetClass then (ac, 0) else (ac, i))
-  where adaAssetClass = Pl.assetClass Pl.adaSymbol Pl.adaToken
+-- | try to use the given function to modify the elements of the given list. If
+-- at least one modification is successful, return 'Just' the modified list,
+-- otherwise fail returning 'Nothing'.
+someJust :: (a -> Maybe a) -> [a] -> Maybe [a]
+someJust _ [] = Nothing
+someJust f (x : xs) = case f x of
+  Just y -> Just $ y : map (\a -> fromMaybe a (f a)) xs
+  Nothing -> (x :) <$> someJust f xs
 
 -- * Token duplication attack
 
@@ -275,12 +73,12 @@ nonAdaValue = over flattenValueI (map $ \(ac, i) -> if ac == adaAssetClass then 
 -- labels of the transaction using 'addLabel'.
 dupTokenAttack ::
   -- | A function describing how the amount of minted tokens of an asset class
-  -- should be changed by the attack. This function @f@ should probably satisfy
+  -- should be changed by the attack. The given function @f@ should probably satisfy
   -- > f ac i == Just j -> i < j
   -- for all @ac@ and @i@, i.e. it should increase in the minted amount.
   -- If it does *not* increase the minted amount, or if @f ac i == Nothing@, the
   -- minted amount will be left unchanged.
-  (Pl.AssetClass -> Integer -> Maybe Integer) ->
+  (L.AssetClass -> Integer -> Maybe Integer) ->
   -- | The wallet of the attacker. Any extra tokens that were minted by the
   -- transaction are paid to this wallet.
   Wallet ->
@@ -289,7 +87,7 @@ dupTokenAttack change attacker skel =
   addLabel DupTokenLbl . paySurplusTo attacker
     <$> mkAttack (mintsConstraintsT % valueL) increaseValue skel
   where
-    increaseValue :: Pl.Value -> Maybe Pl.Value
+    increaseValue :: L.Value -> Maybe L.Value
     increaseValue v =
       case someJust
         ( \(ac, i) -> case change ac i of
@@ -308,26 +106,6 @@ dupTokenAttack change attacker skel =
 data DupTokenLbl = DupTokenLbl
   deriving (Eq, Show)
 
--- | try to use the given function to modify the elements of the given list. If
--- at least one modification is successful, return 'Just' the modified list,
--- otherwise fail returning 'Nothing'.
-someJust :: (a -> Maybe a) -> [a] -> Maybe [a]
-someJust _ [] = Nothing
-someJust f (x : xs) = case f x of
-  Just y -> Just $ y : map (\x -> fromMaybe x (f x)) xs
-  Nothing -> (x :) <$> someJust f xs
-
--- | Add a label to a 'TxSkel'. If there is already a pre-existing label, the
--- given label will be added, forming a pair @(newlabel, oldlabel)@.
-addLabel :: LabelConstrs x => x -> TxSkel -> TxSkel
-addLabel newlabel =
-  over
-    txLabelL
-    ( \case
-        TxLabel Nothing -> TxLabel $ Just newlabel
-        TxLabel (Just oldlabel) -> TxLabel $ Just (newlabel, oldlabel)
-    )
-
 -- * Datum hijacking attack
 
 -- | A datum hijacking attack, simplified: This attack tries to substitute a
@@ -341,30 +119,24 @@ addLabel newlabel =
 datumHijackingAttack ::
   forall a.
   ( Typeable a,
-    Pl.UnsafeFromData (Pl.DatumType a),
-    Pl.UnsafeFromData (Pl.RedeemerType a)
+    Pl.UnsafeFromData (L.DatumType a),
+    Pl.UnsafeFromData (L.RedeemerType a)
   ) =>
   -- | Validator script to steal from.
-  Pl.TypedValidator a ->
+  L.TypedValidator a ->
   -- | A function indicating whether to try the attack on a 'PaysScript'
   -- constraint with the given datum and value.
-  (Pl.DatumType a -> Pl.Value -> Bool) ->
+  (L.DatumType a -> L.Value -> Bool) ->
   Attack
 datumHijackingAttack val change skel =
   addLabel DatumHijackingLbl
     <$> mkAttack paysScriptConstraintsT changeRecipient skel
   where
-    -- -- This solution with @changeRecipient'@ is not nice. It would be cleaner to
-    -- -- have a traversal that focuses all 'PaysScriptConstraint's that pay to the
-    -- -- validator that we want to steal from an then apply @changeRecipient@.
-    -- changeRecipient' :: [PaysScriptConstraint] -> Maybe [PaysScriptConstraint]
-    -- changeRecipient' = oneJust changeRecipient
-
     changeRecipient :: PaysScriptConstraint -> Maybe PaysScriptConstraint
     changeRecipient (PaysScriptConstraint val' dat money) =
       case val' ~*~? val of
         Just HRefl ->
-          if Pl.validatorHash val' == Pl.validatorHash val && change dat money
+          if L.validatorHash val' == L.validatorHash val && change dat money
             then Just $ PaysScriptConstraint @a datumHijackingTarget dat money
             else Nothing
         Nothing -> Nothing
@@ -375,7 +147,7 @@ data DatumHijackingLbl = DatumHijackingLbl
 -- | The trivial validator that always succeds; this is a sufficient target for
 -- the datum hijacking attack since we only want to show feasibility of the
 -- attack.
-datumHijackingTarget :: Pl.TypedValidator a
+datumHijackingTarget :: L.TypedValidator a
 datumHijackingTarget = unsafeTypedValidatorFromUPLC (Pl.getPlc $$(Pl.compile [||tgt||]))
   where
     tgt ::
@@ -384,21 +156,3 @@ datumHijackingTarget = unsafeTypedValidatorFromUPLC (Pl.getPlc $$(Pl.compile [||
       Pl.BuiltinData ->
       ()
     tgt _ _ _ = ()
-
--- -- | If the given function evaluates exactly one element @x@ to @Just y@, return
--- -- the list with @x@ changed for @y@, else return @Nothing@.
--- oneJust :: (b -> Maybe b) -> [b] -> Maybe [b]
--- oneJust _ [] = Nothing
--- oneJust f (x : xs)
---   | Just y <- f x = (y :) <$> allNothing f xs
---   | otherwise = (x :) <$> oneJust f xs
-
--- -- | return the list, only if all elements are eveluated to @Nothing@ by the
--- -- given function
--- allNothing :: (b -> Maybe b) -> [b] -> Maybe [b]
--- allNothing _ [] = Just []
--- allNothing f (x : xs)
---   | Just _ <- f x = Nothing
---   | otherwise = (x :) <$> allNothing f xs
-
--- -- scriptRecipientP :: Pl.TypedValidator a -> Prism' PaysScriptConstraint (Pl.DatumType a, Pl.Value)

--- a/cooked-validators/src/Cooked/Attack.hs
+++ b/cooked-validators/src/Cooked/Attack.hs
@@ -25,7 +25,7 @@ import Type.Reflection
 -- | The type of attacks that operate on a single transaction. The idea is to
 -- try to modify a transaction, or return @Nothing@ if the modification does not
 -- apply; use this with the 'somewhere' and 'everywhere' modalities from
--- 'Cooked.MockChain.Monad'.
+-- "Cooked.MockChain.Monad".
 type Attack = TxSkel -> Maybe TxSkel
 
 -- | The simplest way to make an attack from an optic: Try to apply the given

--- a/cooked-validators/src/Cooked/MockChain/Attack.hs
+++ b/cooked-validators/src/Cooked/MockChain/Attack.hs
@@ -1,0 +1,323 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cooked.MockChain.Attack where
+
+import Cooked.Currencies
+import Cooked.MockChain
+import Cooked.Tx.Constraints
+import Data.Maybe
+import qualified Ledger as Pl hiding (lookup)
+import qualified Ledger.Typed.Scripts as Pl
+import qualified Ledger.Value as Pl
+import Optics.Core
+import qualified PlutusTx.AssocMap as Pl
+import qualified PlutusTx.IsData as Pl
+import qualified PlutusTx.Numeric as Pl (negate)
+import Type.Reflection
+
+-- * The type of attacks, and functions to turn optics into attacks
+
+type Attack = TxSkel -> Maybe TxSkel
+
+-- | The simplest way to make an attack from an optic: Apply some function to
+-- all of its foci, of fail returning @Nothing@ if nothing is in focus.
+mkAttack :: Is k A_Traversal => Optic' k is TxSkel a -> (a -> a) -> Attack
+mkAttack = failover
+
+-- * Some optics on 'TxSkel's, 'Constraint's, etc.
+
+-- There's a recurring pattern here to work around the existential type
+-- variables in the constructors in 'Cooked.Tx.Constraints.Type': Define a type
+-- that corresponds to the image of the constructor an then use that type as the
+-- "codomain" of the optics.
+
+-- ** Picking apart 'TxSkel's
+
+data TxLabel where
+  TxLabel :: Show x => Maybe x -> TxLabel
+
+txLabelL :: Lens' TxSkel TxLabel
+txLabelL =
+  lens
+    (\(TxSkel l _ _) -> TxLabel l)
+    (\(TxSkel _ o c) (TxLabel l) -> TxSkel l o c)
+
+txOptsL :: Lens' TxSkel TxOpts
+txOptsL = lens txOpts (\(TxSkel l _ c) o -> TxSkel l o c)
+
+txConstraintsL :: Lens' TxSkel Constraints
+txConstraintsL =
+  lens
+    txConstraints
+    (\(TxSkel l o _) c -> TxSkel l o c)
+
+constraintPair :: Iso' Constraints ([MiscConstraint], [OutConstraint])
+constraintPair = iso (\(i :=>: o) -> (i, o)) (uncurry (:=>:))
+
+outConstraintsL :: Lens' TxSkel [OutConstraint]
+outConstraintsL = txConstraintsL % constraintPair % _2
+
+miscConstraintsL :: Lens' TxSkel [MiscConstraint]
+miscConstraintsL = txConstraintsL % constraintPair % _1
+
+-- ** Picking apart 'MiscConstraint's
+
+data MintsConstraint where
+  MintsConstraint ::
+    (Pl.ToData a, Show a) =>
+    Maybe a ->
+    [Pl.MintingPolicy] ->
+    Pl.Value ->
+    MintsConstraint
+
+mintsConstraintP :: Prism' MiscConstraint MintsConstraint
+mintsConstraintP =
+  prism'
+    ( \case
+        MintsConstraint r ps v -> Mints r ps v
+    )
+    ( \case
+        Mints r ps v -> Just $ MintsConstraint r ps v
+        _ -> Nothing
+    )
+
+mintsConstraintsT :: Traversal' TxSkel MintsConstraint
+mintsConstraintsT = miscConstraintsL % traversed % mintsConstraintP
+
+data SpendsScriptConstraint where
+  SpendsScriptConstraint ::
+    (SpendsConstrs a) =>
+    Pl.TypedValidator a ->
+    Pl.RedeemerType a ->
+    (SpendableOut, Pl.DatumType a) ->
+    SpendsScriptConstraint
+
+spendsScriptConstraintP :: Prism' MiscConstraint SpendsScriptConstraint
+spendsScriptConstraintP =
+  prism'
+    ( \case
+        SpendsScriptConstraint v r o -> SpendsScript v r o
+    )
+    ( \case
+        SpendsScript v r o -> Just $ SpendsScriptConstraint v r o
+        _ -> Nothing
+    )
+
+spendableOutL :: Lens' SpendsScriptConstraint SpendableOut
+spendableOutL =
+  lens
+    ( \case
+        SpendsScriptConstraint _ _ (o, _) -> o
+    )
+    ( \c o -> case c of
+        SpendsScriptConstraint v r (_, d) -> SpendsScriptConstraint v r (o, d)
+    )
+
+spendsPKConstraintP :: Prism' MiscConstraint SpendableOut
+spendsPKConstraintP =
+  prism'
+    SpendsPK
+    ( \case
+        SpendsPK o -> Just o
+        _ -> Nothing
+    )
+
+-- ** Picking apart 'OutConstraint's
+
+data PaysScriptConstraint where
+  PaysScriptConstraint ::
+    (Pl.ToData (Pl.DatumType a), Show (Pl.DatumType a), Typeable a) =>
+    Pl.TypedValidator a ->
+    Pl.DatumType a ->
+    Pl.Value ->
+    PaysScriptConstraint
+
+paysScriptConstraintP :: Prism' OutConstraint PaysScriptConstraint
+paysScriptConstraintP =
+  prism'
+    ( \case
+        PaysScriptConstraint v d x -> PaysScript v d x
+    )
+    ( \case
+        PaysScript v d x -> Just $ PaysScriptConstraint v d x
+        _ -> Nothing
+    )
+
+-- data PaysPKWithDatumConstraint where
+--   PaysPKWithDatumConstraint ::
+--     (Pl.ToData a, Show a) =>
+--     Pl.PubKeyHash ->
+--     Maybe Pl.StakePubKeyHash ->
+--     Maybe a ->
+--     Pl.Value ->
+--     PaysPKWithDatumConstraint
+
+paysScriptConstraintsT :: Traversal' TxSkel PaysScriptConstraint
+paysScriptConstraintsT = outConstraintsL % traversed % paysScriptConstraintP
+
+-- ** Extracting 'Pl.Value's from different types
+
+class HasValue a where
+  valueL :: Lens' a Pl.Value
+
+instance HasValue Pl.ChainIndexTxOut where
+  valueL =
+    lens
+      ( \case
+          Pl.PublicKeyChainIndexTxOut _ x -> x
+          Pl.ScriptChainIndexTxOut _ _ _ x -> x
+      )
+      ( \o x -> case o of
+          Pl.PublicKeyChainIndexTxOut a _ -> Pl.PublicKeyChainIndexTxOut a x
+          Pl.ScriptChainIndexTxOut a v d _ -> Pl.ScriptChainIndexTxOut a v d x
+      )
+
+instance HasValue SpendableOut where
+  valueL = _2 % valueL
+
+instance HasValue OutConstraint where
+  valueL =
+    lens
+      ( \case
+          PaysScript _ _ v -> v
+          PaysPKWithDatum _ _ _ v -> v
+      )
+      ( \c x -> case c of
+          PaysScript v d _ -> PaysScript v d x
+          PaysPKWithDatum h sh d _ -> PaysPKWithDatum h sh d x
+      )
+
+instance HasValue MintsConstraint where
+  valueL =
+    lens
+      ( \case
+          MintsConstraint _ _ x -> x
+      )
+      ( \c x -> case c of
+          MintsConstraint r ps _ -> MintsConstraint r ps x
+      )
+
+instance HasValue SpendsScriptConstraint where
+  valueL = spendableOutL % valueL
+
+-- | Given two 'AffineTraversal's of the same source and targe types, which are
+-- disjoint in the sense that at most one has a focus at any given instant,
+-- combine them in to one affine traversal. If the disjointness requirement is
+-- violated, this is not a lawful 'AffineTraversal'.
+unsafeOr ::
+  (Is k An_AffineTraversal, Is l An_AffineTraversal) =>
+  Optic' k is s a ->
+  Optic' l js s a ->
+  AffineTraversal' s a
+unsafeOr o1 o2 = withAffineTraversal o1 $ \m1 u1 ->
+  withAffineTraversal o2 $ \m2 u2 ->
+    atraversal
+      ( \s -> case m1 s of
+          Left _ -> case m2 s of
+            Left _ -> Left s
+            Right a -> Right a
+          Right a -> Right a
+      )
+      (\s a -> u2 (u1 s a) a)
+
+infixr 6 `unsafeOr` -- same as <>
+
+valueAT :: AffineTraversal' MiscConstraint Pl.Value
+valueAT =
+  (spendsScriptConstraintP % valueL)
+    `unsafeOr` (mintsConstraintP % valueL)
+    `unsafeOr` (spendsPKConstraintP % valueL)
+
+txInValue :: TxSkel -> Pl.Value
+txInValue = foldOf (miscConstraintsL % traversed % valueAT)
+
+txOutValue :: TxSkel -> Pl.Value
+txOutValue = foldOf (outConstraintsL % traversed % valueL)
+
+-- * Token duplication attack
+
+-- | A token duplication attack which tries to modify every 'Mints'-constraint
+-- of a 'TxSkel'
+dupTokenAttack ::
+  Show x =>
+  -- | An optional label to attach to the modified 'TxSkel'. If there is already
+  -- a pre-existing label, the given label will be added, forming a pair
+  -- @(newlabel, oldlabel)@.
+  Maybe x ->
+  -- | This function associates to 'Pl.AssetClass'es functions to describe how
+  -- the amount of minted tokens of that asset class should be changed by the
+  -- attack. The given function @f@ is expected to satisfy
+  -- > f ac i == Just j -> i <= j
+  -- for all @ac@ and @i@ (i.e. it should never decrease the minted
+  -- amount). If @f ac i == Nothing@, the value will be left unchanged.
+  (Pl.AssetClass -> Integer -> Maybe Integer) ->
+  -- | The wallet of the attacker. Any extra tokens that were minted by the
+  -- transaction are paid to this wallet.
+  Wallet ->
+  Attack
+dupTokenAttack lab opts attacker skel =
+  addLabel
+    . paySurplusTo attacker
+    <$> mkAttack (mintsConstraintsT % valueL) increaseValue skel
+  where
+    increaseValue :: Pl.Value -> Pl.Value
+    increaseValue (Pl.Value symbolMap) =
+      Pl.Value $
+        Pl.mapWithKey
+          ( \cs tokenNameMap ->
+              Pl.mapWithKey
+                ( \tn i -> fromMaybe i $ opts (Pl.assetClass cs tn) i
+                )
+                tokenNameMap
+          )
+          symbolMap
+
+    paySurplusTo :: Wallet -> TxSkel -> TxSkel
+    paySurplusTo w s = over outConstraintsL (paysPK (walletPKHash w) surplus :) s
+      where
+        surplus = txInValue s <> Pl.negate (txOutValue s)
+
+    addLabel :: TxSkel -> TxSkel
+    addLabel
+      | Just l <- lab =
+        over
+          txLabelL
+          ( \case
+              TxLabel Nothing -> TxLabel $ Just l
+              TxLabel (Just x) -> TxLabel $ Just (l, x)
+          )
+      | otherwise = id
+
+-- * A datum hijacking attack
+
+datumHijackingAttack ::
+  Pl.TypedValidator a ->
+  Attack
+datumHijackingAttack honest = mkAttack paysScriptConstraintsT changeRecipient
+  where
+    changeRecipient :: PaysScriptConstraint -> PaysScriptConstraint
+    changeRecipient = undefined
+      where
+        thief :: Pl.TypedValidator a
+        thief = undefined -- always return True
+
+-- Just so we have something to sell in our auction that's not Ada:
+-- Have a banana.
+
+bananaAssetClass :: Pl.AssetClass
+bananaAssetClass = permanentAssetClass "Banana"
+
+-- | Value representing a number of bananas
+banana :: Integer -> Pl.Value
+banana = Pl.assetClassValue bananaAssetClass
+
+-- | How many bananas are in the given value? This is a left inverse of 'banana'.
+bananasIn :: Pl.Value -> Integer
+bananasIn v = Pl.assetClassValueOf v bananaAssetClass
+
+testSkel :: TxSkel
+testSkel = txSkel [Mints (Just ()) [] (banana 5)]

--- a/cooked-validators/src/Cooked/MockChain/Attack.hs
+++ b/cooked-validators/src/Cooked/MockChain/Attack.hs
@@ -322,7 +322,7 @@ datumHijackingAttack lab honest change skel =
     changeRecipient c@(PaysScriptConstraint val dat money) =
       case val ~*~? honest of
         Just HRefl ->
-          if change dat
+          if val == honest && change dat
             then PaysScriptConstraint thief dat money
             else c
         Nothing -> c

--- a/cooked-validators/src/Cooked/Tx/Constraints/Optics.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Optics.hs
@@ -1,0 +1,238 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- | Various Optics on 'TxSkels', constraints, and all the other types defined
+-- in 'Cooked.Tx.Constraints.Type'.
+module Cooked.Tx.Constraints.Optics where
+
+import Cooked.Tx.Constraints.Type
+import qualified Ledger as L
+import qualified Ledger.Ada as L
+import qualified Ledger.Typed.Scripts as L
+import qualified Ledger.Value as L
+import Optics.Core
+
+-- A few remarks:
+
+-- There's a recurring pattern here to work around the existential type
+-- variables in the constructors in 'Cooked.Tx.Constraints.Type': Define a type
+-- that corresponds to the image of the constructor an then use that type as the
+-- target of the optics.
+
+-- The naming convention for optics in this module is as follows: Lenses have
+-- names that end in 'I', Prisms end in 'P', traversals in 'T', affine
+-- traversals in 'AT', isos in 'I'. There are not yet and optics of other types
+-- here.
+
+-- * General helpers
+
+-- | Given two 'AffineTraversal's of the same source and target types, which are
+-- disjoint in the sense that at most one of them has a focus at any given
+-- input, combine them in to one affine traversal. If the disjointness
+-- requirement is violated, this will not be a lawful 'AffineTraversal'.
+unsafeOr ::
+  (Is k An_AffineTraversal, Is l An_AffineTraversal) =>
+  Optic' k is s a ->
+  Optic' l js s a ->
+  AffineTraversal' s a
+unsafeOr o1 o2 = withAffineTraversal o1 $ \m1 u1 ->
+  withAffineTraversal o2 $ \m2 u2 ->
+    atraversal
+      ( \s -> case m1 s of
+          Left _ -> case m2 s of
+            Left _ -> Left s
+            Right a -> Right a
+          Right a -> Right a
+      )
+      (\s a -> u2 (u1 s a) a)
+
+infixr 6 `unsafeOr` -- same fixity as <>
+
+-- * Picking apart 'TxSkel's
+
+data TxLabel where
+  TxLabel :: LabelConstrs x => Maybe x -> TxLabel
+
+txLabelL :: Lens' TxSkel TxLabel
+txLabelL =
+  lens
+    (\(TxSkel l _ _) -> TxLabel l)
+    (\(TxSkel _ o c) (TxLabel l) -> TxSkel l o c)
+
+txOptsL :: Lens' TxSkel TxOpts
+txOptsL = lens txOpts (\(TxSkel l _ c) o -> TxSkel l o c)
+
+txConstraintsL :: Lens' TxSkel Constraints
+txConstraintsL =
+  lens
+    txConstraints
+    (\(TxSkel l o _) c -> TxSkel l o c)
+
+constraintPairI :: Iso' Constraints ([MiscConstraint], [OutConstraint])
+constraintPairI = iso (\(i :=>: o) -> (i, o)) (uncurry (:=>:))
+
+outConstraintsL :: Lens' TxSkel [OutConstraint]
+outConstraintsL = txConstraintsL % constraintPairI % _2
+
+miscConstraintsL :: Lens' TxSkel [MiscConstraint]
+miscConstraintsL = txConstraintsL % constraintPairI % _1
+
+-- * Picking apart 'MiscConstraint's
+
+data MintsConstraint where
+  MintsConstraint ::
+    MintsConstrs a =>
+    Maybe a ->
+    [L.MintingPolicy] ->
+    L.Value ->
+    MintsConstraint
+
+mintsConstraintP :: Prism' MiscConstraint MintsConstraint
+mintsConstraintP =
+  prism'
+    ( \case
+        MintsConstraint r ps v -> Mints r ps v
+    )
+    ( \case
+        Mints r ps v -> Just $ MintsConstraint r ps v
+        _ -> Nothing
+    )
+
+mintsConstraintsT :: Traversal' TxSkel MintsConstraint
+mintsConstraintsT = miscConstraintsL % traversed % mintsConstraintP
+
+data SpendsScriptConstraint where
+  SpendsScriptConstraint ::
+    (SpendsConstrs a) =>
+    L.TypedValidator a ->
+    L.RedeemerType a ->
+    (SpendableOut, L.DatumType a) ->
+    SpendsScriptConstraint
+
+spendsScriptConstraintP :: Prism' MiscConstraint SpendsScriptConstraint
+spendsScriptConstraintP =
+  prism'
+    ( \case
+        SpendsScriptConstraint v r o -> SpendsScript v r o
+    )
+    ( \case
+        SpendsScript v r o -> Just $ SpendsScriptConstraint v r o
+        _ -> Nothing
+    )
+
+spendableOutL :: Lens' SpendsScriptConstraint SpendableOut
+spendableOutL =
+  lens
+    ( \case
+        SpendsScriptConstraint _ _ (o, _) -> o
+    )
+    ( \c o -> case c of
+        SpendsScriptConstraint v r (_, d) -> SpendsScriptConstraint v r (o, d)
+    )
+
+spendsPKConstraintP :: Prism' MiscConstraint SpendableOut
+spendsPKConstraintP =
+  prism'
+    SpendsPK
+    ( \case
+        SpendsPK o -> Just o
+        _ -> Nothing
+    )
+
+-- * Picking apart 'OutConstraint's
+
+data PaysScriptConstraint where
+  PaysScriptConstraint ::
+    PaysScriptConstrs a =>
+    L.TypedValidator a ->
+    L.DatumType a ->
+    L.Value ->
+    PaysScriptConstraint
+
+paysScriptConstraintP :: Prism' OutConstraint PaysScriptConstraint
+paysScriptConstraintP =
+  prism'
+    ( \case
+        PaysScriptConstraint v d x -> PaysScript v d x
+    )
+    ( \case
+        PaysScript v d x -> Just $ PaysScriptConstraint v d x
+        _ -> Nothing
+    )
+
+paysScriptConstraintsT :: Traversal' TxSkel PaysScriptConstraint
+paysScriptConstraintsT = outConstraintsL % traversed % paysScriptConstraintP
+
+-- * Extracting 'L.Value's from different types
+
+class HasValue a where
+  valueL :: Lens' a L.Value
+
+instance HasValue L.ChainIndexTxOut where
+  valueL =
+    lens
+      ( \case
+          L.PublicKeyChainIndexTxOut _ x -> x
+          L.ScriptChainIndexTxOut _ _ _ x -> x
+      )
+      ( \o x -> case o of
+          L.PublicKeyChainIndexTxOut a _ -> L.PublicKeyChainIndexTxOut a x
+          L.ScriptChainIndexTxOut a v d _ -> L.ScriptChainIndexTxOut a v d x
+      )
+
+instance HasValue SpendableOut where
+  valueL = _2 % valueL
+
+instance HasValue OutConstraint where
+  valueL =
+    lens
+      ( \case
+          PaysScript _ _ v -> v
+          PaysPKWithDatum _ _ _ v -> v
+      )
+      ( \c x -> case c of
+          PaysScript v d _ -> PaysScript v d x
+          PaysPKWithDatum h sh d _ -> PaysPKWithDatum h sh d x
+      )
+
+instance HasValue MintsConstraint where
+  valueL =
+    lens
+      ( \case
+          MintsConstraint _ _ x -> x
+      )
+      ( \c x -> case c of
+          MintsConstraint r ps _ -> MintsConstraint r ps x
+      )
+
+instance HasValue SpendsScriptConstraint where
+  valueL = spendableOutL % valueL
+
+valueAT :: AffineTraversal' MiscConstraint L.Value
+valueAT =
+  (spendsScriptConstraintP % valueL)
+    `unsafeOr` (mintsConstraintP % valueL)
+    `unsafeOr` (spendsPKConstraintP % valueL)
+
+-- | The combined value contained in all 'MiscConstraints' of a 'TxSkel'.
+txSkelInValue :: TxSkel -> L.Value
+txSkelInValue = foldOf (miscConstraintsL % traversed % valueAT)
+
+-- | The combined value contained in all 'OutConstraints' of a 'TxSkel'.
+txSkelOutValue :: TxSkel -> L.Value
+txSkelOutValue = foldOf (outConstraintsL % traversed % valueL)
+
+-- * Picking apart 'Value's
+
+flattenValueI :: Iso' L.Value [(L.AssetClass, Integer)]
+flattenValueI =
+  iso
+    (map (\(cSymbol, tName, amount) -> (L.assetClass cSymbol tName, amount)) . L.flattenValue)
+    (foldl (\v (ac, amount) -> v <> L.assetClassValue ac amount) mempty)
+
+nonAdaValue :: L.Value -> L.Value
+nonAdaValue = over flattenValueI (map $ \(ac, i) -> if ac == adaAssetClass then (ac, 0) else (ac, i))
+  where
+    adaAssetClass = L.assetClass L.adaSymbol L.adaToken

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -173,11 +173,11 @@ mints = Mints @() Nothing
 -- A TxSkel does /NOT/ include a Wallet since wallets only exist in mock mode.
 data TxSkel where
   TxSkel ::
-    (Show x, ConstraintsSpec constraints) =>
+    (Show x) =>
     { txLabel :: Maybe x,
       -- | Set of options to use when generating this transaction.
       txOpts :: TxOpts,
-      txConstraints :: constraints
+      txConstraints :: Constraints
     } ->
     TxSkel
 
@@ -187,11 +187,15 @@ txSkel = txSkelOpts def
 
 -- | Constructs a skeleton without a default label, but with custom options
 txSkelOpts :: ConstraintsSpec constraints => TxOpts -> constraints -> TxSkel
-txSkelOpts = TxSkel @() Nothing
+txSkelOpts opts cs = TxSkel @() Nothing opts (toConstraints cs)
 
 -- | Constructs a skeleton with a label
 txSkelLbl :: (Show x, ConstraintsSpec constraints) => x -> constraints -> TxSkel
-txSkelLbl x = TxSkel (Just x) def
+txSkelLbl x = TxSkel (Just x) def . toConstraints
+
+-- | Constructs a skeleton with the given labtl, options, and constraints
+txSkelLblOpts :: (Show x, ConstraintsSpec constraints) => x -> TxOpts -> constraints -> TxSkel
+txSkelLblOpts x os cs = TxSkel (Just x) os (toConstraints cs)
 
 -- | Set of options to modify the behavior of generating and validating some transaction. Some of these
 -- options only have an effect when running in the 'Plutus.Contract.Contract', some only have an effect when

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -10,7 +10,6 @@
 module Cooked.Tx.Constraints.Type where
 
 import Data.Default
-import Data.Functor.Identity
 import qualified Ledger as Pl hiding (unspentOutputs)
 import qualified Ledger.Credential as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, TypedValidator)
@@ -239,8 +238,8 @@ data TxSkel where
 
 instance Eq TxSkel where
   TxSkel l1 o1 c1 == TxSkel l2 o2 c2 =
-    case (l1 ~*~? l2, Identity c1 ~*~? Identity c2) of
-      (Just HRefl, Just HRefl) -> (l1, o1, c1) == (l2, o2, c2)
+    case l1 ~*~? l2 of
+      Just HRefl -> (l1, o1, c1) == (l2, o2, c2)
       _ -> False
 
 -- | Constructs a skeleton without a default label and with default 'TxOpts'

--- a/cooked-validators/tests/Cooked/AttackSpec.hs
+++ b/cooked-validators/tests/Cooked/AttackSpec.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cooked.AttackSpec (tests) where
+
+import Control.Monad
+import Cooked.Attack
+import Cooked.MockChain
+import Cooked.Tx.Constraints
+import Data.Default
+import qualified Ledger as L
+import qualified Ledger.Ada as L
+import qualified Ledger.Typed.Scripts as L
+import Optics.Core
+import qualified PlutusTx as Pl
+import qualified PlutusTx.Prelude as Pl
+import Test.Tasty
+import Test.Tasty.HUnit
+import Type.Reflection
+
+-- * Tests for the datum hijacking attack
+
+-- ** Mock contract for the datum hijacking attack
+
+-- This is a very simple contract: The first transaction locks some Ada to the
+-- validator, using the datum 'FirstLock', the second transaction then re-locks
+-- the same amount to the same validator, using the datum 'SecondLock'. The
+-- datum hijacking attack should target the secon transaction, and substitute a
+-- different recipient.
+
+data MockDatum = FirstLock | SecondLock deriving (Show)
+
+instance Pl.Eq MockDatum where
+  {-# INLINEABLE (==) #-}
+  FirstLock == FirstLock = True
+  SecondLock == SecondLock = True
+  _ == _ = False
+
+Pl.makeLift ''MockDatum
+Pl.unstableMakeIsData ''MockDatum
+
+data MockContract
+
+instance L.ValidatorTypes MockContract where
+  type DatumType MockContract = MockDatum
+  type RedeemerType MockContract = ()
+
+-- ** Transactions (and 'TxSkels') for the datum hijacking attack
+
+lockValue :: L.Value
+lockValue = L.lovelaceValueOf 123456789
+
+lockTxSkel :: L.TypedValidator MockContract -> TxSkel
+lockTxSkel v =
+  txSkelOpts
+    (def {adjustUnbalTx = True})
+    (PaysScript v FirstLock lockValue)
+
+txLock :: MonadBlockChain m => L.TypedValidator MockContract -> m ()
+txLock = void . validateTxSkel . lockTxSkel
+
+relockTxSkel :: L.TypedValidator MockContract -> SpendableOut -> TxSkel
+relockTxSkel v o =
+  txSkelOpts
+    (def {adjustUnbalTx = True})
+    ( [SpendsScript v () (o, FirstLock)]
+        :=>: [PaysScript v SecondLock lockValue]
+    )
+
+txRelock ::
+  MonadBlockChain m =>
+  L.TypedValidator MockContract ->
+  m ()
+txRelock v = do
+  [utxo] <- scriptUtxosSuchThat v (\_ _ -> True) -- (\d _ -> FirstLock Pl.== d)
+  void $ validateTxSkel $ relockTxSkel v (fst utxo)
+
+-- ** Validators for the datum hijacking attack
+
+-- | Try to extract a datum from an output.
+{-# INLINEABLE outputDatum #-}
+outputDatum :: L.TxInfo -> L.TxOut -> Maybe MockDatum
+outputDatum txi o = do
+  h <- L.txOutDatum o
+  L.Datum d <- L.findDatum h txi
+  Pl.fromBuiltinData d
+
+{-# INLINEABLE mkCarefulValidator #-}
+mkCarefulValidator :: MockDatum -> () -> L.ScriptContext -> Bool
+mkCarefulValidator datum _ ctx =
+  let txi = L.scriptContextTxInfo ctx
+   in case datum of
+        FirstLock ->
+          L.valueLockedBy txi (L.ownHash ctx) == lockValue
+            && case L.getContinuingOutputs ctx of
+              [o] -> outputDatum txi o Pl.== Just SecondLock
+        SecondLock -> Pl.trace "there must be exactly one output" False
+
+carefulValidator :: L.TypedValidator MockContract
+carefulValidator =
+  L.mkTypedValidator @MockContract
+    $$(Pl.compile [||mkCarelessValidator||])
+    $$(Pl.compile [||wrap||])
+  where
+    wrap = L.wrapValidator @MockDatum @()
+
+{-# INLINEABLE mkCarelessValidator #-}
+mkCarelessValidator :: MockDatum -> () -> L.ScriptContext -> Bool
+mkCarelessValidator datum _ ctx =
+  let txi = L.scriptContextTxInfo ctx
+   in case datum of
+        FirstLock ->
+          L.valueLockedBy txi (L.ownHash ctx) == lockValue
+            && case L.txInfoOutputs txi of
+              [o] -> outputDatum (L.scriptContextTxInfo ctx) o Pl.== Just SecondLock
+        SecondLock -> Pl.trace "there must be exactly one output" False
+
+carelessValidator :: L.TypedValidator MockContract
+carelessValidator =
+  L.mkTypedValidator @MockContract
+    $$(Pl.compile [||mkCarelessValidator||])
+    $$(Pl.compile [||wrap||])
+  where
+    wrap = L.wrapValidator @MockDatum @()
+
+-- ** Testing the datum hijacking attack on 'TxSkels'
+
+-- relockTxSkel' :: Monad m => L.TypedValidator MockContract -> MockChainT m TxSkel
+-- relockTxSkel' v = do
+--   txLock v
+--   [utxo] <- scriptUtxosSuchThat v (\_ _ -> True)
+--   return $ relockTxSkel v (fst utxo)
+
+-- dhTxSkelTests :: TestTree
+-- dhTxSkelTests =
+--   testGroup
+--     "datum hijacking tests on 'TxSkel's"
+--     [ testCase "" $
+--         let skelOrErr :: Either MockChainError (TxSkel, UtxoState)
+--             skelOrErr = runMockChain (relockTxSkel' carefulValidator)
+--          in testBool $
+--               case skelOrErr of
+--                 Left _ -> False
+--                 Right (skel, _) ->
+--                   let skelExpected =
+--                         over
+--                           paysScriptConstraintsT
+--                           ( \case
+--                               PaysScriptConstraint v d x ->
+--                                 case v ~*~? carefulValidator of
+--                                   Just HRefl ->
+--                                     PaysScriptConstraint (trivialValidator @MockContract) d x
+--                                   Nothing -> error "could not set up test"
+--                           )
+--                           skel
+--                    in datumHijackingAttack (Nothing @()) carefulValidator (\_ _ -> True) skel
+--                         == Just skelExpected
+--     ]
+
+-- ** Testing the datum hijacking attack on traces
+
+dhTrace :: MonadBlockChain m => L.TypedValidator MockContract -> m ()
+dhTrace v = do
+  txLock v
+  txRelock v
+
+dhTraceTests :: TestTree
+dhTraceTests =
+  testGroup
+    "datum hijacking traces"
+    [ -- testCase "careful validator can not be fooled" $
+      --   testFailsFrom'
+      --     isCekEvaluationFailure
+      --     def
+      --     ( somewhere
+      --         ( datumHijackingAttack
+      --             (Nothing @())
+      --             carefulValidator
+      --             (\d _ -> SecondLock Pl.== d)
+      --         )
+      --         (dhTrace carefulValidator)
+      --     ),
+      -- testCase "careless validator can be fooled" $
+      --   testSucceeds
+      --     ( somewhere
+      --         ( datumHijackingAttack
+      --             (Nothing @())
+      --             carelessValidator
+      --             (\d _ -> SecondLock Pl.== d)
+      --         )
+      --         (dhTrace carelessValidator)
+      --     )
+      testCase "at least something works" $
+        testSucceeds (dhTrace carelessValidator)
+    ]
+
+tests :: [TestTree]
+tests =
+  [ testGroup
+      "Attack DSL"
+      [ -- dhTxSkelTests,
+        dhTraceTests
+      ]
+  ]

--- a/cooked-validators/tests/Cooked/AttackSpec.hs
+++ b/cooked-validators/tests/Cooked/AttackSpec.hs
@@ -14,7 +14,7 @@ import Cooked.Attack
 import Cooked.MockChain
 import Cooked.Tx.Constraints
 import Data.Default
-import qualified Ledger as L hiding (singleton)
+import qualified Ledger as L hiding (singleton, validatorHash)
 import qualified Ledger.Ada as L
 import qualified Ledger.Typed.Scripts as L
 import qualified Ledger.Value as L
@@ -284,7 +284,9 @@ datumHijackingAttackTests =
                PaysScript val2 SecondLock x1,
                PaysScript val1 FirstLock x2,
                PaysScript val1 SecondLock x2]
-            skelOut = datumHijackingAttack val1 (\d x -> SecondLock Pl.== d && x2 `L.geq` x) skelIn
+            skelOut = datumHijackingAttack @MockContract
+              (\v -> L.validatorHash val1 == L.validatorHash v)
+              (\d x -> SecondLock Pl.== d && x2 `L.geq` x) skelIn
             skelExpected = txSkelLbl DatumHijackingLbl
               [PaysScript val1 SecondLock x1,
                PaysScript thief SecondLock x3,
@@ -297,8 +299,8 @@ datumHijackingAttackTests =
           isCekEvaluationFailure
           def
           ( somewhere
-              ( datumHijackingAttack
-                  carefulValidator
+              ( datumHijackingAttack @MockContract
+                  (\v -> L.validatorHash v == L.validatorHash carefulValidator)
                   (\d _ -> SecondLock Pl.== d)
               )
               (datumHijackingTrace carefulValidator)
@@ -306,8 +308,8 @@ datumHijackingAttackTests =
       testCase "careless validator" $
         testSucceeds
           ( somewhere
-              ( datumHijackingAttack
-                  carelessValidator
+              ( datumHijackingAttack @MockContract
+                  (\v -> L.validatorHash v == L.validatorHash carelessValidator)
                   (\d _ -> SecondLock Pl.== d)
               )
               (datumHijackingTrace carelessValidator)

--- a/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
+++ b/cooked-validators/tests/Cooked/MockChain/Monad/StagedSpec.hs
@@ -75,7 +75,7 @@ tests =
           app f (TxSkel l opts constraintsSpec) =
             case toConstraints constraintsSpec of
               [] :=>: [PaysPKWithDatum pk stak dat val] ->
-                Just $ TxSkel l opts [PaysPKWithDatum pk stak dat (f val)]
+                Just $ txSkelLblOpts l opts [PaysPKWithDatum pk stak dat (f val)]
               _ -> Nothing
           -- Two transformations
           f x = Pl.lovelaceValueOf 3_000_000

--- a/cooked-validators/tests/Cooked/OutputReorderingSpec.hs
+++ b/cooked-validators/tests/Cooked/OutputReorderingSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Cooked.OutputReorderingSpec (tests) where
 
@@ -37,14 +36,11 @@ genTx = fmap fst . rightToMaybe . runMockChain . fmap snd . generateTx'
 -- the ordering of the outputs
 skel :: Wallet -> Wallet -> TxSkel
 skel w1 w2 =
-  TxSkel
-    { txLabel = Nothing @(),
-      txOpts = def {forceOutputOrdering = True},
-      txConstraints =
-        [ paysPK (walletPKHash w1) (Pl.lovelaceValueOf 1_000),
-          paysPK (walletPKHash w2) (Pl.lovelaceValueOf 1_000)
-        ]
-    }
+  txSkelOpts
+    (def {forceOutputOrdering = True})
+    [ paysPK (walletPKHash w1) (Pl.lovelaceValueOf 1_000),
+      paysPK (walletPKHash w2) (Pl.lovelaceValueOf 1_000)
+    ]
 
 -- | Checks that the first two outputs in a transaction are payments to the two
 -- given wallets

--- a/cooked-validators/tests/Spec.hs
+++ b/cooked-validators/tests/Spec.hs
@@ -1,10 +1,10 @@
+import qualified Cooked.AttackSpec as AttackSpec
 import qualified Cooked.BalanceSpec as Ba
 import qualified Cooked.MockChain.Monad.StagedSpec as StagedSpec
 import qualified Cooked.MockChain.UtxoStateSpec as UtxoStateSpec
 import qualified Cooked.MockChain.WalletSpec as WalletSpec
 import qualified Cooked.OutputReorderingSpec as OutputReorderingSpec
 import qualified Cooked.QuickValueSpec as QuickValueSpec
-import qualified Cooked.AttackSpec as AttackSpec
 import Test.Tasty
 
 main :: IO ()

--- a/cooked-validators/tests/Spec.hs
+++ b/cooked-validators/tests/Spec.hs
@@ -4,6 +4,7 @@ import qualified Cooked.MockChain.UtxoStateSpec as UtxoStateSpec
 import qualified Cooked.MockChain.WalletSpec as WalletSpec
 import qualified Cooked.OutputReorderingSpec as OutputReorderingSpec
 import qualified Cooked.QuickValueSpec as QuickValueSpec
+import qualified Cooked.AttackSpec as AttackSpec
 import Test.Tasty
 
 main :: IO ()
@@ -13,10 +14,11 @@ tests :: TestTree
 tests =
   testGroup
     "cooked-validators"
-    [ testGroup "Reordering outputs" OutputReorderingSpec.tests,
-      testGroup "Balancing transactions" Ba.tests,
-      testGroup "Quick values" QuickValueSpec.tests,
-      testGroup "Staged monad" StagedSpec.tests,
-      testGroup "UtxoState" UtxoStateSpec.tests,
-      testGroup "Wallet" WalletSpec.tests
+    [ -- testGroup "Reordering outputs" OutputReorderingSpec.tests,
+      -- testGroup "Balancing transactions" Ba.tests,
+      -- testGroup "Quick values" QuickValueSpec.tests,
+      -- testGroup "Staged monad" StagedSpec.tests,
+      -- testGroup "UtxoState" UtxoStateSpec.tests,
+      -- testGroup "Wallet" WalletSpec.tests,
+      testGroup "Attack" AttackSpec.tests
     ]

--- a/cooked-validators/tests/Spec.hs
+++ b/cooked-validators/tests/Spec.hs
@@ -14,11 +14,11 @@ tests :: TestTree
 tests =
   testGroup
     "cooked-validators"
-    [ -- testGroup "Reordering outputs" OutputReorderingSpec.tests,
-      -- testGroup "Balancing transactions" Ba.tests,
-      -- testGroup "Quick values" QuickValueSpec.tests,
-      -- testGroup "Staged monad" StagedSpec.tests,
-      -- testGroup "UtxoState" UtxoStateSpec.tests,
-      -- testGroup "Wallet" WalletSpec.tests,
+    [ testGroup "Reordering outputs" OutputReorderingSpec.tests,
+      testGroup "Balancing transactions" Ba.tests,
+      testGroup "Quick values" QuickValueSpec.tests,
+      testGroup "Staged monad" StagedSpec.tests,
+      testGroup "UtxoState" UtxoStateSpec.tests,
+      testGroup "Wallet" WalletSpec.tests,
       testGroup "Attack" AttackSpec.tests
     ]

--- a/examples/tests/AuctionSpec.hs
+++ b/examples/tests/AuctionSpec.hs
@@ -160,7 +160,7 @@ tryDatumHijack =
             A.Bidding _ -> True
             _ -> False
         )
-        Nothing -- if there is more than one 'Bidding' output, try stealing all of them
+        (0 ==) -- if there is more than one 'Bidding' output, try stealing only the first
     )
     (noBids <|> oneBid <|> twoBids)
 

--- a/examples/tests/AuctionSpec.hs
+++ b/examples/tests/AuctionSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module AuctionSpec where
 
@@ -156,11 +156,11 @@ tryDatumHijack :: (Alternative m, MonadModalMockChain m) => m ()
 tryDatumHijack =
   somewhere
     ( datumHijackingAttack @A.Auction
-        (const True) -- try to steal from every validator
-        ( \d _ -> case d of -- but only steal outputs that have the 'Bidding' datum
+        ( \_ d _ -> case d of -- try to steal all outputs that have the 'Bidding' datum, no matter their validator or value
             A.Bidding _ -> True
             _ -> False
         )
+        Nothing -- if there is more than one 'Bidding' output, try stealing all of them
     )
     (noBids <|> oneBid <|> twoBids)
 

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -373,6 +373,6 @@ datumHijacking' =
             Accumulator _ _ -> True
             _ -> False
         )
-        (Just 0) -- if there is more than one output with 'Accumulator' datum, steal the first
+        (0 ==) -- if there is more than one output with 'Accumulator' datum, steal the first
     )
     exampleMtrace


### PR DESCRIPTION
The idea of this PR is that  `type Attack = TxSkel -> Maybe TxSkel`, such that an attack is a possibly failing modification of a `TxSkel`. Then, we can have a function `mkAttack` that has a type like `Optic TxSkel a -> (a -> Maybe a) -> Attack` that takes a possibly failing modification of `a`s and turns it into a possibly failing modification of `TxSkel`s by trying to apply it to all of the foci of a given optic. [Here](https://github.com/tweag/plutus-libs/blob/b848e271817d0b77cc482924707034e277ffb481/cooked-validators/src/Cooked/Attack.hs#L34) is that function.

This PR
- implements a few optics to pick apart `TxSkels`,
- provides hopefully easy-to use token duplication and datum hijacking attacks,
- slightly changes how `TxSkel`s are implemented: They now contain `Constraints`, and not anymore things that are of a type that satisfies `ConstraintsSpec`; it also adds a few smart constructors for `TxSkel`s.