### PR TITLE
Fix outdated example in `unsafeModTx` comment

### DIFF
--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -390,7 +390,7 @@ data TxOpts = TxOpts
     -- in unforeseen ways. It is mostly used to test contracts that have been written for custom PABs.
     --
     -- One interesting use of this function is to observe a transaction just before it is being
-    -- sent for validation, with @unsafeModTx = RawModTx Debug.Trace.traceShowId@.
+    -- sent for validation, with @unsafeModTx = RawModTxAfterBalancing Debug.Trace.traceShowId@.
     --
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     -- By default, this is set to 'Id'.


### PR DESCRIPTION
Fixes a tiny outdated example (how to print a transaction before validation), encountered when auditing.