### PR TITLE
No need for source repository for moo

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -30,13 +30,7 @@ source-repository-package
     plutus-use-cases
     rewindable-index
     cardano-node-emulator
-
--- The last update fixes some bug
-source-repository-package
-  type: git
-  location: https://github.com/astanin/moo
-  tag: dbda5e76ac3b4c72c805ec0cdb9bcdff7bb6247d
-  --sha256: 1mdj218hgh7s5a6b9k14vg9i06zxah0wa42ycdgh245izs8nfv0x
+  --sha256: 16s7ny52cwmfw202q6pfgibaz98rnbrm1laf129ll8nyscwqpjgy
 
 -- Everything below this point has been copied from plutus-apps' cabal.project
 
@@ -171,6 +165,7 @@ source-repository-package
       lib/strict-non-empty-containers
       lib/test-utils
       lib/text-class
+    --sha256: 0i40hp1mdbljjcj4pn3n6zahblkb2jmpm8l4wnb36bya1pzf66fx
 
 -- Direct dependency.
 source-repository-package
@@ -179,6 +174,7 @@ source-repository-package
     tag: 5cd16ba995f1cd48c2b5f885c702ca6f2a2abbaa
     subdir:
       contractmodel
+    --sha256: 17cj4whx2s4hv68azgj54nfp7l61gs6fqdlbaw713yqzmypmsmdd
 
 -- Should follow cardano-wallet.
 source-repository-package
@@ -190,6 +186,7 @@ source-repository-package
       command-line
       -- cardano-addresses
       core
+    --sha256: 129r5kyiw10n2021bkdvnr270aiiwyq58h472d151ph0r7wpslgp
 
 -- This is needed because we rely on an unreleased feature
 -- https://github.com/input-output-hk/cardano-ledger/pull/3111
@@ -221,3 +218,4 @@ source-repository-package
       libs/small-steps
       libs/small-steps-test
       libs/non-integral
+    --sha256: 1jg1h05gcms119mw7fz798xpj3hr5h426ga934vixmgf88m1jmfx


### PR DESCRIPTION
CHaP contains the patched version. Also add sha256, which will be required by haskell.nix.