### PR TITLE
Set LANG for GHC

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,17 +50,20 @@
           ## Needed by `pirouette-plutusir` and `cooked`
           LD_LIBRARY_PATH = with pkgs;
             lib.strings.makeLibraryPath [ libsodium zlib xz z3 ];
+          LANG = "C.UTF-8";
         in {
           default = pkgs.mkShell {
             buildInputs = required
               ++ (with haskellPackages; [ haskell-language-server ])
               ++ (with pkgs; [ ormolu hpack hlint ]);
             inherit LD_LIBRARY_PATH;
+            inherit LANG;
           };
 
           ci = pkgs.mkShell {
             buildInputs = required;
             inherit LD_LIBRARY_PATH;
+            inherit LANG;
           };
         };
       });


### PR DESCRIPTION
Without a proper `LANG` setting (with UTF-8), GHC fails when printing unicode characters, which happens when printing "minus infinity" for the valid interval of transactions.