### PR TITLE
Make sure to use nixpkgs's Ormolu

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,9 +67,12 @@
           };
 
           default = pkgs.mkShell {
-            buildInputs = buildInputs
-              ++ (with hpkgs; [ haskell-language-server ])
-              ++ (with pkgs; [ ormolu hpack hlint ]);
+            ## NOTE: `pkgs.ormolu` must appear before `hpkgs.haskell-language-server`
+            ## in the `buildInputs`, so as to take precedence. This ensures that the
+            ## version of Ormolu available in the path is that of nixpkgs and not the
+            ## one pinned by HLS.
+            buildInputs = buildInputs ++ (with pkgs; [ ormolu hpack hlint ])
+              ++ (with hpkgs; [ haskell-language-server ]);
             inherit (pre-commit) shellHook;
             inherit LD_LIBRARY_PATH;
           };


### PR DESCRIPTION
The order of arguments matters in `buildInputs`, sadly. In this case, `pkgs.ormolu` was shadowed by the Ormolu brought by `hpkgs.haskell-language-server`. The versions are quite different: nixpkgs contains Ormolu 0.3 while HLS brings Ormolu 0.5. Since most things rely on nixpkgs's Ormolu, I think it makes more sense to ensure that it is the one picked up by the pre-commit hooks and available in the environment. The current PR fixes that issue by reordering the build inputs, and leaves a note for our future selves.