### PR TITLE
Remove redundancy in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,11 +2,6 @@ packages:
   cooked-validators
   examples
 
-source-repository-package
-  type: git
-  location: https://github.com/tweag/pirouette.git
-  tag: 6cebde8792b8a84cc9c4a1cecf9f90285173d662
-
 package cardano-crypto-praos
   flags: -external-libsodium-vrf
 
@@ -35,13 +30,6 @@ source-repository-package
     plutus-use-cases
     rewindable-index
     cardano-node-emulator
-
--- The last update fixes some bug
-source-repository-package
-  type: git
-  location: https://github.com/astanin/moo
-  tag: dbda5e76ac3b4c72c805ec0cdb9bcdff7bb6247d
-  --sha256: 1mdj218hgh7s5a6b9k14vg9i06zxah0wa42ycdgh245izs8nfv0x
 
 -- The last update fixes some bug
 source-repository-package


### PR DESCRIPTION
Pirouette is not needed anymore, and `moo` was declared twice.