### PR TITLE
Ltl cleanup

### DIFF
--- a/cooked-validators/src/Cooked/Ltl.hs
+++ b/cooked-validators/src/Cooked/Ltl.hs
@@ -265,7 +265,7 @@ interpLtl (Instr (Builtin b) f) = interpBuiltin b >>= interpLtl . f
 
 -- * Convenience functions
 
--- Users of this library should never use 'StartLtl' and 'StopLtl'
+-- Users of this module should never use 'StartLtl' and 'StopLtl'
 -- explicitly. Here are some safe-to-use functions that should be used
 -- instead. Most functions like the ones below should be defined for the class
 -- 'MonadModal' because there might be other possibilities to equip a monad with

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -17,6 +17,8 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Trans.Control
 import Control.Monad.Trans.Writer
+import Cooked.Attack
+import Cooked.Ltl
 import Cooked.MockChain.UtxoPredicate
 import Cooked.MockChain.Wallet
 import Cooked.Tx.Constraints
@@ -213,6 +215,11 @@ as ma w = signingWith (w NE.:| []) ma
 -- | Flipped version of 'as'
 signs :: (MonadMockChain m) => Wallet -> m a -> m a
 signs = flip as
+
+-- ** Modalities
+
+-- | A modal mock chain is a mock chain that allows us to use LTL modifications with 'Attack's
+type MonadModalMockChain m = (MonadMockChain m, MonadModal m, Modification m ~ Attack)
 
 -- ** Deriving further 'MonadBlockChain' instances
 

--- a/cooked-validators/src/Cooked/Tx/Constraints/Optics.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Optics.hs
@@ -17,12 +17,14 @@ import Optics.Core
 -- A few remarks:
 
 -- There's a recurring pattern here to work around the existential type
--- variables in the constructors in 'Cooked.Tx.Constraints.Type': Define a type
+-- variables in the constructors in "Cooked.Tx.Constraints.Type": Define a type
 -- that corresponds to the image of the constructor an then use that type as the
--- target of the optics.
+-- target of the optics. So, if you find a single-constructor type in this
+-- module that you would like some explanation for, look at the comments for the
+-- types 'MiscConstraint' and 'OutConstraint' in "Cooked.Tx.Constraints.Type".
 
 -- The naming convention for optics in this module is as follows: Lenses have
--- names that end in 'I', Prisms end in 'P', traversals in 'T', affine
+-- names that end in 'L', Prisms end in 'P', traversals in 'T', affine
 -- traversals in 'AT', isos in 'I'. There are not yet and optics of other types
 -- here.
 
@@ -229,6 +231,7 @@ flattenValueI =
     (map (\(cSymbol, tName, amount) -> (L.assetClass cSymbol tName, amount)) . L.flattenValue)
     (foldl (\v (ac, amount) -> v <> L.assetClassValue ac amount) mempty)
 
+-- | The portion of a 'L.Value' that is not Ada.
 nonAdaValue :: L.Value -> L.Value
 nonAdaValue = over flattenValueI (map $ \(ac, i) -> if ac == adaAssetClass then (ac, 0) else (ac, i))
   where

--- a/cooked-validators/tests/Cooked/AttackSpec.hs
+++ b/cooked-validators/tests/Cooked/AttackSpec.hs
@@ -48,7 +48,6 @@ mkCarefulPolicy tName allowedAmount _ ctx
   | otherwise = Pl.trace "tried to mint wrong amount" False
   where
     txi = L.scriptContextTxInfo ctx
-    L.Minting me = L.scriptContextPurpose ctx
 
     amnt :: Maybe Integer
     amnt = case L.flattenValue (L.txInfoMint txi) of

--- a/cooked-validators/tests/Cooked/LtlSpec.hs
+++ b/cooked-validators/tests/Cooked/LtlSpec.hs
@@ -24,7 +24,7 @@ instance {-# OVERLAPS #-} Semigroup TestModification where
 instance {-# OVERLAPS #-} Monoid TestModification where
   mempty = id
 
-instance (MonadPlus m, MonadFail m) => InterpLtl TestModification TestBuiltin (WriterT [Integer] m) where
+instance MonadPlus m => InterpLtl TestModification TestBuiltin (WriterT [Integer] m) where
   interpBuiltin GetInteger = return 42
   interpBuiltin (EmitInteger i) =
     get
@@ -45,8 +45,7 @@ nonemptyTraces :: [Staged (LtlOp TestModification TestBuiltin) ()]
 nonemptyTraces =
   [ getInteger >>= emitInteger,
     emitInteger 1 >> emitInteger 2,
-    emitInteger 1 >> getInteger >>= emitInteger >> emitInteger 2,
-    emitInteger 1 >> emitInteger 2 <|> emitInteger 3 >> emitInteger 4
+    emitInteger 1 >> getInteger >>= emitInteger >> emitInteger 2
   ]
 
 emptyTraces :: [Staged (LtlOp TestModification TestBuiltin) ()]

--- a/examples/tests/AuctionSpec.hs
+++ b/examples/tests/AuctionSpec.hs
@@ -144,7 +144,7 @@ failingSingle =
 -- | Token duplication attack: Whenever we see a transaction that mints
 -- something, try to mint one more token and pay it to the attacker. This should
 -- be ruled out by the minting policy of the thread token.
-tryDupTokens :: StagedMockChain ()
+tryDupTokens :: (Alternative m, MonadModalMockChain m) => m ()
 tryDupTokens =
   somewhere
     ( dupTokenAttack
@@ -153,7 +153,7 @@ tryDupTokens =
     )
     (noBids <|> oneBid <|> twoBids)
 
-tryDatumHijack :: StagedMockChain ()
+tryDatumHijack :: (Alternative m, MonadModalMockChain m) => m ()
 tryDatumHijack =
   somewhere
     ( datumHijackingAttack @A.Auction

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -364,7 +364,7 @@ datumHijackingTrace' =
       def
       datumHijacking'
 
-datumHijacking' :: StagedMockChain ()
+datumHijacking' :: MonadModalMockChain m => m ()
 datumHijacking' =
   somewhere
     ( Cooked.datumHijackingAttack @PMultiSig


### PR DESCRIPTION
In the light of the upcoming blog post about the LTL modalities, here are a few comments I added to the relevant modules. 

This PR also restores `MonadModal`, which I had overzealously deleted, and thereby closes #124.