### PR TITLE
Add shared system libraries in LD_LIBRARY_PATH

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -57,4 +57,6 @@ in {
   # Besides what's needed for building, we also want our instance of the
   # the haskell-language-server
   dev-deps = [ custom-hls ];
+
+  LD_LIBRARY_PATH = with rawpkgs; "${zlib}/lib:${lzma.out}/lib";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -3,4 +3,7 @@ let
   ourpkgs = import ./nix/packages.nix {};
 in pkgs.mkShell {
     buildInputs = ourpkgs.build-deps ++ ourpkgs.dev-deps;
+
+    # Ensure that libz.so and liblzma.so are available to TH splices, cabal repl, etc.
+    LD_LIBRARY_PATH = ourpkgs.LD_LIBRARY_PATH;
 }


### PR DESCRIPTION
This fixes warnings about missing libraries issued by the TH interpreter.

```
<no location info>: warning: [-Wmissed-extra-shared-lib]
    libz.so: cannot open shared object file: No such file or directory
    It's OK if you don't want to use symbols from it directly.
    (the package DLL is loaded by the system linker
     which manages dependencies by itself).
```