### PR TITLE
Some more cleanup around the direct monad

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -325,7 +325,7 @@ runTransactionValidation ::
   -- Phase 1 - valid. This will be the list that contains the ballancing wallet
   -- and the collateral wallet.
   [Wallet] ->
-  -- | The transaction to vaildate. It should already be balanced and have
+  -- | The transaction to validate. It should already be balanced and have
   -- appropriate collateral.
   --
   -- The witnesses in script inputs must use the 'C.InlineScriptDatum'
@@ -337,7 +337,7 @@ runTransactionValidation ::
   -- | The data on transaction inputs. If the transaction is successful, these
   -- will be deleted from the 'mcstDatums'.
   Map Pl.DatumHash Pl.Datum ->
-  -- | The data on transaction outputs. If the transaction is succesfil, these
+  -- | The data on transaction outputs. If the transaction is successful, these
   -- will be added to the 'mcstDatums'.
   Map Pl.DatumHash Pl.Datum ->
   MockChainT m Pl.SomeCardanoApiTx

--- a/cooked-validators/src/Cooked/MockChain/Monad/GenerateTx.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/GenerateTx.hs
@@ -47,7 +47,7 @@ generateTxBodyContent' ::
   -- chooses.
   --
   -- The latter option will (probably, We've not yet completely understood how
-  -- this works!) rely on the information in the UTxO what will be included when
+  -- this works!) rely on the information in the UTxO that will be included when
   -- the 'C.TxBodyContent' is finally transformed into an actual 'C.Tx'.
   --
   -- The former option (i.e. to include the datum) is necessary when such


### PR DESCRIPTION
This adds a few comments, and makes it so that the unused data are removed from the `mcstDatums` on successful transaction validation.