### PR TITLE
Remove datum from `SpendsScript` with no feature loss

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -136,13 +136,11 @@ spOutResolveDatum spOut = return spOut
 -- interest right from the start and avoid querying the chain for them
 -- afterwards using "utxosSuchThat" functions.
 spOutsFromCardanoTx :: MonadBlockChain m => Pl.CardanoTx -> m [SpendableOut]
-spOutsFromCardanoTx cardanoTx = forM (Pl.getCardanoTxOutRefs cardanoTx) go
-  where
-    go :: MonadBlockChain m => (Pl.TxOut, Pl.TxOutRef) -> m SpendableOut
-    go (txOut, txOutRef) =
-      case Pl.fromTxOut txOut of
-        Just chainIndexTxOut -> spOutResolveDatum (txOutRef, chainIndexTxOut)
-        Nothing -> fail "could not extract ChainIndexTxOut"
+spOutsFromCardanoTx cardanoTx = forM (Pl.getCardanoTxOutRefs cardanoTx) $
+  \(txOut, txOutRef) ->
+    case Pl.fromTxOut txOut of
+      Just chainIndexTxOut -> spOutResolveDatum (txOutRef, chainIndexTxOut)
+      Nothing -> fail "could not extract ChainIndexTxOut"
 
 -- | Select public-key UTxOs that might contain some datum but no staking address.
 -- This is just a simpler variant of 'utxosSuchThat'. If you care about staking credentials

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -114,6 +114,14 @@ spendableRef txORef = do
 -- constraints, this results in a runtime error. This function modifies the
 -- value to replace the datum hash by the datum by looking it up in the state
 -- of the block chain.
+--
+-- Outputs obtained from a "CardanoTx" (using "getCardanoTxOutRefs") have datum
+-- hashes instead of datums. If you want to use them in spend constraints, you
+-- first have to preprocess them with this function.
+--
+-- As a user though, when writing endpoints and traces, you will prefer to use
+-- the "spOutsFromCardanoTx" helper if you need to extract a "SpendableOut"
+-- from a "CardanoTx" to use it in a spend constraint.
 spOutResolveDatum ::
   MonadBlockChain m =>
   SpendableOut ->

--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -50,8 +50,7 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
   awaitSlot = C.awaitSlot
   awaitTime = C.awaitTime
 
-datumFromTxOut :: (C.AsContractError e) => Pl.ChainIndexTxOut -> C.Contract w s e (Maybe Pl.Datum)
-datumFromTxOut Pl.PublicKeyChainIndexTxOut {} = pure Nothing
-datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Right d) _) = pure $ Just d
--- datum is always present in the nominal case, guaranteed by chain-index
-datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) = C.datumFromHash dh
+  datumFromTxOut Pl.PublicKeyChainIndexTxOut {} = pure Nothing
+  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Right d) _) = pure $ Just d
+  -- datum is always present in the nominal case, guaranteed by chain-index
+  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) = C.datumFromHash dh

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -240,9 +240,8 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
   datumFromTxOut Pl.PublicKeyChainIndexTxOut {} = pure Nothing
   datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Right d) _) = pure $ Just d
   -- datum is always present in the nominal case, guaranteed by chain-index
-  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) = do
-    MockChainSt {mcstDatums} <- get
-    return $ M.lookup dh mcstDatums
+  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) =
+    M.lookup dh <$> gets mcstDatums
 
   currentSlot = gets mcstCurrentSlot
 

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -237,6 +237,13 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
 
   utxosSuchThat = utxosSuchThat'
 
+  datumFromTxOut Pl.PublicKeyChainIndexTxOut {} = pure Nothing
+  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Right d) _) = pure $ Just d
+  -- datum is always present in the nominal case, guaranteed by chain-index
+  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) = do
+    MockChainSt {mcstDatums} <- get
+    return $ M.lookup dh mcstDatums
+
   currentSlot = gets mcstCurrentSlot
 
   currentTime = asks (Pl.slotToEndPOSIXTime . Pl.pSlotConfig . mceParams) <*> gets mcstCurrentSlot

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -53,11 +53,11 @@ class ToLedgerConstraint constraint where
   toLedgerConstraint :: constraint -> LedgerConstraint a
 
 instance ToLedgerConstraint MiscConstraint where
-  extractDatumStr (SpendsScript _validator _redeemer (_out, datum)) =
+  extractDatumStr (SpendsScript _ _ (_, Pl.ScriptChainIndexTxOut _ _ (Right datum) _)) =
     M.singleton (Pl.datumHash . Pl.Datum $ Pl.toBuiltinData datum) (show datum)
   extractDatumStr _ = M.empty
 
-  toLedgerConstraint (SpendsScript v r ((oref, o), _a)) = (lkups, constr)
+  toLedgerConstraint (SpendsScript v r (oref, o)) = (lkups, constr)
     where
       lkups =
         Pl.otherScript (Pl.validatorScript v)

--- a/cooked-validators/src/Cooked/Tx/Constraints/Optics.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Optics.hs
@@ -92,7 +92,7 @@ data SpendsScriptConstraint where
     (SpendsConstrs a) =>
     L.TypedValidator a ->
     L.RedeemerType a ->
-    (SpendableOut, L.DatumType a) ->
+    SpendableOut ->
     SpendsScriptConstraint
 
 spendsScriptConstraintP :: Prism' MiscConstraint SpendsScriptConstraint
@@ -113,10 +113,10 @@ spendableOutL :: Lens' SpendsScriptConstraint SpendableOut
 spendableOutL =
   lens
     ( \case
-        SpendsScriptConstraint _ _ (o, _) -> o
+        SpendsScriptConstraint _ _ o -> o
     )
     ( \c o -> case c of
-        SpendsScriptConstraint v r (_, d) -> SpendsScriptConstraint v r (o, d)
+        SpendsScriptConstraint v r _ -> SpendsScriptConstraint v r o
     )
 
 spendsPKConstraintP :: Prism' MiscConstraint SpendableOut

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cooked.Tx.Constraints.Pretty where
 
@@ -15,6 +16,7 @@ import qualified Ledger as Pl hiding (unspentOutputs)
 import qualified Ledger.Scripts as Pl
 import qualified Ledger.Typed.Scripts as Pl (DatumType, TypedValidator, validatorScript)
 import qualified Plutus.Script.Utils.V1.Scripts as Pl
+import qualified PlutusTx.IsData.Class as Pl
 import Prettyprinter (Doc, (<+>))
 import qualified Prettyprinter as PP
 
@@ -66,11 +68,11 @@ prettyMiscConstraint (Mints mr policies val) =
         Just $ "Policies:" <+> PP.list (map prettyMintingPolicy policies)
       ]
 prettyMiscConstraint (SignedBy pkhs) = prettyEnum "SignedBy" "-" $ prettyWallet <$> pkhs
-prettyMiscConstraint (SpendsScript val red outdat) =
+prettyMiscConstraint (SpendsScript val red spOut) =
   prettyEnum
     ("SpendsScript" <+> prettyTypedValidator val)
     "-"
-    ["Redeemer:" <+> PP.viaShow red, prettyOutputDatum val outdat]
+    ["Redeemer:" <+> PP.viaShow red, prettyScriptOutputDatum val spOut]
 prettyMiscConstraint _ = "<constraint without pretty def>"
 
 prettyHash :: (Show a) => a -> Doc ann
@@ -79,13 +81,28 @@ prettyHash = PP.pretty . take 6 . show
 prettyMintingPolicy :: Pl.MintingPolicy -> Doc ann
 prettyMintingPolicy = prettyHash . Pl.mintingPolicyHash
 
-prettyOutputDatum :: (Show (Pl.DatumType a)) => Pl.TypedValidator a -> (SpendableOut, Pl.DatumType a) -> Doc ann
-prettyOutputDatum _ (out, dat) =
-  let (ppAddr, mppVal) = prettyTxOut $ Pl.toTxOut $ snd out
+prettyScriptOutputDatum ::
+  forall a ann.
+  (Pl.UnsafeFromData (Pl.DatumType a), Show (Pl.DatumType a)) =>
+  Pl.TypedValidator a ->
+  SpendableOut ->
+  Doc ann
+prettyScriptOutputDatum _ (_, chainIndexTxOut) =
+  let (ppAddr, mppVal) = prettyTxOut $ Pl.toTxOut chainIndexTxOut
    in PP.align $
         PP.vsep $
           catMaybes
-            [Just $ "Output" <+> "at" <+> ppAddr, mppVal, Just $ "Datum:" <+> prettyDatum dat]
+            [ Just $ "Output" <+> "at" <+> ppAddr,
+              mppVal,
+              case chainIndexTxOut of
+                Pl.ScriptChainIndexTxOut _ _ (Right datum) _ ->
+                  let typedDatum :: Pl.DatumType a
+                      typedDatum = Pl.unsafeFromBuiltinData (Pl.getDatum datum)
+                   in Just $ "Datum:" <+> prettyDatum typedDatum
+                Pl.ScriptChainIndexTxOut _ _ (Left datumHash) _ ->
+                  Just $ "Datum hash:" <+> prettyHash datumHash
+                _ -> error "Not a script output"
+            ]
 
 prettyTxOut :: Pl.TxOut -> (Doc ann, Maybe (Doc ann))
 prettyTxOut tout = (prettyAddressTypeAndHash $ Pl.txOutAddress tout, mPrettyValue $ Pl.txOutValue tout)

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -102,6 +102,15 @@ data MiscConstraint where
     (SpendsConstrs a) =>
     Pl.TypedValidator a ->
     Pl.RedeemerType a ->
+    -- | Utxo to spend.
+    -- WARNING: A "SpendableOut" contains a "ChainIndexTxOut" that contains
+    -- either a datum or its hash. Spending a script "SpendableOut" which does
+    -- not contain the datum explicitly causes the generated transaction to
+    -- fail (datum not found).
+    --
+    -- This does not occur in practice when spending UTxOs obtained by
+    -- searching through the chain with "scriptUtxosSuchThat", or those
+    -- extracted from "CardanoTx" by using "spOutsFromCardanoTx".
     SpendableOut ->
     MiscConstraint
   -- | Ensure that a 'Pl.PubKeyHash' spends a specific UTxO. The hash is not an

--- a/cooked-validators/src/Example.hs
+++ b/cooked-validators/src/Example.hs
@@ -1,19 +1,112 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module Example where
 
 import Control.Monad
 import Cooked.MockChain
 import Cooked.Tx.Constraints
+import qualified Ledger as Pl
 import qualified Ledger.Ada as Pl
+import qualified Ledger.Typed.Scripts as Pl
+import qualified PlutusTx as Pl
+import qualified PlutusTx.Prelude as Pl
+import qualified Test.Tasty as Tasty
+import qualified Test.Tasty.HUnit as Tasty
 
--- * MockChain Example
+-- Toy example: the "AContract" with "ADatum" and "ARedeemer"
+--
+-- Its validator succeeds when redeeming with "ARedeemer1" and fails with
+-- "ARedeemer2".
 
--- | Start from the initial 'UtxoIndex', where each known 'wallet's have the
--- same amount of Ada, then transfers 4200 lovelace from wallet 1 to wallet 2.
--- This transfers from wallet 1 because that's the default signer of transactions
--- if nothing else is specified.
-example :: Either MockChainError ((), UtxoState)
-example = runMockChain $ do
+data ADatum = ADatum deriving (Show)
+
+instance Pl.Eq ADatum where
+  ADatum == ADatum = True
+
+Pl.makeLift ''ADatum
+Pl.unstableMakeIsData ''ADatum
+
+data ARedeemer = ARedeemer1 | ARedeemer2 deriving (Show)
+
+instance Pl.Eq ARedeemer where
+  ARedeemer1 == ARedeemer1 = True
+  ARedeemer2 == ARedeemer2 = True
+  _ == _ = False
+
+Pl.makeLift ''ARedeemer
+Pl.unstableMakeIsData ''ARedeemer
+
+data AContract
+
+instance Pl.ValidatorTypes AContract where
+  type DatumType AContract = ADatum
+  type RedeemerType AContract = ARedeemer
+
+{-# INLINEABLE mkAValidator #-}
+mkAValidator :: ADatum -> ARedeemer -> Pl.ScriptContext -> Bool
+mkAValidator _ ARedeemer1 _ = True
+mkAValidator _ ARedeemer2 _ = False
+
+aValidator :: Pl.TypedValidator AContract
+aValidator =
+  Pl.mkTypedValidator @AContract
+    $$(Pl.compile [||mkAValidator||])
+    $$(Pl.compile [||wrap||])
+  where
+    wrap = Pl.mkUntypedValidator @ADatum @ARedeemer
+
+-- Example endpoints
+
+payEndpoint :: MonadBlockChain m => Integer -> Integer -> m SpendableOut
+payEndpoint amountToPk amountToScript = do
+  cardanoTx <-
+    validateTxSkel $
+      txSkel
+        [ paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf amountToPk),
+          PaysScript aValidator ADatum (Pl.lovelaceValueOf amountToScript)
+        ]
+  spOuts <- spOutsFromCardanoTx cardanoTx
+  -- We return the second (index 1) utxo from the transaction outputs:
+  -- the script output
+  return (spOuts !! 1)
+
+spendEndpoint :: MonadBlockChain m => SpendableOut -> ARedeemer -> m ()
+spendEndpoint spOut redeemer =
   void $
     validateTxSkel $
       txSkel
-        [paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf 4200)]
+        [SpendsScript aValidator redeemer spOut]
+
+-- Example traces, one success, one failure
+
+example1 :: MonadMockChain m => m ()
+example1 = do
+  spOut <- payEndpoint 42_000_000 5_000_000
+  spendEndpoint spOut ARedeemer1
+
+example2 :: MonadMockChain m => m ()
+example2 = do
+  spOut <- payEndpoint 42_000_000 5_000_000
+  spendEndpoint spOut ARedeemer2
+
+-- Test suite including a failing test to showcase pretty printing of
+-- constraints
+
+tests :: Tasty.TestTree
+tests =
+  Tasty.testGroup
+    "Order"
+    [ Tasty.testCase "Redeem a script output with ARedeemer1" $
+        testSucceeds example1,
+      Tasty.testCase "Redeem a script output with ARedeemer2" $
+        testSucceeds example2
+    ]
+
+runTests :: IO ()
+runTests = Tasty.defaultMain tests

--- a/cooked-validators/tests/Cooked/AttackSpec/DatumHijacking.hs
+++ b/cooked-validators/tests/Cooked/AttackSpec/DatumHijacking.hs
@@ -72,7 +72,7 @@ relockTxSkel :: L.TypedValidator MockContract -> SpendableOut -> TxSkel
 relockTxSkel v o =
   txSkelOpts
     (def {adjustUnbalTx = True})
-    ( [SpendsScript v () (o, FirstLock)]
+    ( [SpendsScript v () o]
         :=>: [PaysScript v SecondLock lockValue]
     )
 

--- a/examples/src/Auction/Offchain.hs
+++ b/examples/src/Auction/Offchain.hs
@@ -60,7 +60,7 @@ txBid ::
   m ()
 txBid p bid = do
   bidder <- ownPaymentPubKeyHash
-  [utxo] <- scriptUtxosSuchThat (A.auctionValidator p) (\_ _ -> True)
+  [(utxo, datum)] <- scriptUtxosSuchThat (A.auctionValidator p) (\_ _ -> True)
   void $
     validateTxSkel $
       txSkelOpts (def {adjustUnbalTx = True}) $
@@ -74,7 +74,7 @@ txBid p bid = do
           :=>: ( [ PaysScript (A.auctionValidator p) (A.Bidding (A.BidderInfo bid bidder)) $
                      A.lot p <> Ada.lovelaceValueOf bid <> Value.assetClassValue (A.threadTokenAssetClass p) 1
                  ]
-                   <> case previousBidder (snd utxo) of
+                   <> case previousBidder datum of
                      Nothing -> []
                      Just (prevBid, prevBidder) ->
                        [paysPK prevBidder (Ada.lovelaceValueOf prevBid)]
@@ -86,7 +86,7 @@ txHammer ::
   A.PolicyParams ->
   m ()
 txHammer p q = do
-  [utxo] <- scriptUtxosSuchThat (A.auctionValidator p) (\_ _ -> True)
+  [(utxo, datum)] <- scriptUtxosSuchThat (A.auctionValidator p) (\_ _ -> True)
   void $
     validateTxSkel $
       txSkelOpts (def {adjustUnbalTx = True}) $
@@ -100,7 +100,7 @@ txHammer p q = do
             [A.threadTokenPolicy q]
             (Value.assetClassValue (A.threadTokenAssetClass p) (-1))
         ]
-          :=>: case previousBidder (snd utxo) of
+          :=>: case previousBidder datum of
             Nothing ->
               [paysPK (A.seller p) (A.lot p)]
             Just (lastBid, lastBidder) ->

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -57,7 +57,7 @@ txUnlock script = do
   void $
     validateTxConstrLbl
       TxUnlock
-      ( [SpendsScript script () (output, datum)]
+      ( [SpendsScript script () output]
           :=>: [ paysPK r1 (Pl.lovelaceValueOf share1),
                  paysPK r2 (Pl.lovelaceValueOf share2)
                ]

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -127,23 +127,23 @@ mkSign params pmt sk = do
 
 mkCollect :: MonadMockChain m => Payment -> Params -> m ()
 mkCollect thePayment params = signs (wallet 1) $ do
-  [initialProp] <- scriptUtxosSuchThat (pmultisig params) isProposal
+  [(initialProp, _)] <- scriptUtxosSuchThat (pmultisig params) isProposal
   signatures <- nubBy ((==) `on` snd) <$> scriptUtxosSuchThat (pmultisig params) isSign
   let signatureValues = mconcat $ map (sOutValue . fst) signatures
   void $
     validateTxConstr $
       ( SpendsScript (pmultisig params) () initialProp :
-        (SpendsScript (pmultisig params) () <$> signatures)
+        (SpendsScript (pmultisig params) () <$> (fst <$> signatures))
       )
         :=>: [ PaysScript
                  (pmultisig params)
                  (Accumulator thePayment (signPk . snd <$> signatures))
-                 (paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues)
+                 (paymentValue thePayment <> sOutValue initialProp <> signatureValues)
              ]
 
 mkPay :: MonadMockChain m => Payment -> Params -> Pl.TxOutRef -> m ()
 mkPay thePayment params tokenOutRef = signs (wallet 1) $ do
-  [accumulated] <- scriptUtxosSuchThat (pmultisig params) isAccumulator
+  [(accumulated, _)] <- scriptUtxosSuchThat (pmultisig params) isAccumulator
   void $
     validateTxConstr $
       -- We payout all the gathered funds to the receiver of the payment, including the minimum ada
@@ -151,7 +151,7 @@ mkPay thePayment params tokenOutRef = signs (wallet 1) $ do
       [ SpendsScript (pmultisig params) () accumulated,
         mints [threadTokenPolicy tokenOutRef threadTokenName] $ Pl.negate $ paramsToken params
       ]
-        :=>: [paysPK (paymentRecipient thePayment) (sOutValue (fst accumulated) <> Pl.negate (paramsToken params))]
+        :=>: [paysPK (paymentRecipient thePayment) (sOutValue accumulated <> Pl.negate (paramsToken params))]
 
 -- *** Auxiliary Functions
 
@@ -342,18 +342,18 @@ trPayment (Payment val dest) = HJ.Payment val dest
 
 mkFakeCollect :: MonadBlockChain m => Payment -> Params -> m ()
 mkFakeCollect thePayment params = do
-  [initialProp] <- scriptUtxosSuchThat (pmultisig params) isProposal
+  [(initialProp, _)] <- scriptUtxosSuchThat (pmultisig params) isProposal
   signatures <- nubBy ((==) `on` snd) <$> scriptUtxosSuchThat (pmultisig params) isSign
   let signatureValues = mconcat $ map (sOutValue . fst) signatures
   void $
     validateTxConstr $
       ( SpendsScript (pmultisig params) () initialProp :
-        (SpendsScript (pmultisig params) () <$> signatures)
+        (SpendsScript (pmultisig params) () <$> (fst <$> signatures))
       )
         :=>: [ PaysScript
                  fakeValidator
                  (HJ.Accumulator (trPayment thePayment) (signPk . snd <$> signatures))
-                 (paymentValue thePayment <> sOutValue (fst initialProp) <> signatureValues)
+                 (paymentValue thePayment <> sOutValue initialProp <> signatureValues)
              ]
 
 -- * Datum Hijacking Attack from 'Cooked.Attack'

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -36,7 +36,7 @@ txUnlock' mRecipient1 mRecipient2 mAmountChanger issuer = do
       share1 = fromMaybe id mAmountChanger half
       share2 = fromMaybe id mAmountChanger (amount - half)
       constraints =
-        [SpendsScript Split.splitValidator () (output, datum)]
+        [SpendsScript Split.splitValidator () output]
           :=>: [ paysPK (maybe r1 walletPKHash mRecipient1) (Pl.lovelaceValueOf share1),
                  paysPK (maybe r2 walletPKHash mRecipient2) (Pl.lovelaceValueOf share2)
                ]
@@ -69,8 +69,8 @@ txUnlockAttack issuer = do
   let half1 = Pl.lovelaceValueOf (amount1 `div` 2)
       half2 = Pl.lovelaceValueOf (amount2 `div` 2)
       constraints =
-        [ SpendsScript Split.splitValidator () (output1, datum1),
-          SpendsScript Split.splitValidator () (output2, datum2)
+        [ SpendsScript Split.splitValidator () output1,
+          SpendsScript Split.splitValidator () output2
         ]
           :=>: [ paysPK r11 half1,
                  paysPK r12 (if amount1 > amount2 then half1 else half2),

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -90,7 +90,7 @@ retrieveFunds t c owner = do
     signs owner $
       validateTxConstrOpts
         (def {autoSlotIncrease = False})
-        ( (ValidateIn (collectionRange c) : map (SpendsScript (typedValidator c) Collect) funds)
+        ( (ValidateIn (collectionRange c) : map (SpendsScript (typedValidator c) Collect) (fst <$> funds))
             :=>: [paysPK (walletPKHash owner) (mconcat $ map (sOutValue . fst) funds)]
         )
 


### PR DESCRIPTION
The `SpendsScript` constraint has a parameter for the datum which is annoying and redundant with the spendable output itself. This was necessary to pretty print these constraints. This PR removes the parameter, keeps pretty-printing as it was, and adds convenience functions to write cleaner endpoints & traces.

- [x] TODO: adapt attack modules
- [x] TODO: adapt examples in the `examples` package

Look at each commit of this PR to get a better grasp at individual changes.

The `Example` module showcases the changes. (you will need to disable the attack modules and tests if you want to try until these are adapted)

### Main changes

- The datum is no longer a parameter of `SpendsScript`
- Pretty printing has been adapted to extract the datum from the spendable out instead
- `BlockChain` has a new operation: `datumFromTxOut` (which only existed for the `Contract` monad).
- New convenience functions `spOutResolveDatum` and `spOutsFromCardanoTx` that make use of `datumFromTxOut`. It is useful to fetch spendable outputs from freshly validated transactions instead of tediously searching through the whole mockchain afterwards with `utxosSuchThat`.

### Why this works?

A `SpendableOut` has a `Pl.ChainIndexTxOut` which contains a datum field. This datum is either (`Either`) an actual `Pl.Datum` or a datum hash (`Pl.DatumHash`).
In practice, the existing classic `SpendsScript` constraint leads to a runtime error (`DatumNotFound` from plutus-apps) when the `Pl.ChainIndexTxOut` only has a hash. This means that we have always been manipulating `ChainIndexTxOut`s with the actual datum inside (when we fetch one with `scriptUtxosSuchThat` for instance).
In other words, removing the datum parameter from `SpendsScript` does not change anything.

On the other hand, script utxos we extract from `Pl.CardanoTx` only have a hash. This is were the new functions `datumFromTxOut`, `spOutResolveDatum`, and `spOutsFromCardanoTx` come in handy: they look up the hash in the context of a `BlockChain` so that we have `SpendableOut`s which are usable by `SpendsScript`.
This is something that we had not noticed before because we were only using `SpendableOut`s coming from `utxosSuchThat` functions.