### PR TITLE
Reduce test execution time by 95%

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -262,8 +262,8 @@ source-repository-package
 -- Cardano mainnet (>=1.35).
 source-repository-package
     type: git
-    location: https://github.com/input-output-hk/cardano-node
-    tag: 1.35.3
+    location: https://github.com/steshaw/cardano-node
+    tag: 94fc6e14f72880e6b542e582d6796f3aff695a00
     subdir:
       cardano-api
       cardano-git-rev


### PR DESCRIPTION
WARNING: You may not want to merge this PR! However, I wanted to make you aware of this performance benefit.

This PR simply points the `cabal.project` to my fork of `cardano-node`. This fork is 1 commit ahead of `1.35.3`. It contains a patch which memoises toBabbagePParams in order to improve performance. The performance issue with `cardano-api` is being tracked as https://github.com/input-output-hk/cardano-node/issues/4622. It's quite probable that there is a less brutal way to fix `cardano-api`. My patch is a bit of a hack.

With this PR:
- cooked-validators:spec:test goes from 3.62s to 0.16s.
- examples:spec:test goes from 33.96s to 1.82s.

Could make a big difference on full audit suites.

This patch doesn't help against `main` because the performance problem was introduced in the Babbage era. So, I found the active branch — `ch/inlines-datums` — which had upgraded to `1.35.3`.

Note, I saw that 3 tests are failing in the cooked-validators test suite on this branch, but I figured that you are aware of that and it doesn't impact the performance improvement.