### PR TITLE
Setup Cachix for this repository

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,8 +64,7 @@ jobs:
         run: |
           ## REVIEW: There might be a way to just build all the devShells? Also,
           ## we might want to consider building all the package dependencies?
-          nix develop .#ci --command true
-          nix develop      --command true
+          nix develop -L --command true
 
   ## REVIEW: We could have `build-and-test` need `setup-nix-dependencies`. That
   ## would save work that is currently duplicated. However, this would make the

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3.3.0
 
+      - run: cat /proc/meminfo
+
+      - run: false
+
       - name: Install Nix
         uses: cachix/install-nix-action@v18
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           ## REVIEW: There might be a way to just build all the devShells? Also,
           ## we might want to consider building all the package dependencies?
-          nix develop -L --command true
+          nix develop --print-build-logs --max-jobs 1 --command true
 
   ## REVIEW: We could have `build-and-test` need `setup-nix-dependencies`. That
   ## would save work that is currently duplicated. However, this would make the

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,6 @@
-name: Build and test
+---
+
+name: CI
 
 on:
   push:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,7 +40,7 @@ jobs:
           nix develop .#ci --command true
 
   cache-all-nix-dependencies:
-    name: Cache All Nix dependencies
+    name: Cache all Nix dependencies
 
     runs-on: ubuntu-latest
     needs: cache-minimal-nix-dependencies

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
 
-  cache-nix-dependencies:
-    name: Cache Nix dependencies
+  cache-nix-ci-dependencies:
+    name: Cache Nix CI dependencies
     runs-on: ubuntu-latest
+    needs: []
 
     steps:
       - name: Check out repository code
@@ -19,8 +20,8 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v18
         with:
-          ## Some flake caching
           extra_nix_config: |
+            ## Access token to avoid triggering GitHub's rate limiting.
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Nix caches
@@ -28,15 +29,43 @@ jobs:
         with:
           name: tweag-plutus-libs
           ## This auth token will give write access to the cache, meaning that
-          ## everything that happens in CI will be
+          ## everything that happens in CI will be pushed at the end of the job.
           authToken: '${{ secrets.CACHIX_TWEAG_PLUTUS_LIBS_AUTH_TOKEN }}'
 
-      - name: Build Nix environment
+      - name: Build Nix CI environment
+        run: |
+          nix develop .#ci --command true
+
+  cache-all-nix-dependencies:
+    name: Cache All Nix dependencies
+    runs-on: ubuntu-latest
+    needs: cache-nix-ci-dependencies
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3.3.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            ## Access token to avoid triggering GitHub's rate limiting.
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Nix caches
+        uses: cachix/cachix-action@v11
+        with:
+          name: tweag-plutus-libs
+          ## This auth token will give write access to the cache, meaning that
+          ## everything that happens in CI will be pushed at the end of the job.
+          authToken: '${{ secrets.CACHIX_TWEAG_PLUTUS_LIBS_AUTH_TOKEN }}'
+
+      - name: Build all Nix environments
         run: |
           ## REVIEW: There might be a way to just build all the devShells? Also,
           ## we might want to consider building all the package dependencies?
-          nix develop      --command true
           nix develop .#ci --command true
+          nix develop      --command true
 
   ## REVIEW: We could have `build-and-test` need `setup-nix-dependencies`. That
   ## would save work that is currently duplicated. However, this would make the
@@ -47,6 +76,7 @@ jobs:
   build-and-test:
     name: Build and run tests
     runs-on: ubuntu-latest
+    needs: cache-nix-ci-dependencies
 
     steps:
     - name: Check out repository code (from PR).
@@ -55,8 +85,8 @@ jobs:
     - name: Install nix.
       uses: cachix/install-nix-action@v18
       with:
-        ## Some flake caching
         extra_nix_config: |
+          ## Access token to avoid triggering GitHub's rate limiting.
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Nix caches
@@ -92,9 +122,9 @@ jobs:
           ./*.res
 
   check-result:
-    needs: build-and-test
     name: Check tests output
     runs-on: ubuntu-latest
+    needs: build-and-test
 
     steps:
     - name: Accessing tests output

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,18 +8,15 @@ on:
 
 jobs:
 
-  cache-nix-ci-dependencies:
-    name: Cache Nix CI dependencies
+  cache-minimal-nix-dependencies:
+    name: Cache minimal Nix dependencies
+
     runs-on: ubuntu-latest
     needs: []
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3.3.0
-
-      - run: cat /proc/meminfo
-
-      - run: false
 
       - name: Install Nix
         uses: cachix/install-nix-action@v18
@@ -42,8 +39,9 @@ jobs:
 
   cache-all-nix-dependencies:
     name: Cache All Nix dependencies
+
     runs-on: ubuntu-latest
-    needs: cache-nix-ci-dependencies
+    needs: cache-minimal-nix-dependencies
 
     steps:
       - name: Check out repository code
@@ -70,16 +68,11 @@ jobs:
           ## we might want to consider building all the package dependencies?
           nix develop --print-build-logs --max-jobs 1 --command true
 
-  ## REVIEW: We could have `build-and-test` need `setup-nix-dependencies`. That
-  ## would save work that is currently duplicated. However, this would make the
-  ## CI quite slower because it would have to re-download things; it would also
-  ## need to first build all the devShells (and not only `ci`) before running
-  ## the rest.
-  ##
   build-and-test:
     name: Build and run tests
+
     runs-on: ubuntu-latest
-    needs: cache-nix-ci-dependencies
+    needs: cache-minimal-nix-dependencies
 
     steps:
     - name: Check out repository code (from PR).
@@ -126,6 +119,7 @@ jobs:
 
   check-result:
     name: Check tests output
+
     runs-on: ubuntu-latest
     needs: build-and-test
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,9 +7,47 @@ on:
   pull_request:
 
 jobs:
+
+  cache-nix-dependencies:
+    name: Cache Nix dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3.3.0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          ## Some flake caching
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Nix caches
+        uses: cachix/cachix-action@v11
+        with:
+          name: tweag-plutus-libs
+          ## This auth token will give write access to the cache, meaning that
+          ## everything that happens in CI will be
+          authToken: '${{ secrets.CACHIX_TWEAG_PLUTUS_LIBS_AUTH_TOKEN }}'
+
+      - name: Build Nix environment
+        run: |
+          ## REVIEW: There might be a way to just build all the devShells? Also,
+          ## we might want to consider building all the package dependencies?
+          nix develop      --command true
+          nix develop .#ci --command true
+
+  ## REVIEW: We could have `build-and-test` need `setup-nix-dependencies`. That
+  ## would save work that is currently duplicated. However, this would make the
+  ## CI quite slower because it would have to re-download things; it would also
+  ## need to first build all the devShells (and not only `ci`) before running
+  ## the rest.
+  ##
   build-and-test:
     name: Build and run tests
     runs-on: ubuntu-latest
+
     steps:
     - name: Check out repository code (from PR).
       uses: actions/checkout@v3.3.0
@@ -20,7 +58,13 @@ jobs:
         ## Some flake caching
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      
+
+    - name: Setup Nix caches
+      uses: cachix/cachix-action@v11
+      with:
+        name: tweag-plutus-libs
+        ## No auth token: read-only access.
+
     ## Example from
     ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
     - name: Accessing the cabal cache.
@@ -51,6 +95,7 @@ jobs:
     needs: build-and-test
     name: Check tests output
     runs-on: ubuntu-latest
+
     steps:
     - name: Accessing tests output
       uses: actions/download-artifact@v3
@@ -65,7 +110,7 @@ jobs:
             echo "!! [$proj]: output from $step"
             cat $proj-$step.out
             res=$(cat $proj-$step.res | cut -d':' -f2)
-            if [[ "$res" != "0" ]]; then 
+            if [[ "$res" != "0" ]]; then
               is_ok=false
             fi
           done
@@ -83,4 +128,3 @@ jobs:
         else
           exit 1
         fi
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
-name: Publish cooked-validators documentation
+name: Deploy
+
 on:
   push:
     branches:
@@ -8,9 +9,12 @@ permissions:
   contents: write
 
 jobs:
+
   build-and-test:
     name: Documentation
+
     runs-on: ubuntu-latest
+
     steps:
     - name: Check out repository code (from PR).
       uses: actions/checkout@v3.3.0
@@ -18,8 +22,8 @@ jobs:
     - name: Install nix.
       uses: cachix/install-nix-action@v18
       with:
-        ## Some flake caching
         extra_nix_config: |
+          ## Access token to avoid triggering GitHub's rate limiting.
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Nix caches

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,13 @@ jobs:
         ## Some flake caching
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      
+
+    - name: Setup Nix caches
+      uses: cachix/cachix-action@v11
+      with:
+        name: tweag-plutus-libs
+        ## No auth token: read-only access.
+
     ## Example from
     ## https://github.com/actions/cache/blob/ac25611caef967612169ab7e95533cf932c32270/examples.md#haskell---cabal
     - name: Accessing the cabal cache.

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/22.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
+
   outputs = { self, nixpkgs, flake-utils, }:
     flake-utils.lib.eachDefaultSystem (system:
       let
@@ -58,4 +59,11 @@
           };
         };
       });
+
+  nixConfig = {
+    extra-trusted-substituters = [ "https://tweag-plutus-libs.cachix.org/" ];
+    extra-trusted-public-keys = [
+      "tweag-plutus-libs.cachix.org-1:0BeVJYx8DnUWJWapRDZeLPOOboBUy3UwhvONd5Qm2Xc="
+    ];
+  };
 }


### PR DESCRIPTION
This PR sets up a Cachix instance for plutus-libs. The CI is modified to build not only `devShells.<system>.ci` but also `devShells.<system>.default` and to push all the obtained derivations in Cachix. The flake enables the use of this Cachix automatically.