### PR TITLE
Make signers explicit

### DIFF
--- a/cooked-validators/README.md
+++ b/cooked-validators/README.md
@@ -42,6 +42,7 @@ datum which we're a recipient of.
 ```haskell
 txUnlock :: (MonadBlockChain m) => m ()
 txUnlock = do
+  -- TODO rewrite the example to not rely on ownPaymentPubKeyHash
   pkh <- ownPaymentPubKeyHash
   (output, datum@(Split.SplitDatum r1 r2 amount)) : _ <-
     scriptUtxosSuchThat splitValidator (isARecipient pkh)

--- a/cooked-validators/src/Cooked/MockChain/Monad.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad.hs
@@ -79,11 +79,6 @@ class (MonadFail m) => MonadBlockChain m where
   -- | Returns an output given a reference to it
   txOutByRef :: Pl.TxOutRef -> m (Maybe Pl.TxOut)
 
-  -- | Returns the hash of our own public key. When running in the "Plutus.Contract.Contract" monad,
-  --  this is a proxy to 'Pl.ownPubKey'; when running in mock mode, the return value can be
-  --  controlled with 'signingWith': the head of the non-empty list will be considered as the "ownPubkey".
-  ownPaymentPubKeyHash :: m Pl.PubKeyHash
-
   -- | Returns the current slot number
   currentSlot :: m Pl.Slot
 
@@ -324,7 +319,6 @@ instance (MonadTrans t, MonadBlockChain m, MonadFail (t m)) => MonadBlockChain (
   utxosSuchThat addr f = lift $ utxosSuchThat addr f
   utxosSuchThisAndThat addrPred datumPred = lift $ utxosSuchThisAndThat addrPred datumPred
   datumFromHash = lift . datumFromHash
-  ownPaymentPubKeyHash = lift ownPaymentPubKeyHash
   txOutByRef = lift . txOutByRef
   currentSlot = lift currentSlot
   currentTime = lift currentTime

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -269,8 +269,6 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
 
   txOutByRef outref = gets (Map.lookup outref . Pl.getIndex . mcstIndex)
 
-  ownPaymentPubKeyHash = asks (walletPKHash . NE.head . mceSigners)
-
   utxosSuchThat = utxosSuchThat'
 
   utxosSuchThisAndThat = utxosSuchThisAndThat'

--- a/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Staged.hs
@@ -82,7 +82,6 @@ data MockChainBuiltin a where
     (Maybe a -> Pl.Value -> Bool) ->
     MockChainBuiltin [(SpendableOut, Maybe a)]
   DatumFromHash :: Pl.DatumHash -> MockChainBuiltin (Maybe Pl.Datum)
-  OwnPubKey :: MockChainBuiltin Pl.PubKeyHash
   -- the following are only available in MonadMockChain, not MonadBlockChain:
   SigningWith :: NE.NonEmpty Wallet -> StagedMockChain a -> MockChainBuiltin a
   AskSigners :: MockChainBuiltin (NE.NonEmpty Wallet)
@@ -157,7 +156,6 @@ instance InterpLtl UntypedTweak MockChainBuiltin InterpMockChain where
   interpBuiltin (UtxosSuchThat a p) = utxosSuchThat a p
   interpBuiltin (UtxosSuchThisAndThat apred dpred) = utxosSuchThisAndThat apred dpred
   interpBuiltin (DatumFromHash h) = datumFromHash h
-  interpBuiltin OwnPubKey = ownPaymentPubKeyHash
   interpBuiltin AskSigners = askSigners
   interpBuiltin GetParams = params
   interpBuiltin (LocalParams f act) = localParams f (interpLtl act)
@@ -208,7 +206,6 @@ instance MonadBlockChain StagedMockChain where
   utxosSuchThisAndThat apred dpred = singletonBuiltin (UtxosSuchThisAndThat apred dpred)
   datumFromHash = singletonBuiltin . DatumFromHash
   txOutByRef = singletonBuiltin . TxOutByRef
-  ownPaymentPubKeyHash = singletonBuiltin OwnPubKey
   currentSlot = singletonBuiltin GetCurrentSlot
   currentTime = singletonBuiltin GetCurrentTime
   awaitSlot = singletonBuiltin . AwaitSlot

--- a/cooked-validators/tests/Cooked/AttackSpec/DatumHijacking.hs
+++ b/cooked-validators/tests/Cooked/AttackSpec/DatumHijacking.hs
@@ -62,9 +62,8 @@ lockTxSkel o v =
     (def {adjustUnbalTx = True})
     ([SpendsPK o] :=>: [paysScript v FirstLock lockValue])
 
-txLock :: MonadBlockChain m => L.TypedValidator MockContract -> m ()
-txLock v = do
-  me <- ownPaymentPubKeyHash
+txLock :: MonadBlockChain m => L.PubKeyHash -> L.TypedValidator MockContract -> m ()
+txLock me v = do
   utxo : _ <- pkUtxosSuchThatValue me (`L.geq` lockValue)
   void $ validateTxSkel $ lockTxSkel utxo v
 
@@ -137,7 +136,7 @@ carelessValidator =
 
 datumHijackingTrace :: MonadBlockChain m => L.TypedValidator MockContract -> m ()
 datumHijackingTrace v = do
-  txLock v
+  txLock (wallet 1) v
   txRelock v
 
 -- * TestTree for the datum hijacking attack

--- a/examples/tests/AuctionSpec.hs
+++ b/examples/tests/AuctionSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
@@ -78,14 +77,14 @@ foo = do
 
 hammerToWithdraw :: MonadMockChain m => m ()
 hammerToWithdraw = do
-  offerUtxo <- A.txOffer (banana 2) 30_000_000 `as` wallet 1
+  offerUtxo <- A.txOffer (banana 2) 30_000_000 (wallet 1)
   A.txHammer offerUtxo `as` wallet 1
 
 noBids :: MonadMockChain m => m ()
 noBids = do
   t0 <- currentTime
   let deadline = t0 + 60_000
-  offerUtxo <- A.txOffer (banana 2) 30_000_000 `as` wallet 1
+  offerUtxo <- A.txOffer (banana 2) 30_000_000 (wallet 1)
   A.txSetDeadline offerUtxo deadline
   awaitTime (deadline + 1)
   A.txHammer offerUtxo
@@ -95,9 +94,9 @@ oneBid :: MonadMockChain m => m ()
 oneBid = do
   t0 <- currentTime
   let deadline = t0 + 60_000
-  offerUtxo <- A.txOffer (banana 2) 30_000_000 `as` wallet 1
+  offerUtxo <- A.txOffer (banana 2) 30_000_000 (wallet 1)
   A.txSetDeadline offerUtxo deadline
-  A.txBid offerUtxo 30_000_000 `as` wallet 2
+  A.txBid offerUtxo 30_000_000 (wallet 2)
   awaitTime (deadline + 1)
   A.txHammer offerUtxo
 
@@ -105,10 +104,10 @@ twoBids :: MonadMockChain m => m ()
 twoBids = do
   t0 <- currentTime
   let deadline = t0 + 60_000
-  offerUtxo <- A.txOffer (banana 2) 30_000_000 `as` wallet 1
+  offerUtxo <- A.txOffer (banana 2) 30_000_000 (wallet 1)
   A.txSetDeadline offerUtxo deadline
-  A.txBid offerUtxo 30_000_000 `as` wallet 2
-  A.txBid offerUtxo 40_000_000 `as` wallet 3
+  A.txBid offerUtxo 30_000_000 (wallet 2)
+  A.txBid offerUtxo 40_000_000 (wallet 3)
   awaitTime (deadline + 1)
   A.txHammer offerUtxo
 
@@ -117,13 +116,13 @@ twoAuctions = do
   t0 <- currentTime
   let deadline1 = t0 + 60_000
       deadline2 = t0 + 90_000
-  offerUtxo1 <- A.txOffer (banana 2) 30_000_000 `as` wallet 1
-  offerUtxo2 <- A.txOffer (banana 3) 50_000_000 `as` wallet 1
+  offerUtxo1 <- A.txOffer (banana 2) 30_000_000 (wallet 1)
+  offerUtxo2 <- A.txOffer (banana 3) 50_000_000 (wallet 1)
   A.txSetDeadline offerUtxo1 deadline1
   A.txSetDeadline offerUtxo2 deadline2
-  A.txBid offerUtxo1 30_000_000 `as` wallet 2
-  A.txBid offerUtxo2 50_000_000 `as` wallet 3
-  A.txBid offerUtxo2 60_000_000 `as` wallet 4
+  A.txBid offerUtxo1 30_000_000 (wallet 2)
+  A.txBid offerUtxo2 50_000_000 (wallet 3)
+  A.txBid offerUtxo2 60_000_000 (wallet 4)
   awaitTime (deadline1 + 1)
   A.txHammer offerUtxo1
   awaitTime (deadline2 + 1)
@@ -164,21 +163,21 @@ successfulSingle =
 failingOffer :: MonadMockChain m => m ()
 failingOffer =
   void $
-    A.txOffer (banana 100) 20_000_000 `as` wallet 2
+    A.txOffer (banana 100) 20_000_000 (wallet 2)
 
 forbiddenHammerToWithdraw :: MonadMockChain m => m ()
 forbiddenHammerToWithdraw = do
-  offerUtxo <- A.txOffer (banana 2) 30_000_000 `as` wallet 1
+  offerUtxo <- A.txOffer (banana 2) 30_000_000 (wallet 1)
   A.txHammer offerUtxo `as` wallet 2
 
 failingTwoBids :: MonadMockChain m => m ()
 failingTwoBids = do
   t0 <- currentTime
   let deadline = t0 + 60_000
-  offerUtxo <- A.txOffer (banana 2) 30_000_000 `as` wallet 1
+  offerUtxo <- A.txOffer (banana 2) 30_000_000 (wallet 1)
   A.txSetDeadline offerUtxo deadline
-  A.txBid offerUtxo 30_000_000 `as` wallet 2
-  A.txBid offerUtxo 30_000_000 `as` wallet 3
+  A.txBid offerUtxo 30_000_000 (wallet 2)
+  A.txBid offerUtxo 30_000_000 (wallet 3)
   awaitTime (deadline + 1)
   A.txHammer offerUtxo
 
@@ -484,9 +483,9 @@ bidderAlternativeTrace :: (Alternative m, MonadMockChain m) => m ()
 bidderAlternativeTrace = do
   t0 <- currentTime
   let deadline = t0 + 60_000
-  offerUtxo <- A.txOffer (banana 2) 30_000_000 `as` wallet 1
+  offerUtxo <- A.txOffer (banana 2) 30_000_000 (wallet 1)
   A.txSetDeadline offerUtxo deadline
-  A.txBid offerUtxo 30_000_000 `as` wallet 2 <|> A.txBid offerUtxo 30_000_000 `as` wallet 3
+  A.txBid offerUtxo 30_000_000 (wallet 2) <|> A.txBid offerUtxo 30_000_000 (wallet 3)
   awaitTime (deadline + 1)
   A.txHammer offerUtxo
 


### PR DESCRIPTION
This change might be somewhat controversial, so I did it on a separate branch to make it easier to review and possibly reject. The main idea is that the balance/collateral wallet is now explicit, and so is the list of additional signers, if any.