### PR TITLE
GH Action for publishing cooked-validators docs

### DIFF
--- a/.github/scripts/build-haddock
+++ b/.github/scripts/build-haddock
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+cabal haddock --haddock-hyperlink-source --haddock-html-location='https://marlowe-playground-staging.plutus.aws.iohkdev.io/doc/haddock/' cooked-validators
+mkdir -p docs
+cp -R dist-newstyle/build/*/ghc-*/cooked-validators-*/doc/html/cooked-validators/* docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-test:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository code (from PR).
+      uses: actions/checkout@v2.4.0
+
+    - name: Install nix.
+      uses: cachix/install-nix-action@v15
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+      # Would using cachix help in anyway? I think we are not building anything, we're
+      # only fetching things from cache.nixos.org and iohk.cachix.org
+      # - uses: cachix/cachix-action@v10
+      #   with:
+      #     name: plutus-libs
+      #     authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      
+    - name: Accessing the cabal cache.
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cabal/store
+          dist-newstyle
+        key: cabal-cache-${{ github.sha }}
+        restore-keys: |
+          cabal-cache
+
+    - name: Accessing the result cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ./*.out
+          ./*.res
+        key: result-cache-${{ github.sha }}
+
+    - name: Chmod test script
+      run: |
+        chmod u+x .github/scripts/build-haddock
+
+    - name: Build documentation
+      uses: ./.github/actions/nix-run
+      with:
+        command: ./.github/scripts/build-haddock
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist-newstyle
 *#
 *.artifact
 *.swp
+docs/


### PR DESCRIPTION
Unfortunately the only way to test this is:
1. Merge this into `main`,
2. Run [these instructions](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token) once the first run fails.

This should show the docs at `https://tweag.github.io/plutus-libs`.