### PR TITLE
Unify collateral fields

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -239,6 +239,11 @@ utxoIndex0 = utxoIndex0From def
 
 -- ** Direct Interpretation of Operations
 
+withCollateral :: TxSkel -> Set SpendableOut -> TxSkel
+withCollateral skel souts = skel {txSkelOpts = txSkelOpts'}
+  where
+    txSkelOpts' = (txSkelOpts skel) {collateral = CollateralUtxos souts}
+
 instance (Monad m) => MonadBlockChain (MockChainT m) where
   validateTxSkel skelUnbal = do
     -- TODO We use the first signer as a default wallet for fees and
@@ -265,7 +270,7 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
     -- have to use 'generateTxBodyContentWithoutInputDatums' here. The
     -- documentation of the 'generateTxBodyContent*' functions might also be
     -- informative.
-    case generateTxBodyContentWithoutInputDatums params managedData (skel {txSkelInsCollateral = collateralInputs}) of
+    case generateTxBodyContentWithoutInputDatums params managedData (skel `withCollateral` collateralInputs) of
       Left err -> throwError $ MCEGenerationError err
       Right txBodyContent -> do
         slot <- currentSlot

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -31,7 +31,7 @@ prettyEnum title tag items =
   PP.hang 1 $ PP.vsep $ title : map (tag <+>) items
 
 prettyTxSkel :: [Wallet] -> TxSkel -> Doc ann
-prettyTxSkel signers (TxSkel lbl opts mints validityRange reqSigners ins _insCollateral outs fee) =
+prettyTxSkel signers (TxSkel lbl opts mints validityRange reqSigners ins outs fee) =
   PP.vsep $
     "Transaction Skeleton:" :
     map

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -710,7 +710,6 @@ data TxSkel where
       txSkelValidityRange :: Pl.POSIXTimeRange,
       txSkelRequiredSigners :: Set Pl.PubKeyHash,
       txSkelIns :: Set TxSkelIn,
-      txSkelInsCollateral :: Set SpendableOut,
       txSkelOuts :: [TxSkelOut],
       txSkelFee :: Integer -- Fee in Lovelace
     } ->
@@ -759,7 +758,7 @@ makeLensesFor
 --
 -- > a == x && b == y `implies` a <> b == x <> y
 instance Semigroup TxSkel where
-  (TxSkel l1 p1 m1 r1 s1 i1 c1 o1 f1) <> (TxSkel l2 p2 m2 r2 s2 i2 c2 o2 f2) =
+  (TxSkel l1 p1 m1 r1 s1 i1 o1 f1) <> (TxSkel l2 p2 m2 r2 s2 i2 o2 f2) =
     TxSkel
       (l1 <> l2)
       (p1 <> p2)
@@ -767,7 +766,6 @@ instance Semigroup TxSkel where
       (r1 `Pl.intersection` r2)
       (s1 <> s2)
       (i1 <> i2)
-      (c1 <> c2)
       (o1 ++ o2)
       (f1 + f2)
 
@@ -780,7 +778,6 @@ instance Monoid TxSkel where
         txSkelValidityRange = Pl.always,
         txSkelRequiredSigners = Set.empty,
         txSkelIns = Set.empty,
-        txSkelInsCollateral = Set.empty,
         txSkelOuts = [],
         txSkelFee = 0
       }


### PR DESCRIPTION
This addresses one of the comments in #191.

I've chosen to get rid of the `TxSkel` itself and keep the one in `TxSkelOpts`, since this also semi-addresses the other comment: namely, removing the not-so-user-adjustable fields from `TxSkel`.
