### PR TITLE
Show instance for UtxoState

### DIFF
--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -376,6 +376,10 @@ prettyUtxoState opts =
       (Pl.Address (Pl.ScriptCredential _) _, _) = LT
     addressOrdering (a1, _) (a2, _) = compare a1 a2
 
+-- | The 'Show' instance is essential for REPL interaction
+instance Show UtxoState where
+  show = renderString $ prettyUtxoState def
+
 -- | Pretty prints the state of an address, that is the list of utxos
 -- (including value and datum), grouped
 prettyAddressState :: PrettyCookedOpts -> Pl.Address -> [(Pl.Value, TxSkelOutDatum)] -> DocCooked


### PR DESCRIPTION
This PR introduces a `Show` instance for `UtxoState`, and is related to #266.

I'm not sure where to put the instance declaration: either I put it next to the definition of `UtxoState`, but it makes a cyclic dependency graph, or I put it next to the definition of `prettyUtxoState`, and it feels kind of lost.