### PR TITLE
Upgrade `TxOpts`

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Direct.hs
@@ -485,7 +485,7 @@ txSkelInputDatums skel = do
 -- iteration, which should compute realistic fees.
 --
 --  This function also adjusts the transaction outputs to contain at least the
---  minimum Ada amount, if the 'ensureMinAda option is @True@.
+--  minimum Ada amount, if the 'txOptEnsureMinAda option is @True@.
 setFeeAndBalance :: (Monad m) => Pl.PubKeyHash -> TxSkel -> MockChainT m (TxSkel, Fee)
 setFeeAndBalance balancePK skel0 = do
   let skel =

--- a/cooked-validators/src/Cooked/MockChain/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Direct.hs
@@ -287,13 +287,13 @@ instance (Monad m) => MonadBlockChainWithoutValidation (MockChainT m) where
 instance Monad m => MonadBlockChain (MockChainT m) where
   validateTxSkel skelUnbal = do
     let balancingWallet =
-          case balanceWallet . txSkelOpts $ skelUnbal of
+          case txOptBalanceWallet . txSkelOpts $ skelUnbal of
             BalanceWithFirstSigner -> NEList.head (txSkelSigners skelUnbal)
             BalanceWith wallet -> wallet
     let balancingWalletPkh = walletPKHash balancingWallet
     let collateralWallet = balancingWallet
     (skel, fee) <-
-      if balance . txSkelOpts $ skelUnbal
+      if txOptBalance . txSkelOpts $ skelUnbal
         then
           setFeeAndBalance
             balancingWalletPkh
@@ -320,8 +320,8 @@ instance Monad m => MonadBlockChain (MockChainT m) where
             inputTxDatums
             (txSkelOutputData skel)
             (txSkelOutValidators skel)
-            (unsafeModTx $ txSkelOpts skel)
-        when (autoSlotIncrease $ txSkelOpts skel) $
+            (txOptUnsafeModTx $ txSkelOpts skel)
+        when (txOptAutoSlotIncrease $ txSkelOpts skel) $
           modify' (\st -> st {mcstCurrentSlot = mcstCurrentSlot st + 1})
         return (Pl.CardanoApiTx someCardanoTx)
 
@@ -489,7 +489,7 @@ txSkelInputDatums skel = do
 setFeeAndBalance :: (Monad m) => Pl.PubKeyHash -> TxSkel -> MockChainT m (TxSkel, Fee)
 setFeeAndBalance balancePK skel0 = do
   let skel =
-        if ensureMinAda $ txSkelOpts skel0
+        if txOptEnsureMinAda $ txSkelOpts skel0
           then ensureTxSkelOutsMinAda skel0
           else skel0
   -- all UTxOs belonging to the balancing public key
@@ -536,7 +536,7 @@ setFeeAndBalance balancePK skel0 = do
       TxSkel ->
       MockChainT m (TxSkel, Fee)
     calcFee n fee cUtxoIndex parms skel = do
-      let bPol = balanceOutputPolicy $ txSkelOpts skel
+      let bPol = txOptBalanceOutputPolicy $ txSkelOpts skel
       attemptedSkel <- balanceTxFromAux bPol BalCalcFee balancePK skel fee
       manageData <- gets mcstDatums
       managedTxOuts <- gets $ utxoIndexToTxOutMap . mcstIndex
@@ -763,7 +763,7 @@ applyBalanceTx balancePK (BalanceTxRes newInputs returnValue availableUtxos) ske
     case mBestOutputIndex of
       Just i ->
         let (left, bestTxOut : right) = splitAt i outs
-         in case balanceOutputPolicy $ txSkelOpts skel of
+         in case txOptBalanceOutputPolicy $ txSkelOpts skel of
               AdjustExistingOutput ->
                 let bestTxOutValue = txSkelOutValue bestTxOut
                     adjustedValue = bestTxOutValue <> returnValue

--- a/cooked-validators/src/Cooked/MockChain/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Direct.hs
@@ -485,11 +485,11 @@ txSkelInputDatums skel = do
 -- iteration, which should compute realistic fees.
 --
 --  This function also adjusts the transaction outputs to contain at least the
---  minimum Ada amount, if the 'adjustUnbalTx' option is @True@.
+--  minimum Ada amount, if the 'ensureMinAda option is @True@.
 setFeeAndBalance :: (Monad m) => Pl.PubKeyHash -> TxSkel -> MockChainT m (TxSkel, Fee)
 setFeeAndBalance balancePK skel0 = do
   let skel =
-        if adjustUnbalTx $ txSkelOpts skel0
+        if ensureMinAda $ txSkelOpts skel0
           then ensureTxSkelOutsMinAda skel0
           else skel0
   -- all UTxOs belonging to the balancing public key

--- a/cooked-validators/src/Cooked/Pretty.hs
+++ b/cooked-validators/src/Cooked/Pretty.hs
@@ -149,9 +149,9 @@ prettyBalancingWallet w =
 
 -- | Prints a list of pubkeys with a flag next to the balancing wallet
 prettySigners :: TxOpts -> NEList.NonEmpty Wallet -> [Doc ann]
-prettySigners TxOpts {balanceWallet = BalanceWithFirstSigner} (firstSigner NEList.:| signers) =
+prettySigners TxOpts {txOptBalanceWallet = BalanceWithFirstSigner} (firstSigner NEList.:| signers) =
   prettyBalancingWallet firstSigner : (prettyPubKeyHash . walletPKHash <$> signers)
-prettySigners TxOpts {balanceWallet = BalanceWith balancingWallet} signers =
+prettySigners TxOpts {txOptBalanceWallet = BalanceWith balancingWallet} signers =
   aux (NEList.toList signers)
   where
     aux :: [Wallet] -> [Doc ann]
@@ -292,21 +292,21 @@ prettyValue =
 mPrettyTxOpts :: TxOpts -> Maybe (Doc ann)
 mPrettyTxOpts
   TxOpts
-    { ensureMinAda,
-      autoSlotIncrease,
-      unsafeModTx,
-      balance,
-      balanceOutputPolicy,
-      balanceWallet
+    { txOptEnsureMinAda,
+      txOptAutoSlotIncrease,
+      txOptUnsafeModTx,
+      txOptBalance,
+      txOptBalanceOutputPolicy,
+      txOptBalanceWallet
     } =
     prettyEnumNonEmpty "Options:" "-" $
       catMaybes
-        [ prettyIfNot def prettyEnsureMinAda ensureMinAda,
-          prettyIfNot True prettyAutoSlotIncrease autoSlotIncrease,
-          prettyIfNot True prettyBalance balance,
-          prettyIfNot def prettyBalanceOutputPolicy balanceOutputPolicy,
-          prettyIfNot def prettyBalanceWallet balanceWallet,
-          prettyIfNot [] prettyUnsafeModTx unsafeModTx
+        [ prettyIfNot def prettyEnsureMinAda txOptEnsureMinAda,
+          prettyIfNot True prettyAutoSlotIncrease txOptAutoSlotIncrease,
+          prettyIfNot True prettyBalance txOptBalance,
+          prettyIfNot def prettyBalanceOutputPolicy txOptBalanceOutputPolicy,
+          prettyIfNot def prettyBalanceWallet txOptBalanceWallet,
+          prettyIfNot [] prettyUnsafeModTx txOptUnsafeModTx
         ]
     where
       prettyIfNot :: Eq a => a -> (a -> Doc ann) -> a -> Maybe (Doc ann)

--- a/cooked-validators/src/Cooked/Pretty.hs
+++ b/cooked-validators/src/Cooked/Pretty.hs
@@ -288,8 +288,7 @@ prettyValue =
 
 -- | Pretty-print a list of transaction skeleton options, only printing an option if its value is non-default.
 -- If no non-default options are in the list, return nothing.
---  'awaitTxConfirmed' and 'forceOutputOrdering'
--- (these are deprecated, TODO) are never printed.
+--  'awaitTxConfirmed' is not printed.
 mPrettyTxOpts :: TxOpts -> Maybe (Doc ann)
 mPrettyTxOpts
   TxOpts

--- a/cooked-validators/src/Cooked/Pretty.hs
+++ b/cooked-validators/src/Cooked/Pretty.hs
@@ -292,7 +292,7 @@ prettyValue =
 mPrettyTxOpts :: TxOpts -> Maybe (Doc ann)
 mPrettyTxOpts
   TxOpts
-    { adjustUnbalTx,
+    { ensureMinAda,
       autoSlotIncrease,
       unsafeModTx,
       balance,
@@ -301,7 +301,7 @@ mPrettyTxOpts
     } =
     prettyEnumNonEmpty "Options:" "-" $
       catMaybes
-        [ prettyIfNot def prettyAdjustUnbalTx adjustUnbalTx,
+        [ prettyIfNot def prettyEnsureMinAda ensureMinAda,
           prettyIfNot True prettyAutoSlotIncrease autoSlotIncrease,
           prettyIfNot True prettyBalance balance,
           prettyIfNot def prettyBalanceOutputPolicy balanceOutputPolicy,
@@ -313,9 +313,9 @@ mPrettyTxOpts
       prettyIfNot defaultValue f x
         | x == defaultValue = Nothing
         | otherwise = Just $ f x
-      prettyAdjustUnbalTx :: Bool -> Doc ann
-      prettyAdjustUnbalTx True = "AdjustUnbalTx (min Ada per transaction)"
-      prettyAdjustUnbalTx False = "No AdjustUnbalTx"
+      prettyEnsureMinAda :: Bool -> Doc ann
+      prettyEnsureMinAda True = "Adjust to ensure min Ada per transaction"
+      prettyEnsureMinAda False = "Don't adjust to ensure min Ada per transaction"
       prettyAutoSlotIncrease :: Bool -> Doc ann
       prettyAutoSlotIncrease True = "Automatic slot increase"
       prettyAutoSlotIncrease False = "No automatic slot increase"

--- a/cooked-validators/src/Cooked/Skeleton.hs
+++ b/cooked-validators/src/Cooked/Skeleton.hs
@@ -169,7 +169,7 @@ data TxOpts = TxOpts
     --  By default, this is set to @True@.
     txOptAutoSlotIncrease :: Bool,
     -- | Applies an arbitrary modification to a transaction after it has been
-    -- potentially adjusted ('ensureMinAda) and balanced. This is prefixed
+    -- potentially adjusted ('txOptEnsureMinAda) and balanced. This is prefixed
     -- with /unsafe/ to draw attention to the fact that modifying a transaction
     -- at that stage might make it invalid. Still, this offers a hook for being
     -- able to alter a transaction in unforeseen ways. It is mostly used to test

--- a/cooked-validators/src/Cooked/Skeleton.hs
+++ b/cooked-validators/src/Cooked/Skeleton.hs
@@ -153,7 +153,7 @@ data TxOpts = TxOpts
     --
     -- By default, this is set to @False@, given this is the default behavior in Plutus:
     -- https://github.com/input-output-hk/plutus-apps/issues/143#issuecomment-1013012744
-    adjustUnbalTx :: Bool,
+    ensureMinAda :: Bool,
     -- | When submitting a transaction for real (i.e., running in the 'Plutus.Contract.Contract' monad),
     --  it is common to call 'Plutus.Contract.Request.awaitTxConfirmed' after 'Plutus.Contract.Request.submitTxConstraints'.
     --  If you /do NOT/ wish to do so, please set this to @False@.
@@ -169,7 +169,7 @@ data TxOpts = TxOpts
     --  By default, this is set to @True@.
     autoSlotIncrease :: Bool,
     -- | Applies an arbitrary modification to a transaction after it has been
-    -- potentially adjusted ('adjustUnbalTx') and balanced. This is prefixed
+    -- potentially adjusted ('ensureMinAda) and balanced. This is prefixed
     -- with /unsafe/ to draw attention to the fact that modifying a transaction
     -- at that stage might make it invalid. Still, this offers a hook for being
     -- able to alter a transaction in unforeseen ways. It is mostly used to test
@@ -210,7 +210,7 @@ data TxOpts = TxOpts
 instance Default TxOpts where
   def =
     TxOpts
-      { adjustUnbalTx = False,
+      { ensureMinAda = False,
         awaitTxConfirmed = True,
         autoSlotIncrease = True,
         unsafeModTx = [],

--- a/cooked-validators/src/Cooked/Skeleton.hs
+++ b/cooked-validators/src/Cooked/Skeleton.hs
@@ -168,11 +168,6 @@ data TxOpts = TxOpts
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     --  By default, this is set to @True@.
     autoSlotIncrease :: Bool,
-    -- | Reorders the transaction outputs to fit the ordering of output
-    -- constraints. Those outputs are put at the very beginning of the list.
-    -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
-    --  By default, this is set to @True@.
-    forceOutputOrdering :: Bool,
     -- | Applies an arbitrary modification to a transaction after it has been
     -- potentially adjusted ('adjustUnbalTx') and balanced. This is prefixed
     -- with /unsafe/ to draw attention to the fact that modifying a transaction
@@ -218,7 +213,6 @@ instance Default TxOpts where
       { adjustUnbalTx = False,
         awaitTxConfirmed = True,
         autoSlotIncrease = True,
-        forceOutputOrdering = True,
         unsafeModTx = [],
         balance = True,
         balanceOutputPolicy = def,

--- a/cooked-validators/src/Cooked/Skeleton.hs
+++ b/cooked-validators/src/Cooked/Skeleton.hs
@@ -153,21 +153,21 @@ data TxOpts = TxOpts
     --
     -- By default, this is set to @False@, given this is the default behavior in Plutus:
     -- https://github.com/input-output-hk/plutus-apps/issues/143#issuecomment-1013012744
-    ensureMinAda :: Bool,
+    txOptEnsureMinAda :: Bool,
     -- | When submitting a transaction for real (i.e., running in the 'Plutus.Contract.Contract' monad),
     --  it is common to call 'Plutus.Contract.Request.awaitTxConfirmed' after 'Plutus.Contract.Request.submitTxConstraints'.
     --  If you /do NOT/ wish to do so, please set this to @False@.
     --
     --  /This has NO effect when running outside of 'Plutus.Contract.Contract'/.
     --  By default, this is set to @True@.
-    awaitTxConfirmed :: Bool,
+    txOptAwaitTxConfirmed :: Bool,
     -- | Whether to increase the slot counter automatically on this submission.
     -- This is useful for modelling transactions that could be submitted in parallel in reality, so there
     -- should be no explicit ordering of what comes first. One good example is in the Crowdfunding use case contract.
     --
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     --  By default, this is set to @True@.
-    autoSlotIncrease :: Bool,
+    txOptAutoSlotIncrease :: Bool,
     -- | Applies an arbitrary modification to a transaction after it has been
     -- potentially adjusted ('ensureMinAda) and balanced. This is prefixed
     -- with /unsafe/ to draw attention to the fact that modifying a transaction
@@ -183,7 +183,7 @@ data TxOpts = TxOpts
     -- default, this is set to the empty list.
     --
     -- The leftmost function in the list is applied first.
-    unsafeModTx :: [RawModTx],
+    txOptUnsafeModTx :: [RawModTx],
     -- | Whether to balance the transaction or not. Balancing
     --  ensures that @input + mint = output + fees + burns@, if you decide to
     --  set @balance = false@ you will have trouble satisfying that equation by
@@ -192,31 +192,31 @@ data TxOpts = TxOpts
     --
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     -- By default, this is set to @True@.
-    balance :: Bool,
+    txOptBalance :: Bool,
     -- | The 'BalanceOutputPolicy' to apply when balancing the transaction.
     --
     -- /This has NO effect when running in 'Plutus.Contract.Contract'/.
     -- By default, this is set to @AdjustExistingOutput@.
-    balanceOutputPolicy :: BalanceOutputPolicy,
+    txOptBalanceOutputPolicy :: BalanceOutputPolicy,
     -- | Which wallet to use to provide outputs for balancing and collaterals.
     -- Either the first signer by default, or an explicit wallet. In the second
     -- case, this wallet must be a signer of the transaction. This option WILL
     -- NOT ensure that it is added in case it is not already present in the
     -- list of signers.
-    balanceWallet :: BalancingWallet
+    txOptBalanceWallet :: BalancingWallet
   }
   deriving (Eq, Show)
 
 instance Default TxOpts where
   def =
     TxOpts
-      { ensureMinAda = False,
-        awaitTxConfirmed = True,
-        autoSlotIncrease = True,
-        unsafeModTx = [],
-        balance = True,
-        balanceOutputPolicy = def,
-        balanceWallet = def
+      { txOptEnsureMinAda = False,
+        txOptAwaitTxConfirmed = True,
+        txOptAutoSlotIncrease = True,
+        txOptUnsafeModTx = [],
+        txOptBalance = True,
+        txOptBalanceOutputPolicy = def,
+        txOptBalanceWallet = def
       }
 
 -- * Description of the Minting

--- a/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
@@ -62,7 +62,7 @@ lockValue = L.lovelaceValueOf 12345678
 lockTxSkel :: Pl.TxOutRef -> Pl.TypedValidator MockContract -> TxSkel
 lockTxSkel o v =
   txSkelTemplate
-    { txSkelOpts = def {ensureMinAda = True},
+    { txSkelOpts = def {txOptEnsureMinAda = True},
       txSkelIns = Map.singleton o TxSkelNoRedeemerForPK,
       txSkelOuts = [paysScriptInlineDatum v FirstLock lockValue]
     }
@@ -76,7 +76,7 @@ txLock v = do
 relockTxSkel :: Pl.TypedValidator MockContract -> Pl.TxOutRef -> TxSkel
 relockTxSkel v o =
   txSkelTemplate
-    { txSkelOpts = def {ensureMinAda = True},
+    { txSkelOpts = def {txOptEnsureMinAda = True},
       txSkelIns = Map.singleton o $ TxSkelRedeemerForScript @MockContract (),
       txSkelOuts = [paysScriptInlineDatum v SecondLock lockValue]
     }

--- a/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
@@ -62,7 +62,7 @@ lockValue = L.lovelaceValueOf 12345678
 lockTxSkel :: Pl.TxOutRef -> Pl.TypedValidator MockContract -> TxSkel
 lockTxSkel o v =
   txSkelTemplate
-    { txSkelOpts = def {adjustUnbalTx = True},
+    { txSkelOpts = def {ensureMinAda = True},
       txSkelIns = Map.singleton o TxSkelNoRedeemerForPK,
       txSkelOuts = [paysScriptInlineDatum v FirstLock lockValue]
     }
@@ -76,7 +76,7 @@ txLock v = do
 relockTxSkel :: Pl.TypedValidator MockContract -> Pl.TxOutRef -> TxSkel
 relockTxSkel v o =
   txSkelTemplate
-    { txSkelOpts = def {adjustUnbalTx = True},
+    { txSkelOpts = def {ensureMinAda = True},
       txSkelIns = Map.singleton o $ TxSkelRedeemerForScript @MockContract (),
       txSkelOuts = [paysScriptInlineDatum v SecondLock lockValue]
     }

--- a/cooked-validators/tests/Cooked/Attack/DupTokenSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DupTokenSpec.hs
@@ -60,7 +60,7 @@ dupTokenTrace pol tName amount recipient = void $ validateTxSkel skel
       let mints = txSkelMintsFromList [(pol, NoMintsRedeemer, tName, amount)]
           mintedValue = txSkelMintsValue mints
        in txSkelTemplate
-            { txSkelOpts = def {adjustUnbalTx = True},
+            { txSkelOpts = def {ensureMinAda = True},
               txSkelMints = mints,
               txSkelOuts = [paysPK (walletPKHash recipient) mintedValue]
             }

--- a/cooked-validators/tests/Cooked/Attack/DupTokenSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DupTokenSpec.hs
@@ -60,7 +60,7 @@ dupTokenTrace pol tName amount recipient = void $ validateTxSkel skel
       let mints = txSkelMintsFromList [(pol, NoMintsRedeemer, tName, amount)]
           mintedValue = txSkelMintsValue mints
        in txSkelTemplate
-            { txSkelOpts = def {ensureMinAda = True},
+            { txSkelOpts = def {txOptEnsureMinAda = True},
               txSkelMints = mints,
               txSkelOuts = [paysPK (walletPKHash recipient) mintedValue]
             }

--- a/cooked-validators/tests/Cooked/InlineDatumsSpec.hs
+++ b/cooked-validators/tests/Cooked/InlineDatumsSpec.hs
@@ -117,7 +117,7 @@ listUtxosTestTrace useInlineDatum validator =
   utxosFromCardanoTx
     <$> validateTxSkel
       txSkelTemplate
-        { txSkelOpts = def {adjustUnbalTx = True},
+        { txSkelOpts = def {ensureMinAda = True},
           txSkelOuts =
             [ ( if useInlineDatum
                   then paysScriptInlineDatum validator FirstPaymentDatum
@@ -145,7 +145,7 @@ spendOutputTestTrace useInlineDatum validator = do
   void $
     validateTxSkel
       txSkelTemplate
-        { txSkelOpts = def {adjustUnbalTx = True},
+        { txSkelOpts = def {ensureMinAda = True},
           txSkelIns =
             Map.singleton
               theTxOutRef
@@ -172,7 +172,7 @@ continuingOutputTestTrace datumKindOnSecondPayment validator = do
   void $
     validateTxSkel
       txSkelTemplate
-        { txSkelOpts = def {adjustUnbalTx = True},
+        { txSkelOpts = def {ensureMinAda = True},
           txSkelIns =
             Map.singleton
               theTxOutRef

--- a/cooked-validators/tests/Cooked/InlineDatumsSpec.hs
+++ b/cooked-validators/tests/Cooked/InlineDatumsSpec.hs
@@ -117,7 +117,7 @@ listUtxosTestTrace useInlineDatum validator =
   utxosFromCardanoTx
     <$> validateTxSkel
       txSkelTemplate
-        { txSkelOpts = def {ensureMinAda = True},
+        { txSkelOpts = def {txOptEnsureMinAda = True},
           txSkelOuts =
             [ ( if useInlineDatum
                   then paysScriptInlineDatum validator FirstPaymentDatum
@@ -145,7 +145,7 @@ spendOutputTestTrace useInlineDatum validator = do
   void $
     validateTxSkel
       txSkelTemplate
-        { txSkelOpts = def {ensureMinAda = True},
+        { txSkelOpts = def {txOptEnsureMinAda = True},
           txSkelIns =
             Map.singleton
               theTxOutRef
@@ -172,7 +172,7 @@ continuingOutputTestTrace datumKindOnSecondPayment validator = do
   void $
     validateTxSkel
       txSkelTemplate
-        { txSkelOpts = def {ensureMinAda = True},
+        { txSkelOpts = def {txOptEnsureMinAda = True},
           txSkelIns =
             Map.singleton
               theTxOutRef

--- a/examples/src/Auction/Offchain.hs
+++ b/examples/src/Auction/Offchain.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Auction.Offchain where
@@ -30,9 +31,10 @@ txOffer :: MonadBlockChain m => Wallet -> L.Value -> Integer -> m Pl.TxOutRef
 txOffer seller lot minBid = do
   tx <-
     validateTxSkel $
-      (txSkelSubmittedBy seller)
+      txSkelTemplate
         { txSkelOpts = def {txOptEnsureMinAda = True},
-          txSkelOuts = [paysScript A.auctionValidator (A.Offer (walletPKHash seller) minBid) lot]
+          txSkelOuts = [paysScript A.auctionValidator (A.Offer (walletPKHash seller) minBid) lot],
+          txSkelSigners = [seller]
         }
   return . head
     . mapMaybe
@@ -53,8 +55,9 @@ txSetDeadline submitter offerOref deadline = do
   Just (A.Offer seller minBid) <- typedDatumFromTxOutRef @(Pl.DatumType A.Auction) offerOref
   Just lot <- valueFromTxOutRef offerOref
   validateTxSkel $
-    (txSkelSubmittedBy submitter)
+    txSkelTemplate
       { txSkelOpts = def {txOptEnsureMinAda = True},
+        txSkelSigners = [submitter],
         txSkelMints =
           txSkelMintsFromList
             [ ( Pl.Versioned A.threadTokenPolicy Pl.PlutusV2,
@@ -96,8 +99,9 @@ txBid submitter offerOref bid = do
       seller = A.getSeller datum
       lotPlusPreviousBidPlusNft = outputValue output
   validateTxSkel $
-    (txSkelSubmittedBy submitter)
+    txSkelTemplate
       { txSkelOpts = def {txOptEnsureMinAda = True},
+        txSkelSigners = [submitter],
         txSkelIns =
           Map.singleton oref $
             TxSkelRedeemerForScript
@@ -141,8 +145,9 @@ txHammer submitter offerOref = do
         Just lot <- valueFromTxOutRef offerOref
         void $
           validateTxSkel $
-            (txSkelSubmittedBy submitter)
+            txSkelTemplate
               { txSkelOpts = def {txOptEnsureMinAda = True},
+                txSkelSigners = [submitter],
                 txSkelIns =
                   Map.singleton offerOref $
                     TxSkelRedeemerForScript @A.Auction (A.Hammer offerOref),
@@ -156,8 +161,9 @@ txHammer submitter offerOref = do
           seller = A.getSeller datum
       void $
         validateTxSkel $
-          (txSkelSubmittedBy submitter)
+          txSkelTemplate
             { txSkelOpts = def {txOptEnsureMinAda = True},
+              txSkelSigners = [submitter],
               txSkelIns =
                 Map.singleton oref $
                   TxSkelRedeemerForScript @A.Auction (A.Hammer offerOref),

--- a/examples/src/Auction/Offchain.hs
+++ b/examples/src/Auction/Offchain.hs
@@ -31,7 +31,7 @@ txOffer seller lot minBid = do
   tx <-
     validateTxSkel $
       (txSkelSubmittedBy seller)
-        { txSkelOpts = def {ensureMinAda = True},
+        { txSkelOpts = def {txOptEnsureMinAda = True},
           txSkelOuts = [paysScript A.auctionValidator (A.Offer (walletPKHash seller) minBid) lot]
         }
   return . head
@@ -54,7 +54,7 @@ txSetDeadline submitter offerOref deadline = do
   Just lot <- valueFromTxOutRef offerOref
   validateTxSkel $
     (txSkelSubmittedBy submitter)
-      { txSkelOpts = def {ensureMinAda = True},
+      { txSkelOpts = def {txOptEnsureMinAda = True},
         txSkelMints =
           txSkelMintsFromList
             [ ( Pl.Versioned A.threadTokenPolicy Pl.PlutusV2,
@@ -97,7 +97,7 @@ txBid submitter offerOref bid = do
       lotPlusPreviousBidPlusNft = outputValue output
   validateTxSkel $
     (txSkelSubmittedBy submitter)
-      { txSkelOpts = def {ensureMinAda = True},
+      { txSkelOpts = def {txOptEnsureMinAda = True},
         txSkelIns =
           Map.singleton oref $
             TxSkelRedeemerForScript
@@ -142,7 +142,7 @@ txHammer submitter offerOref = do
         void $
           validateTxSkel $
             (txSkelSubmittedBy submitter)
-              { txSkelOpts = def {ensureMinAda = True},
+              { txSkelOpts = def {txOptEnsureMinAda = True},
                 txSkelIns =
                   Map.singleton offerOref $
                     TxSkelRedeemerForScript @A.Auction (A.Hammer offerOref),
@@ -157,7 +157,7 @@ txHammer submitter offerOref = do
       void $
         validateTxSkel $
           (txSkelSubmittedBy submitter)
-            { txSkelOpts = def {ensureMinAda = True},
+            { txSkelOpts = def {txOptEnsureMinAda = True},
               txSkelIns =
                 Map.singleton oref $
                   TxSkelRedeemerForScript @A.Auction (A.Hammer offerOref),

--- a/examples/src/Auction/Offchain.hs
+++ b/examples/src/Auction/Offchain.hs
@@ -31,7 +31,7 @@ txOffer seller lot minBid = do
   tx <-
     validateTxSkel $
       (txSkelSubmittedBy seller)
-        { txSkelOpts = def {adjustUnbalTx = True},
+        { txSkelOpts = def {ensureMinAda = True},
           txSkelOuts = [paysScript A.auctionValidator (A.Offer (walletPKHash seller) minBid) lot]
         }
   return . head
@@ -54,7 +54,7 @@ txSetDeadline submitter offerOref deadline = do
   Just lot <- valueFromTxOutRef offerOref
   validateTxSkel $
     (txSkelSubmittedBy submitter)
-      { txSkelOpts = def {adjustUnbalTx = True},
+      { txSkelOpts = def {ensureMinAda = True},
         txSkelMints =
           txSkelMintsFromList
             [ ( Pl.Versioned A.threadTokenPolicy Pl.PlutusV2,
@@ -97,7 +97,7 @@ txBid submitter offerOref bid = do
       lotPlusPreviousBidPlusNft = outputValue output
   validateTxSkel $
     (txSkelSubmittedBy submitter)
-      { txSkelOpts = def {adjustUnbalTx = True},
+      { txSkelOpts = def {ensureMinAda = True},
         txSkelIns =
           Map.singleton oref $
             TxSkelRedeemerForScript
@@ -142,7 +142,7 @@ txHammer submitter offerOref = do
         void $
           validateTxSkel $
             (txSkelSubmittedBy submitter)
-              { txSkelOpts = def {adjustUnbalTx = True},
+              { txSkelOpts = def {ensureMinAda = True},
                 txSkelIns =
                   Map.singleton offerOref $
                     TxSkelRedeemerForScript @A.Auction (A.Hammer offerOref),
@@ -157,7 +157,7 @@ txHammer submitter offerOref = do
       void $
         validateTxSkel $
           (txSkelSubmittedBy submitter)
-            { txSkelOpts = def {adjustUnbalTx = True},
+            { txSkelOpts = def {ensureMinAda = True},
               txSkelIns =
                 Map.singleton oref $
                   TxSkelRedeemerForScript @A.Auction (A.Hammer offerOref),


### PR DESCRIPTION
A very small PR to upgrade `TxOpts`:

* Prefix the fields with `txOpt`, e.g. `txOptBalanceWallet`
* Remove `forceOutputOrdering` which is no longer relevant (the outputs of our transactions are always generated in the same order as their spec in the skeleton)
* Rename `adjustUnbalTx` to `ensureMinAda` to avoid confusion with balancing (option `balance`)