### PR TITLE
Update to hls 1.8.0

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -21,9 +21,9 @@ let
     (iohkpkgs.haskell-nix.hackage-package {
       compiler-nix-name = "ghc810420210212";
       name = "haskell-language-server";
-      version = "1.7.0.0";
+      version = "1.8.0.0";
       modules = [{
-        packages.ghcide.patches = [ patches/ghcide_partial_iface.patch ];
+        # packages.ghcide.patches = [ patches/ghcide_partial_iface.patch ];
         packages.ghcide.flags.ghc-patched-unboxed-bytecode = true;
       }];
     }).components.exes;
@@ -35,7 +35,7 @@ in {
   build-deps = with rawpkgs; [
         # libs required to build plutus
         libsodium
-        lzma
+        xz
         zlib
 
         # required to build in a pure nix shell

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4ee7270856a6ba4617c7e51a6c619f365faad894",
-        "sha256": "022xg02wmr5dj3y2qgn3c2sfg97w41avbl7nwyml6cvqin9qskhl",
+        "rev": "a070082964b624cc0949029a7fce01faebc59c85",
+        "sha256": "02l36jc8a05fpk2grsj9qkl38dp5k7ilx9p3sygw6ppj3hax9xk1",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/4ee7270856a6ba4617c7e51a6c619f365faad894.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/a070082964b624cc0949029a7fce01faebc59c85.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
-        "sha256": "0g9gak16a0mx6kwjzpz8fx4rwl9p1jj8f4f4frl12vjhnrssf6zp",
+        "rev": "abe6ea8ac11de69b7708ca9c70e8cd007600cd73",
+        "sha256": "1cv5hx2gdc8wmyspbz7ahw1p2bg69jfgg3ahxg4b4jvhq4bmy9ya",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/74b10859829153d5c5d50f7c77b86763759e8654.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/abe6ea8ac11de69b7708ca9c70e8cd007600cd73.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This addresses #162 
This is a pinnning update of the nix repos and an update to use hls version 1.8.0.
A patch was applied to the previous version. It is not compatible nor applied on the new one.
Basic usage seems to work but further review is required before merging.