### PR TITLE
Replace `datumFromTxOut` with `datumFromHash`

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Contract.hs
@@ -52,7 +52,4 @@ instance (C.AsContractError e) => MonadBlockChain (C.Contract w s e) where
   awaitSlot = C.awaitSlot
   awaitTime = C.awaitTime
 
-  datumFromTxOut Pl.PublicKeyChainIndexTxOut {} = pure Nothing
-  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Right d) _) = pure $ Just d
-  -- datum is always present in the nominal case, guaranteed by chain-index
-  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) = C.datumFromHash dh
+  datumFromHash = C.datumFromHash

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -239,11 +239,7 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
 
   utxosSuchThisAndThat = utxosSuchThisAndThat'
 
-  datumFromTxOut Pl.PublicKeyChainIndexTxOut {} = pure Nothing
-  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Right d) _) = pure $ Just d
-  -- datum is always present in the nominal case, guaranteed by chain-index
-  datumFromTxOut (Pl.ScriptChainIndexTxOut _ _ (Left dh) _) =
-    M.lookup dh <$> gets mcstDatums
+  datumFromHash dh = M.lookup dh <$> gets mcstDatums
 
   currentSlot = gets mcstCurrentSlot
 

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -80,7 +80,7 @@ data MockChainBuiltin a where
     (Pl.Address -> Bool) ->
     (Maybe a -> Pl.Value -> Bool) ->
     MockChainBuiltin [(SpendableOut, Maybe a)]
-  DatumFromTxOut :: Pl.ChainIndexTxOut -> MockChainBuiltin (Maybe Pl.Datum)
+  DatumFromHash :: Pl.DatumHash -> MockChainBuiltin (Maybe Pl.Datum)
   OwnPubKey :: MockChainBuiltin Pl.PubKeyHash
   -- the following are only available in MonadMockChain, not MonadBlockChain:
   SigningWith :: NE.NonEmpty Wallet -> StagedMockChain a -> MockChainBuiltin a
@@ -155,7 +155,7 @@ instance InterpLtl UntypedTweak MockChainBuiltin InterpMockChain where
   interpBuiltin (AwaitTime t) = awaitTime t
   interpBuiltin (UtxosSuchThat a p) = utxosSuchThat a p
   interpBuiltin (UtxosSuchThisAndThat apred dpred) = utxosSuchThisAndThat apred dpred
-  interpBuiltin (DatumFromTxOut o) = datumFromTxOut o
+  interpBuiltin (DatumFromHash h) = datumFromHash h
   interpBuiltin OwnPubKey = ownPaymentPubKeyHash
   interpBuiltin AskSigners = askSigners
   interpBuiltin GetParams = params
@@ -205,7 +205,7 @@ instance MonadBlockChain StagedMockChain where
   validateTxSkel = singletonBuiltin . ValidateTxSkel
   utxosSuchThat a p = singletonBuiltin (UtxosSuchThat a p)
   utxosSuchThisAndThat apred dpred = singletonBuiltin (UtxosSuchThisAndThat apred dpred)
-  datumFromTxOut = singletonBuiltin . DatumFromTxOut
+  datumFromHash = singletonBuiltin . DatumFromHash
   txOutByRef = singletonBuiltin . TxOutByRef
   ownPaymentPubKeyHash = singletonBuiltin OwnPubKey
   currentSlot = singletonBuiltin GetCurrentSlot


### PR DESCRIPTION
This is related to some bigger-picture changes on PR #181, but I think it warrants its own discussion on a separate PR. The type of the function `datumFromTxOut :: MonadBlockChain m => ChainIndexTxOut -> m (Maybe Datum)`, which currently is a primitive of `MonadBlockChain`, is a bit strange. Conceptually, I think that two functions, namely  
- one pure function to look for datum (hashes) in `ChainIndexTxOut`s, and 
- one function in `MonadBlockChain` to resolve datum hashes 

would be a cleaner solution. In particular, this would free us to do whatever we want to the `SpendableOut` type, as long as we remain able to query it for datum hashes.