### PR TITLE
Remove collateral from the `TxSkel`

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -239,11 +239,6 @@ utxoIndex0 = utxoIndex0From def
 
 -- ** Direct Interpretation of Operations
 
-withCollateral :: TxSkel -> Set SpendableOut -> TxSkel
-withCollateral skel souts = skel {txSkelOpts = txSkelOpts'}
-  where
-    txSkelOpts' = (txSkelOpts skel) {collateral = CollateralUtxos souts}
-
 instance (Monad m) => MonadBlockChain (MockChainT m) where
   validateTxSkel skelUnbal = do
     -- TODO We use the first signer as a default wallet for fees and
@@ -263,14 +258,14 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
             & txSkelRequiredSignersL
             %~ (<> Set.singleton balancingWalletPkh)
         )
-    collateralInputs <- calcCollateral collateralWallet (collateral . txSkelOpts $ skel)
+    collateralInputs <- calcCollateral collateralWallet
     params <- askParams
     managedData <- gets mcstDatums
     -- See the comment at the arguments of 'runTransactionValidation' on why we
     -- have to use 'generateTxBodyContentWithoutInputDatums' here. The
     -- documentation of the 'generateTxBodyContent*' functions might also be
     -- informative.
-    case generateTxBodyContentWithoutInputDatums params managedData (skel `withCollateral` collateralInputs) of
+    case generateTxBodyContent withoutDatums {gtpCollateralIns = collateralInputs} params managedData skel of
       Left err -> throwError $ MCEGenerationError err
       Right txBodyContent -> do
         slot <- currentSlot
@@ -531,7 +526,7 @@ setFeeAndBalance balancePK skel0 = do
 -- https://github.com/input-output-hk/plutus-apps/blob/d4255f05477fd8477ee9673e850ebb9ebb8c9657/plutus-ledger/src/Ledger/Fee.hs#L19
 estimateTxSkelFee :: Pl.Params -> Pl.UTxO Pl.EmulatorEra -> Map Pl.DatumHash Pl.Datum -> TxSkel -> Either MockChainError Integer
 estimateTxSkelFee params utxo managedData skel = do
-  txBodyContent <- left MCEGenerationError $ generateTxBodyContent params managedData skel
+  txBodyContent <- left MCEGenerationError $ generateTxBodyContent withDatums params managedData skel
   let nkeys = C.estimateTransactionKeyWitnessCount txBodyContent
   txBody <-
     left
@@ -544,20 +539,15 @@ estimateTxSkelFee params utxo managedData skel = do
     C.Lovelace fee -> pure fee
 
 -- | Calculates the collateral for a transaction
-calcCollateral :: (Monad m) => Wallet -> Collateral -> MockChainT m (Set SpendableOut)
-calcCollateral w col = do
-  case col of
-    -- We're given a specific utxo to use as collateral
-    CollateralUtxos r -> return r
-    -- We must pick them; we'll first select
-    CollateralAuto -> do
-      souts <- pkUtxosSuchThat @Void (walletPKHash w) (noDatum .&& valueSat hasOnlyAda)
-      when (null souts) $
-        throwError MCENoSuitableCollateral
-      -- TODO We only keep one element of the list because we are limited on
-      -- how many collateral inputs a transaction can have. Should this be
-      -- investigated further for a better approach?
-      return $ Set.fromList $ take 1 (fst <$> souts)
+calcCollateral :: (Monad m) => Wallet -> MockChainT m (Set SpendableOut)
+calcCollateral w = do
+  souts <- pkUtxosSuchThat @Void (walletPKHash w) (noDatum .&& valueSat hasOnlyAda)
+  when (null souts) $
+    throwError MCENoSuitableCollateral
+  -- TODO We only keep one element of the list because we are limited on
+  -- how many collateral inputs a transaction can have. Should this be
+  -- investigated further for a better approach?
+  return $ Set.fromList $ take 1 (fst <$> souts)
 
 balanceTxFromAux :: (Monad m) => BalanceOutputPolicy -> BalanceStage -> Pl.PubKeyHash -> TxSkel -> MockChainT m TxSkel
 balanceTxFromAux utxoPolicy stage balancePK txskel = do

--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -239,6 +239,11 @@ utxoIndex0 = utxoIndex0From def
 
 -- ** Direct Interpretation of Operations
 
+withCollateral :: TxSkel -> Set SpendableOut -> TxSkel
+withCollateral skel souts = skel {txSkelOpts = txSkelOpts'}
+  where
+    txSkelOpts' = (txSkelOpts skel) {collateral = CollateralUtxos souts}
+
 instance (Monad m) => MonadBlockChain (MockChainT m) where
   validateTxSkel skelUnbal = do
     -- TODO We use the first signer as a default wallet for fees and
@@ -265,7 +270,7 @@ instance (Monad m) => MonadBlockChain (MockChainT m) where
     -- have to use 'generateTxBodyContentWithoutInputDatums' here. The
     -- documentation of the 'generateTxBodyContent*' functions might also be
     -- informative.
-    case generateTxBodyContentWithoutInputDatums params managedData (skel {txSkelInsCollateral = collateralInputs}) of
+    case generateTxBodyContentWithoutInputDatums params managedData (skel `withCollateral` collateralInputs) of
       Left err -> throwError $ MCEGenerationError err
       Right txBodyContent -> do
         slot <- currentSlot

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -172,7 +172,6 @@ prettyOpts opts = case mapMaybe cmpAgainstDefAndPrint fields of
         Field "autoSlotIncrease" autoSlotIncrease,
         Field "unsafeModTx" unsafeModTx,
         Field "balance" balance,
-        Field "collateral" collateral,
         Field "balanceOutputPolicy" balanceOutputPolicy
       ]
 

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -31,7 +31,7 @@ prettyEnum title tag items =
   PP.hang 1 $ PP.vsep $ title : map (tag <+>) items
 
 prettyTxSkel :: [Wallet] -> TxSkel -> Doc ann
-prettyTxSkel signers (TxSkel lbl opts mints validityRange reqSigners ins _insCollateral outs fee) =
+prettyTxSkel signers (TxSkel lbl opts mints validityRange reqSigners ins outs fee) =
   PP.vsep $
     "Transaction Skeleton:" :
     map

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -710,7 +710,6 @@ data TxSkel where
       txSkelValidityRange :: Pl.POSIXTimeRange,
       txSkelRequiredSigners :: Set Pl.PubKeyHash,
       txSkelIns :: Set TxSkelIn,
-      txSkelInsCollateral :: Set SpendableOut,
       txSkelOuts :: [TxSkelOut],
       txSkelFee :: Integer -- Fee in Lovelace
     } ->
@@ -759,7 +758,7 @@ makeLensesFor
 --
 -- > a == x && b == y `implies` a <> b == x <> y
 instance Semigroup TxSkel where
-  (TxSkel l1 p1 m1 r1 s1 i1 c1 o1 f1) <> (TxSkel l2 p2 m2 r2 s2 i2 c2 o2 f2) =
+  (TxSkel l1 p1 m1 r1 s1 i1 o1 f1) <> (TxSkel l2 p2 m2 r2 s2 i2 o2 f2) =
     TxSkel
       (l1 <> l2)
       (p1 <> p2)
@@ -767,7 +766,6 @@ instance Semigroup TxSkel where
       (r1 `Pl.intersection` r2)
       (s1 <> s2)
       (i1 <> i2)
-      (c1 <> c2)
       (o1 ++ o2)
       (f1 + f2)
 
@@ -780,7 +778,6 @@ instance Monoid TxSkel where
         txSkelValidityRange = Pl.always,
         txSkelRequiredSigners = Set.empty,
         txSkelIns = Set.empty,
-        txSkelInsCollateral = Set.empty,
         txSkelOuts = [],
         txSkelFee = 0
       }


### PR DESCRIPTION
This takes a stab at one of the bullets in #191, and can be applied (or discarded) without #195 (although it bases on #195).

Note that we lose the ability to specify the collateral UTxOs explicitly. I'm not sure this was ever used though, and if it is ever needed, it'll be easier to add this when the need arises (perhaps, as an argument to `validateTxSkel`).

If we're happy with this, I'll also remove the fee from `TxSkel` later on.