### PR TITLE
Repair wrong assumption in the dupTokenAttack

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/UtxoState.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoState.hs
@@ -201,7 +201,10 @@ prettyCurrencyAndAmount symbol =
     prettySymbol = PP.pretty . take 7 . show
 
     prettySpacedNumber :: Integer -> Doc ann
-    prettySpacedNumber = psnTerm "" 0
+    prettySpacedNumber i =
+      if i >= 0
+        then psnTerm "" 0 i
+        else "-" <> psnTerm "" 0 (- i)
       where
         psnTerm :: Doc ann -> Integer -> Integer -> Doc ann
         psnTerm acc _ 0 = acc


### PR DESCRIPTION
The token duplication attack implemented by `dupTokenAttack` made the assumption that all non-Ada values in the `OutConstraints` of the transaction to be modified were also minted on that very same transaction. That's not true generally, of course. This PR 
- makes it so that the attacker in `dupTokenAttack` is paid exactly those tokens that weren't minted on the unmodified transaction but are minted on the modified transaction, (This means that if the transaction was unbalanced before the modification, it will remain so after the transaction. The old `dupTokenAttack` simply paid the whole surplus to the attacker, thereby balancing the transaction.)
- changes the order of outputs of the modified transaction: The attacker's output is now the last (it was the first before), and
- enables pretty-printing of values with negative parts. This was needed to have informative error messages on the test that checks the noew behaviour of the `dupTokenAttack`. Before, a negative entry in a value sent the pretty printer into a loop.