### PR TITLE
Add the addTokenAttack and the `withTweak` idiom

### DIFF
--- a/cooked-validators/cooked-validators.cabal
+++ b/cooked-validators/cooked-validators.cabal
@@ -14,6 +14,7 @@ library
   exposed-modules:
       Cooked
       Cooked.Attack
+      Cooked.Attack.AddToken
       Cooked.Attack.DatumHijacking
       Cooked.Attack.DoubleSat
       Cooked.Attack.DupToken

--- a/cooked-validators/src/Cooked/Attack.hs
+++ b/cooked-validators/src/Cooked/Attack.hs
@@ -1,5 +1,6 @@
 module Cooked.Attack (module X) where
 
+import Cooked.Attack.AddToken as X
 import Cooked.Attack.DatumHijacking as X
 import Cooked.Attack.DoubleSat as X
 import Cooked.Attack.DupToken as X

--- a/cooked-validators/src/Cooked/Attack/AddToken.hs
+++ b/cooked-validators/src/Cooked/Attack/AddToken.hs
@@ -1,0 +1,56 @@
+module Cooked.Attack.AddToken where
+
+import Control.Monad
+import Cooked.Attack.Tweak
+import Cooked.MockChain.Wallet
+import Cooked.Tx.Constraints
+import qualified Ledger as Pl
+import qualified Ledger.Typed.Scripts as Pl
+import qualified Ledger.Value as Pl
+import Optics.Core
+import qualified Plutus.Script.Utils.V1.Scripts as Pl
+
+-- | This attack adds extra tokens, depending on the minting policy. It is
+-- different from the 'dupTokenAttack' in that it does not merely try to
+-- increase the amount of tokens minted: It tries to mint tokens of asset
+-- classes that were not necessarily present on the unmodified transaction.
+--
+-- This attack adds an 'AddTokenLbl' with the token name of the additional
+-- minted token(s). It returns additional value minted.
+addTokenAttack ::
+  -- | For each policy that occurs in some 'Mints' constraint, return a list of
+  -- token names together with how many tokens with that name be minted, using
+  -- the same redeemer as on the original transaction. For each of the elements
+  -- of the returned list, one modified transaction will be tried.
+  (Pl.MintingPolicy -> [(Pl.TokenName, Integer)]) ->
+  -- | The wallet of the attacker. Any extra tokens will be paid to this wallet.
+  Wallet ->
+  Tweak Pl.Value
+addTokenAttack extraTokens attacker = do
+  mintsCs <- viewTweak $ partsOf mintsConstraintsT
+  msum $
+    map
+      ( \(MintsConstraint redeemer pols _value) ->
+          msum $
+            map
+              ( \pol ->
+                  msum $
+                    map
+                      ( \(extraTn, amount) ->
+                          let extraValue =
+                                Pl.assetClassValue
+                                  (Pl.assetClass (Pl.scriptCurrencySymbol pol) extraTn)
+                                  amount
+                           in do
+                                _ <- addMiscConstraintTweak $ Mints redeemer [pol] extraValue
+                                addLabelTweak $ AddTokenLbl extraTn
+                                addOutConstraintTweak $ paysPK (walletPKHash attacker) extraValue
+                                return extraValue
+                      )
+                      $ extraTokens pol
+              )
+              pols
+      )
+      mintsCs
+
+newtype AddTokenLbl = AddTokenLbl Pl.TokenName deriving (Show, Eq)

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -177,10 +177,24 @@ type MonadModalMockChain m = (MonadMockChain m, MonadModal m, Modification m ~ U
 somewhere :: MonadModalMockChain m => Tweak b -> m a -> m a
 somewhere x = modifyLtl (LtlTruth `LtlUntil` LtlAtom (UntypedTweak x))
 
--- | Apply an 'Tweak' to every transaction in a given trace. This is also
+-- | Apply a 'Tweak' to every transaction in a given trace. This is also
 -- successful if there are no transactions at all.
 everywhere :: MonadModalMockChain m => Tweak b -> m a -> m a
 everywhere x = modifyLtl (LtlFalsity `LtlRelease` LtlAtom (UntypedTweak x))
+
+-- | Apply a 'Tweak' to the next transaction in the given trace. The order of
+-- arguments is reversed compared to 'somewhere' and 'everywhere', because that
+-- enables an idiom like
+--
+-- > do ...
+-- >    endpoint arguments `withTweak` someModification
+-- >    ...
+--
+-- where @endpoint@ builds and validates a single transaction depending on the
+-- given @arguments@. Then `withTweak` says "I want to modify the transaction
+-- returned by this endpoint in the following way".
+withTweak :: MonadModalMockChain m => m x -> Tweak a -> m x
+withTweak trace tweak = modifyLtl (LtlAtom $ UntypedTweak tweak) trace
 
 -- * 'MonadBlockChain' and 'MonadMockChain' instances
 


### PR DESCRIPTION
This PR adds an attack that can add extra tokens to the `Mints` constraints of a transaction. This is different from the `dupTokenAttack`, because that attack only increases the amount, but does not introduce new asset classes.

As a bonus, there's now a function `withTweak` that says "apply this Tweak on this endpoint". It enables [idioms like this](https://github.com/tweag/plutus-libs/blob/300be50050b608a5ba59c0b6e678d02d4fc69375/examples/tests/AuctionSpec.hs#L347).