### PR TITLE
Use upstream's `hpack` now that it's fixed

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -124,11 +124,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1674550893,
-        "narHash": "sha256-HXI8AB96PP7UZ7iPANACXM8qc9eMz0ljxBEDM8JJKhY=",
+        "lastModified": 1675688762,
+        "narHash": "sha256-oit/SxMk0B380ASuztBGQLe8TttO1GJiXF8aZY9AYEc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7bdf85f6bbef581eb687838d19f2b35a4c9d77f0",
+        "rev": "ab608394886fb04b8a5df3cb0bab2598400e3634",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,31 +18,7 @@
           hooks = {
             nixfmt.enable = true;
             ormolu.enable = true;
-
-            ## FIXME: The upstream `hpack` hook is completely broken, so we
-            ## write our own, heavily inspired by theirs but introducing some
-            ## fixes. The bugs have been reported at
-            ##
-            ## https://github.com/cachix/pre-commit-hooks.nix/issues/235
-            ##
-            ## and we should simply update pre-commit-hooks, remove all this and
-            ## replace it by `hpack.enable = true` once they are fixed.
-            hpack-fixed = {
-              enable = true;
-              entry = let
-                hpack-dir = pkgs.writeShellApplication {
-                  name = "hpack-dir";
-                  text = ''
-                    set -e
-                    find . -type f -name package.yaml | while read -r file; do
-                        ${pkgs.hpack}/bin/hpack --force "$file"
-                    done
-                  '';
-                };
-              in "${hpack-dir}/bin/hpack-dir";
-              files = "(\\.l?hs(-boot)?$)|(\\.cabal$)|((^|/)package\\.yaml$)";
-              pass_filenames = false;
-            };
+            hpack.enable = true;
           };
         };
       in {


### PR DESCRIPTION
https://github.com/cachix/pre-commit-hooks.nix/pull/236 has been merged; we can now rely on upstream again.