### PR TITLE
Add a function to run tweaks in the mock chain

### DIFF
--- a/cooked-validators/src/Cooked/Tweak/Common.hs
+++ b/cooked-validators/src/Cooked/Tweak/Common.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- | This module defines 'Tweaks' which are the fundamental building blocks of
 -- our "domain specific language" for attacks.


### PR DESCRIPTION
This clarifies the documentation comment for `runTweakInChain` and adds a function
```haskell
runTweakInChain' :: MonadBlockChainWithoutValidation m => Tweak m a -> TxSkel -> m [(a, TxSkel)]
```
which allows one to manually apply a tweak to a transaction, returning all modified transactions in a list.

@gabrielhdt and I discussed something like this in the morning, and because I'm not convinced that this feature is useful in the spirit of much of the rest of cooked, at least `MonadModalBlockChain`, I thought I'd open this PR to discuss it with you.