### PR TITLE
Patch tx modifier before balancing

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -51,7 +51,7 @@ class (MonadFail m) => MonadBlockChain m where
   --  which inputs to add in case the output-side of the balancing equation is bigger.
   --
   --  The 'TxSkel' receives a 'TxOpts' record with a number of options to customize how validation works.
-  validateTxSkel :: TxSkel -> m Pl.TxId
+  validateTxSkel :: TxSkel -> m Pl.CardanoTx
 
   -- | Returns a list of spendable outputs that belong to a given address and satisfy a given predicate;
   --  Additionally, return the datum present in there if it happened to be a script output. It is important
@@ -89,15 +89,15 @@ class (MonadFail m) => MonadBlockChain m where
   awaitTime :: Pl.POSIXTime -> m Pl.POSIXTime
 
 -- | Calls 'validateTxSkel' with a skeleton that is set with some specific options.
-validateTxConstrOpts :: (MonadBlockChain m, ConstraintsSpec constraints) => TxOpts -> constraints -> m Pl.TxId
+validateTxConstrOpts :: (MonadBlockChain m, ConstraintsSpec constraints) => TxOpts -> constraints -> m Pl.CardanoTx
 validateTxConstrOpts opts = validateTxSkel . txSkelOpts opts
 
 -- | Calls 'validateTx' with the default set of options and no label.
-validateTxConstr :: (MonadBlockChain m, ConstraintsSpec constraints) => constraints -> m Pl.TxId
+validateTxConstr :: (MonadBlockChain m, ConstraintsSpec constraints) => constraints -> m Pl.CardanoTx
 validateTxConstr = validateTxSkel . txSkel
 
 -- | Calls 'validateTxSkel' with the default set of options but passes an arbitrary showable label to it.
-validateTxConstrLbl :: (LabelConstrs lbl, MonadBlockChain m, ConstraintsSpec constraints) => lbl -> constraints -> m Pl.TxId
+validateTxConstrLbl :: (LabelConstrs lbl, MonadBlockChain m, ConstraintsSpec constraints) => lbl -> constraints -> m Pl.CardanoTx
 validateTxConstrLbl lbl = validateTxSkel . txSkelLbl lbl
 
 spendableRef :: (MonadBlockChain m) => Pl.TxOutRef -> m SpendableOut

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -50,7 +50,7 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
   awaitTime = C.awaitTime
 
 datumFromTxOut :: (C.AsContractError e) => Pl.ChainIndexTxOut -> C.Contract w s e (Maybe Pl.Datum)
-datumFromTxOut (Pl.PublicKeyChainIndexTxOut {}) = pure Nothing
+datumFromTxOut Pl.PublicKeyChainIndexTxOut {} = pure Nothing
 datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Right d) _) = pure $ Just d
 -- datum is always present in the nominal case, guaranteed by chain-index
 datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) = C.datumFromHash dh

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -24,9 +24,9 @@ instance (C.AsContractError e) => MonadFail (C.Contract w s e) where
 instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
   validateTxSkel TxSkel {txConstraints, txOpts} = do
     let (lkups, constrs) = toLedgerConstraint @Constraints @Void (toConstraints txConstraints)
-    txId <- Pl.getCardanoTxId <$> C.submitTxConstraintsWith lkups constrs
-    when (awaitTxConfirmed txOpts) $ C.awaitTxConfirmed txId
-    return txId
+    tx <- C.submitTxConstraintsWith lkups constrs
+    when (awaitTxConfirmed txOpts) $ C.awaitTxConfirmed $ Pl.getCardanoTxId tx
+    return tx
 
   utxosSuchThat addr datumPred = do
     allUtxos <- M.toList <$> C.utxosAt addr

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -455,6 +455,8 @@ setFeeAndValidRange bPol w (Pl.UnbalancedTx tx0 reqSigs0 uindex slotRange) = do
       let tx1 = tx {Pl.txFee = fee}
       attemptedTx <- balanceTxFromAux bPol BalCalcFee w tx1
       case Pl.evaluateTransactionFee cUtxoIndex reqSigs attemptedTx of
+        -- necessary to capture script failure for failed cases
+        Left (Left err@(Pl.Phase2, Pl.ScriptFailure _)) -> throwError $ MCEValidationError err
         Left err -> throwError $ FailWith $ "calcFee: " ++ show err
         Right newFee
           | newFee == fee -> pure newFee -- reached fixpoint

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -225,9 +225,9 @@ utxoIndex0 = utxoIndex0From def
 instance (Monad m) => MonadBlockChain (MockChainT m) where
   validateTxSkel skel = do
     (reqSigs, tx) <- generateTx' skel
-    txId <- validateTx' reqSigs tx
+    _ <- validateTx' reqSigs tx
     when (autoSlotIncrease $ txOpts skel) $ modify' (\st -> st {mcstCurrentSlot = mcstCurrentSlot st + 1})
-    return txId
+    return (Pl.EmulatorTx tx)
 
   txOutByRef outref = gets (M.lookup outref . Pl.getIndex . mcstIndex)
 

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -61,7 +61,7 @@ interpret = flip evalStateT [] . interpLtl
 -- * 'StagedMockChain': An AST for 'MonadMockChain' computations
 
 data MockChainBuiltin a where
-  ValidateTxSkel :: TxSkel -> MockChainBuiltin Pl.TxId
+  ValidateTxSkel :: TxSkel -> MockChainBuiltin Pl.CardanoTx
   TxOutByRef :: Pl.TxOutRef -> MockChainBuiltin (Maybe Pl.TxOut)
   GetCurrentSlot :: MockChainBuiltin Pl.Slot
   AwaitSlot :: Pl.Slot -> MockChainBuiltin Pl.Slot

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -343,14 +343,13 @@ data BalanceOutputPolicy
 --  We have a distinguished datatype to be able to provide a little more info on
 --  the show instance.
 data RawModTx
-  =  -- | no effect modifier
+  = -- | no effect modifier
     Id
   | -- | Apply modification on transaction after balancing is performed
     RawModTxAfterBalancing (Pl.Tx -> Pl.Tx)
   | -- | Apply modification on transaction before balancing and transaction fee computation
-    -- are performed
+    --   are performed.
     RawModTxBeforeBalancing (Pl.Tx -> Pl.Tx)
-
 
 -- | only applies modification for RawModTxAfterBalancing
 applyRawModOnBalancedTx :: RawModTx -> Pl.Tx -> Pl.Tx
@@ -363,7 +362,6 @@ applyRawModOnUnbalancedTx :: RawModTx -> Pl.UnbalancedTx -> Pl.UnbalancedTx
 applyRawModOnUnbalancedTx Id tx = tx
 applyRawModOnUnbalancedTx (RawModTxAfterBalancing _) tx = tx
 applyRawModOnUnbalancedTx (RawModTxBeforeBalancing f) tx = (Pl.tx %~ f) tx
-
 
 instance Eq RawModTx where
   Id == Id = True

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -9,8 +9,11 @@
 
 module Cooked.Tx.Constraints.Type where
 
+import Control.Lens
 import Data.Default
 import qualified Ledger as Pl hiding (unspentOutputs)
+import qualified Ledger.Constraints as Pl
+import qualified Ledger.Constraints.OffChain as Pl
 import qualified Ledger.Credential as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, TypedValidator)
 import qualified PlutusTx as Pl
@@ -339,11 +342,28 @@ data BalanceOutputPolicy
 -- | Wraps a function that can be applied to a transaction right before submitting it.
 --  We have a distinguished datatype to be able to provide a little more info on
 --  the show instance.
-data RawModTx = Id | RawModTx (Pl.Tx -> Pl.Tx)
+data RawModTx
+  =  -- | no effect modifier
+    Id
+  | -- | Apply modification on transaction after balancing is performed
+    RawModTxAfterBalancing (Pl.Tx -> Pl.Tx)
+  | -- | Apply modification on transaction before balancing and transaction fee computation
+    -- are performed
+    RawModTxBeforeBalancing (Pl.Tx -> Pl.Tx)
 
-applyRawModTx :: RawModTx -> Pl.Tx -> Pl.Tx
-applyRawModTx Id tx = tx
-applyRawModTx (RawModTx f) tx = f tx
+
+-- | only applies modification for RawModTxAfterBalancing
+applyRawModOnBalancedTx :: RawModTx -> Pl.Tx -> Pl.Tx
+applyRawModOnBalancedTx Id tx = tx
+applyRawModOnBalancedTx (RawModTxAfterBalancing f) tx = f tx
+applyRawModOnBalancedTx (RawModTxBeforeBalancing _) tx = tx
+
+-- | only applies modification for RawModTxBeforeBalancing
+applyRawModOnUnbalancedTx :: RawModTx -> Pl.UnbalancedTx -> Pl.UnbalancedTx
+applyRawModOnUnbalancedTx Id tx = tx
+applyRawModOnUnbalancedTx (RawModTxAfterBalancing _) tx = tx
+applyRawModOnUnbalancedTx (RawModTxBeforeBalancing f) tx = (Pl.tx %~ f) tx
+
 
 instance Eq RawModTx where
   Id == Id = True
@@ -351,7 +371,8 @@ instance Eq RawModTx where
 
 instance Show RawModTx where
   show Id = "Id"
-  show (RawModTx _) = "RawModTx"
+  show (RawModTxAfterBalancing _) = "RawModTxAfterBalancing"
+  show (RawModTxBeforeBalancing _) = "RawModTxBeforeBalancing"
 
 -- | Specifies how to select the collateral input
 data Collateral


### PR DESCRIPTION
This PR introduces the following modifications:

- Update each `validateTx` functions to return `CardanoTx` instead of `TxId`
- Update `RawModTx ` data type to allow the modification of a transaction before balancing and transaction fee computation are performed
- Update `calcFee` function to properly throw `MCEValidationError` when a script failure is witnessed during transaction fee computation.

