### PR TITLE
Implement pretty-print for time constraints

### DIFF
--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -75,7 +75,9 @@ prettyMiscConstraint (SpendsScript val red spOut) =
     ("SpendsScript" <+> prettyTypedValidator val)
     "-"
     ["Redeemer:" <+> PP.viaShow red, prettyScriptOutputDatum val spOut]
-prettyMiscConstraint _ = "<constraint without pretty def>"
+prettyMiscConstraint (Before time) = "Before:" <+> PP.pretty time
+prettyMiscConstraint (After time) = "After:" <+> PP.pretty time
+prettyMiscConstraint (ValidateIn timeRange) = "ValidateIn:" <+> PP.pretty timeRange
 
 prettyHash :: (Show a) => a -> Doc ann
 prettyHash = PP.pretty . take 6 . show


### PR DESCRIPTION
For some reason, time constraints were not pretty printed. This is a trivial implementation relying on Plutus' `Pretty` instances for `POSIXTime` and `POSIXTimeRange`.

E.g.
```
ValidateTxSkel
         - Signers: [wallet #1 (a2c20c)]
         - Constraints:
            /\ ValidateIn: (-∞ , +∞)
            [...]
```