### PR TITLE
Clean up the comments

### DIFF
--- a/cooked-validators/src/Cooked/Skeleton.hs
+++ b/cooked-validators/src/Cooked/Skeleton.hs
@@ -422,7 +422,7 @@ instance IsTxSkelOutAllowedOwner (Pl.TypedValidator a) where
 data TxSkelOut where
   Pays ::
     ( Show o, -- This is needed only for the 'Show' instance of 'TxSkel', which in turn is only needed in tests.
-      IsOnchainOutput o,
+      IsTxInfoOutput o,
       IsTxSkelOutAllowedOwner (OwnerType o),
       Typeable (OwnerType o),
       ToCredential (OwnerType o),


### PR DESCRIPTION
I know that there are many outdated or confusing comments in cooked-validators. We've now reached a point where it makes sense to go through all of the code and remove or reword them. I'll also do simple renamings in this PR, but nothing else. 

- [ ] Cooked/Attack/AddToken.hs
- [ ] Cooked/Attack/DatumHijacking.hs
- [ ] Cooked/Attack/DoubleSat.hs
- [ ] Cooked/Attack/DupToken.hs
- [ ] Cooked/Attack.hs
- [ ] Cooked/Currencies.hs
- [ ] Cooked/Ltl.hs
- [ ] Cooked/MockChain/BlockChain.hs
- [ ] Cooked/MockChain/Direct.hs
- [ ] Cooked/MockChain/GenerateTx.hs
- [ ] Cooked/MockChain/Staged.hs
- [ ] Cooked/MockChain/Testing.hs
- [ ] Cooked/MockChain/UtxoState.hs
- [ ] Cooked/MockChain.hs
- [x] Cooked/Output.hs
- [ ] Cooked/Pretty/Class.hs
- [ ] Cooked/Pretty.hs
- [ ] Cooked/RawUPLC.hs
- [ ] Cooked/Skeleton.hs
- [ ] Cooked/Tweak/AddInputsAndOutputs.hs
- [ ] Cooked/Tweak/Common.hs
- [ ] Cooked/Tweak/Labels.hs
- [ ] Cooked/Tweak/OutPermutations.hs
- [ ] Cooked/Tweak/TamperDatum.hs
- [ ] Cooked/Tweak.hs
- [ ] Cooked/Wallet.hs
- [ ] Cooked.hs