### PR TITLE
Depend on latest `plutus-apps` main branch

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,14 @@
+packages:
+  cooked-validators
+  examples
+
 package cardano-crypto-praos
   flags: -external-libsodium-vrf
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus-apps.git
-  -- This is a commit from June 28
-  tag: a9763f89f65ec4c17b11a40de37a4824c3a7a201
+  tag: 02ae267c02c09bbec4e2ba0d4b9b4757f08efb2d
   subdir:
     freer-extras
     plutus-chain-index
@@ -16,18 +19,14 @@ source-repository-package
     plutus-ledger
     plutus-ledger-constraints
     plutus-script-utils
+    plutus-streaming
     plutus-use-cases
-    quickcheck-dynamic
     playground-common
 
 -- Everything below this point has been copied from plutus-apps' cabal.project
 
 -- Bump this if you need newer packages.
-index-state: 2022-05-18T00:00:00Z
-
-packages:
-  cooked-validators
-  examples
+index-state: 2022-02-22T20:47:03Z
 
 -- We never, ever, want this.
 write-ghc-environment-files: never
@@ -40,12 +39,27 @@ benchmarks: true
 test-show-details: streaming
 
 allow-newer:
-    *:aeson
-  , size-based:template-haskell
+  size-based:template-haskell
 
 constraints:
-     aeson >= 2,
-     hedgehog >= 1.1
+     -- Because later versions of hedgehog introduce a change which break 'cardano-ledger':
+     -- Test/Cardano/Chain/Delegation/Model.hs:91:41: error:
+     --   • Could not deduce (TraversableB SignalSDELEG)
+     -- TODO: Try to remove on next `cardano-node` version upgrade.
+     hedgehog >= 1.0.2 && < 1.1
+
+-- The plugin will typically fail when producing Haddock documentation. However,
+-- in this instance you can simply tell it to defer any errors to runtime (which
+-- will never happen since you're building documentation).
+--
+-- So, any package using 'PlutusTx.compile' in the code for which you need to
+-- generate haddock documentation should use the following 'haddock-options'.
+package plutus-ledger
+  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+package plutus-script-utils
+  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+package plutus-contract
+  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
 
 -- These packages appear in our dependency tree and are very slow to build.
 -- Empirically, turning off optimization shaves off ~50% build time.
@@ -83,7 +97,7 @@ package cardano-wallet-core-integration
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: 066f7002aac5a0efc20e49643fea45454f226caa
+  tag: 46f994e216a1f8b36fe4669b47b2a7011b0e153c
   subdir:
     contra-tracer
     iohk-monitoring
@@ -100,7 +114,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus
-  tag: d24a7540e4659b57ce2ab25dadb968991e232191
+  tag: 6d9ac7c2f89363d574dbc10be5c2db4b661c9a43
   subdir:
     plutus-core
     plutus-ledger-api
@@ -143,7 +157,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-wallet
-  tag: 0cdd1b72a16b2f287b5f1bf137b5eba15bc7f300
+  tag: f6d4db733c4e47ee11683c343b440552f59beff7
   subdir:
     lib/cli
     lib/core
@@ -157,13 +171,11 @@ source-repository-package
     lib/text-class
 
 -- Should follow cardano-wallet.
--- More precisally, this should be a version compatible with the current
--- Cardano mainnet (>=1.35).
--- Current version is dated to 2022/05/24.
+-- Currently tracking v1.34.1.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-node
-  tag: 95c3692cfbd4cdb82071495d771b23e51840fb0e
+  tag: 2b1d18c6c7b7142d9eebfec34da48840ed4409b6
   subdir:
     cardano-api
     cardano-cli
@@ -178,7 +190,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-config
-  tag: 1646e9167fab36c0bff82317743b96efa2d3adaa
+  tag: e9de7a2cf70796f6ff26eac9f9540184ded0e4e6
+  --sha256: 1wm1c99r5zvz22pdl8nhkp13falvqmj8dgkm8fxskwa9ydqz01ld
 
 -- Using a fork until our patches can be merged upstream
 source-repository-package
@@ -190,16 +203,16 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/hedgehog-extras
-  tag: 967d79533c21e33387d0227a5f6cc185203fe658
+  tag: edf6945007177a638fbeb8802397f3a6f4e47c14
+  --sha256: 0wc7qzkc7j4ns2rz562h6qrx2f8xyq7yjcb7zidnj7f6j0pcd0i9
 
 -- Should follow cardano-wallet.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger
-  tag: e290bf8d0ea272a51e9acd10adc96b4e12e00d37
+  tag: 1a9ec4ae9e0b09d54e49b2a40c4ead37edadcce5
   subdir:
     eras/alonzo/impl
-    eras/babbage/impl
     eras/byron/chain/executable-spec
     eras/byron/crypto
     eras/byron/crypto/test
@@ -213,7 +226,7 @@ source-repository-package
     libs/cardano-ledger-core
     libs/cardano-ledger-pretty
     libs/cardano-protocol-tpraos
-    libs/vector-map
+    libs/compact-map
     libs/non-integral
     libs/set-algebra
     libs/small-steps
@@ -223,8 +236,10 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 04245dbd69387da98d3a37de9f400965e922bb0e
+  tag: 4fac197b6f0d2ff60dc3486c593b68dc00969fbf
   subdir:
+    io-classes
+    io-sim
     monoidal-synchronisation
     network-mux
     ntp-client
@@ -236,40 +251,22 @@ source-repository-package
     ouroboros-network
     ouroboros-network-framework
     ouroboros-network-testing
-
--- Should follow cardano-node.
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/io-sim
-  tag: 57e888b1894829056cb00b7b5785fdf6a74c3271
-  subdir:
-    io-classes
-    io-sim
     strict-stm
-
--- Should follow cardano-node.
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/typed-protocols
-  tag: 181601bc3d9e9d21a671ce01e0b481348b3ca104
-  subdir:
     typed-protocols
     typed-protocols-cborg
     typed-protocols-examples
-
 
 -- Should follow cardano-wallet.
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 631cb6cf1fa01ab346233b610a38b3b4cba6e6ab
+  tag: 41545ba3ac6b3095966316a99883d678b5ab8da8
   subdir:
     base-deriving-via
     binary
     binary/test
     cardano-crypto-class
     cardano-crypto-praos
-    cardano-crypto-tests
     measures
     orphans-deriving-via
     slotting
@@ -294,7 +291,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-addresses
-  tag: b9f424cc64459a95a2f190a1839ec9bc94cc778c
+  tag: 71006f9eb956b0004022e80aadd4ad50d837b621
   subdir:
     command-line
     core
@@ -311,25 +308,13 @@ source-repository-package
   location: https://github.com/input-output-hk/Win32-network
   tag: 3825d3abf75f83f406c1f7161883c438dac7277d
 
--- Until https://github.com/tibbe/ekg-json/pull/12 gets merged with aeson2 support
-source-repository-package
-  type: git
-  location: https://github.com/vshabanov/ekg-json
-  tag: 00ebe7211c981686e65730b7144fbf5350462608
-
--- TODO This is a compatibility shim to make it easier for our library dependencies to
--- be compatible with both aeson 1 & 2.  Once downstream projects are all upgraded to
--- work with aeson-2, library dependencies will need to be updated to no longer use
--- this compatibility shim and have bounds to indicate they work with aeson-2 only.
--- After this, the dependency to hw-aeson can be dropped.
-source-repository-package
-    type: git
-    location: https://github.com/haskell-works/hw-aeson
-    tag: d99d2f3e39a287607418ae605b132a3deb2b753f
-    --sha256: 1vxqcwjg9q37wbwi27y9ba5163lzfz51f1swbi0rp681yg63zvn4
-
 -- Temporary indexing
 source-repository-package
   type: git
   location: https://github.com/raduom/hysterical-screams
-  tag: f3bbd38a19f99de5c8ddc650c94330b2d09a865b
+  tag: 4c523469e9efd3f0d10d17da3304923b7b0e0674
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/quickcheck-dynamic
+  tag: c272906361471d684440f76c297e29ab760f6a1e

--- a/cooked-validators/src/Cooked/Attack.hs
+++ b/cooked-validators/src/Cooked/Attack.hs
@@ -15,6 +15,7 @@ import Cooked.Tx.Constraints
 import Cooked.Tx.Constraints.Optics
 import Data.Maybe
 import qualified Ledger as L hiding (validatorHash)
+import qualified Ledger.Scripts as L
 import qualified Ledger.Typed.Scripts as L
 import Optics.Core
 import qualified PlutusTx as Pl

--- a/cooked-validators/src/Cooked/Currencies.hs
+++ b/cooked-validators/src/Cooked/Currencies.hs
@@ -19,6 +19,7 @@ import qualified Ledger.Typed.Scripts as Scripts
 import qualified Ledger.Value as Pl
 import qualified Ledger.Value as Value
 import qualified Plutus.Script.Utils.V1.Scripts as Validation
+import qualified Plutus.V1.Ledger.Scripts as V1
 import qualified PlutusTx
 import qualified PlutusTx.Builtins.Class as Pl
 import PlutusTx.Prelude hiding (Applicative (..))
@@ -79,7 +80,7 @@ mkQuickCurrencyPolicy _ _ = True
 
 quickCurrencyPolicy :: Scripts.MintingPolicy
 quickCurrencyPolicy =
-  Ledger.mkMintingPolicyScript
+  V1.mkMintingPolicyScript
     $$(PlutusTx.compile [||Scripts.mkUntypedMintingPolicy mkQuickCurrencyPolicy||])
 
 quickCurrencySymbol :: Value.CurrencySymbol
@@ -91,7 +92,7 @@ mkPermanentCurrencyPolicy _ _ = False
 
 permanentCurrencyPolicy :: Scripts.MintingPolicy
 permanentCurrencyPolicy =
-  Ledger.mkMintingPolicyScript
+  V1.mkMintingPolicyScript
     $$(PlutusTx.compile [||Scripts.mkUntypedMintingPolicy mkPermanentCurrencyPolicy||])
 
 permanentCurrencySymbol :: Value.CurrencySymbol

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -14,6 +14,7 @@ import Data.Maybe
 import qualified Data.Text as T
 import Data.Void
 import qualified Ledger as Pl
+import qualified Ledger.Scripts as Pl
 import qualified Plutus.Contract as C
 import qualified PlutusTx as Pl
 
@@ -42,7 +43,7 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
 
   txOutByRef ref = fmap Pl.toTxOut <$> C.unspentTxOutFromRef ref
 
-  ownPaymentPubKeyHash = fmap Pl.unPaymentPubKeyHash C.ownPaymentPubKeyHash
+  ownPaymentPubKeyHash = fmap Pl.unPaymentPubKeyHash C.ownFirstPaymentPubKeyHash
 
   currentSlot = C.currentSlot
   currentTime = C.currentTime

--- a/cooked-validators/src/Cooked/MockChain/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Testing.hs
@@ -14,8 +14,8 @@ import Cooked.MockChain.Wallet
 import Data.Default
 import qualified Data.Text as T
 import Debug.Trace
-import Ledger (ScriptError (EvaluationError))
 import Ledger.Index (ValidationError (ScriptFailure))
+import Ledger.Scripts (ScriptError (EvaluationError))
 import qualified Test.QuickCheck as QC
 import qualified Test.Tasty.HUnit as HU
 

--- a/cooked-validators/src/Cooked/MockChain/UtxoState.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoState.hs
@@ -13,6 +13,7 @@ import Data.Maybe (catMaybes, mapMaybe)
 import qualified Ledger as Pl
 import qualified Ledger.Ada as Ada
 import qualified Ledger.Credential as Pl
+import qualified Ledger.Scripts as Pl
 import qualified Ledger.Value as Pl
 import qualified PlutusTx.AssocMap as Pl
 import qualified PlutusTx.Numeric as Pl

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -21,7 +21,9 @@ import qualified Ledger as Pl hiding (singleton, unspentOutputs)
 import qualified Ledger.Constraints as Pl
 import qualified Ledger.Constraints.TxConstraints as Pl
 import qualified Ledger.Credential as Pl
+import qualified Ledger.Scripts as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, validatorScript)
+import qualified Plutus.Script.Utils.V1.Scripts as Pl
 import qualified PlutusTx as Pl
 
 -- * Converting 'Constraint's to 'Pl.ScriptLookups', 'Pl.TxConstraints'

--- a/cooked-validators/src/Cooked/Tx/Constraints/Optics.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Optics.hs
@@ -11,7 +11,7 @@ import Cooked.Tx.Constraints.Type
 import qualified Ledger as L
 import qualified Ledger.Ada as L
 import qualified Ledger.Typed.Scripts as L
-import qualified Ledger.Value as L hiding (adaSymbol, adaToken)
+import qualified Ledger.Value as L
 import Optics.Core
 
 -- A few remarks:

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -12,7 +12,9 @@ import Data.Char
 import Data.Default
 import Data.Maybe (catMaybes, mapMaybe)
 import qualified Ledger as Pl hiding (unspentOutputs)
+import qualified Ledger.Scripts as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, TypedValidator, validatorScript)
+import qualified Plutus.Script.Utils.V1.Scripts as Pl
 import Prettyprinter (Doc, (<+>))
 import qualified Prettyprinter as PP
 
@@ -89,7 +91,7 @@ prettyTxOut :: Pl.TxOut -> (Doc ann, Maybe (Doc ann))
 prettyTxOut tout = (prettyAddressTypeAndHash $ Pl.txOutAddress tout, mPrettyValue $ Pl.txOutValue tout)
 
 prettyTypedValidator :: Pl.TypedValidator a -> Doc ann
-prettyTypedValidator = prettyAddressTypeAndHash . Pl.scriptHashAddress . Pl.validatorHash . Pl.validatorScript
+prettyTypedValidator = prettyAddressTypeAndHash . Pl.scriptAddress . Pl.validatorScript
 
 prettyDatumVal ::
   (Show (Pl.DatumType a)) =>

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -15,6 +15,7 @@ import qualified Ledger as Pl hiding (unspentOutputs)
 import qualified Ledger.Constraints as Pl
 import qualified Ledger.Constraints.OffChain as Pl
 import qualified Ledger.Credential as Pl
+import qualified Ledger.Scripts as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, RedeemerType, TypedValidator)
 import qualified PlutusTx as Pl
 import qualified PlutusTx.Eq as Pl


### PR DESCRIPTION
We used to depend on a commit of `plutus-apps` that was force-pushed out of existence, which means cabal has trouble fetching it. This PR moves to depend on `plutus-apps` main branch.