### PR TITLE
Sometimes even `isCekEvaluationFailure` is too coarse.

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Testing.hs
@@ -12,7 +12,9 @@ import Cooked.MockChain.Monad.Staged
 import Cooked.MockChain.UtxoState
 import Cooked.MockChain.Wallet
 import Data.Default
+import qualified Data.Text as T
 import Debug.Trace
+import Ledger (ScriptError (EvaluationError))
 import Ledger.Index (ValidationError (ScriptFailure))
 import qualified Test.QuickCheck as QC
 import qualified Test.Tasty.HUnit as HU
@@ -124,6 +126,12 @@ testFailsFrom' predi = testAllSatisfiesFrom (either predi (testFailureMsg . show
 isCekEvaluationFailure :: (IsProp prop) => MockChainError -> prop
 isCekEvaluationFailure (MCEValidationError (_, ScriptFailure _)) = testSuccess
 isCekEvaluationFailure e = testFailureMsg $ "Expected 'CekEvaluationFailure', got: " ++ show e
+
+-- | Similar to 'isCekEvaluationFailure', but enables us to check for a specific error message in the error.
+isCekEvaluationFailureWithMsg :: (IsProp prop) => (String -> Bool) -> MockChainError -> prop
+isCekEvaluationFailureWithMsg f (MCEValidationError (_, ScriptFailure (EvaluationError msgs _)))
+  | any (f . T.unpack) msgs = testSuccess
+isCekEvaluationFailureWithMsg _ e = testFailureMsg $ "Expected 'CekEvaluationFailure' with specific messages, got: " ++ show e
 
 -- | Ensure that all results produced by the set of traces encoded by the 'StagedMockChain'
 -- satisfy the given predicate. If you wish to build custom predicates

--- a/examples/tests/AuctionSpec.hs
+++ b/examples/tests/AuctionSpec.hs
@@ -15,6 +15,7 @@ import Cooked.Ltl
 import Cooked.MockChain
 import Cooked.Tx.Constraints
 import Data.Default
+import Data.List (isPrefixOf)
 import qualified Data.Map.Strict as M
 import qualified Ledger as L
 import qualified Ledger.Ada as Ada
@@ -171,7 +172,8 @@ attacks =
     "Attacks"
     [ testCase "token duplication" $
         testFailsFrom'
-          isCekEvaluationFailure
+          -- Ensure that the trace fails and gives back an error message satisfying a specific condition
+          (isCekEvaluationFailureWithMsg ("not minting or burning" `isPrefixOf`))
           testInit
           tryDupTokens,
       testCase "datum hijacking" $


### PR DESCRIPTION
This PR adds some finer control over which failure conditions should the trace fail with; in particular, we get to specify we want a trace to fail with at least one error message satisfying a given condition.