### PR TITLE
Add .gitattributes to hide *.pir files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The *.pir files are not parrot intermediate representation, as the linguist
+# thought, but plutus intermetidate representation, and they should be ignored
+# on the languages pane. This also hides diffs over *.pir files.
+*.pir linguist-generated


### PR DESCRIPTION
If you look at our languages pane, the github linguist thinks that the greatest part of this repo is made up of parrot intermediate representation files. That's obviously wrong and due to it misidentifying Plutus intermediate representation files. These should be ignored (in the languages pane, in diffs, and line count), and the .gitattributes in thist commit ensures that.