### PR TITLE
Replace the nonempty list of signers with a regular list

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Balancing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Balancing.hs
@@ -19,7 +19,6 @@ import Cooked.Wallet
 import Data.Default
 import Data.Function
 import Data.List
-import qualified Data.List.NonEmpty as NEList
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe
@@ -39,7 +38,9 @@ balancedTxSkel :: MonadBlockChainBalancing m => TxSkel -> m (TxSkel, Fee, Set PV
 balancedTxSkel skelUnbal = do
   let balancingWallet =
         case txOptBalanceWallet . txSkelOpts $ skelUnbal of
-          BalanceWithFirstSigner -> NEList.head (txSkelSigners skelUnbal)
+          BalanceWithFirstSigner -> case txSkelSigners skelUnbal of
+            [] -> error "Can't select balancing wallet: There has to be at least one wallet in txSkelSigners"
+            bw : _ -> bw
           BalanceWith bWallet -> bWallet
   let collateralWallet = balancingWallet
   (skel, fee) <-

--- a/cooked-validators/src/Cooked/Skeleton.hs
+++ b/cooked-validators/src/Cooked/Skeleton.hs
@@ -24,7 +24,6 @@ import Data.Default
 import Data.Either.Combinators
 import Data.Function
 import Data.List
-import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEList
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -699,7 +698,7 @@ data TxSkel where
       txSkelOpts :: TxOpts,
       txSkelMints :: TxSkelMints,
       txSkelValidityRange :: Pl.POSIXTimeRange,
-      txSkelSigners :: NonEmpty Wallet,
+      txSkelSigners :: [Wallet],
       txSkelIns :: Map Pl.TxOutRef TxSkelRedeemer,
       txSkelInsReference :: Set Pl.TxOutRef,
       txSkelOuts :: [TxSkelOut]
@@ -730,7 +729,7 @@ txSkelTemplate =
       txSkelOpts = def,
       txSkelMints = Map.empty,
       txSkelValidityRange = Pl.always,
-      txSkelSigners = wallet 1 NEList.:| [],
+      txSkelSigners = [],
       txSkelIns = Map.empty,
       txSkelInsReference = Set.empty,
       txSkelOuts = []

--- a/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
@@ -67,7 +67,8 @@ lockTxSkel o v =
   txSkelTemplate
     { txSkelOpts = def {txOptEnsureMinAda = True},
       txSkelIns = Map.singleton o TxSkelNoRedeemerForPK,
-      txSkelOuts = [paysScriptInlineDatum v FirstLock lockValue]
+      txSkelOuts = [paysScriptInlineDatum v FirstLock lockValue],
+      txSkelSigners = [wallet 1]
     }
 
 txLock :: MonadBlockChain m => Pl.TypedValidator MockContract -> m ()
@@ -81,7 +82,8 @@ relockTxSkel v o =
   txSkelTemplate
     { txSkelOpts = def {txOptEnsureMinAda = True},
       txSkelIns = Map.singleton o $ TxSkelRedeemerForScript (),
-      txSkelOuts = [paysScriptInlineDatum v SecondLock lockValue]
+      txSkelOuts = [paysScriptInlineDatum v SecondLock lockValue],
+      txSkelSigners = [wallet 1]
     }
 
 txRelock ::
@@ -154,7 +156,7 @@ carelessValidator =
     wrap = Pl.mkUntypedValidator
 
 txSkelFromOuts :: [TxSkelOut] -> TxSkel
-txSkelFromOuts os = txSkelTemplate {txSkelOuts = os}
+txSkelFromOuts os = txSkelTemplate {txSkelOuts = os, txSkelSigners = [wallet 1]}
 
 -- * TestTree for the datum hijacking attack
 
@@ -202,7 +204,8 @@ tests =
                       paysScriptInlineDatum val2 SecondLock x1,
                       paysScriptInlineDatum val1 FirstLock x2,
                       paysScriptInlineDatum b SecondLock x2
-                    ]
+                    ],
+                  txSkelSigners = [wallet 1]
                 }
          in [ testCase "no modified transactions if no interesting outputs to steal" $ [] @=? skelOut mempty (const True),
               testCase "one modified transaction for one interesting output" $

--- a/cooked-validators/tests/Cooked/Attack/DoubleSatSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DoubleSatSpec.hs
@@ -128,12 +128,12 @@ dsTestMockChainSt = case runMockChainRaw def def setup of
   Right (_, mcst) -> mcst
   where
     setup = do
-      validateTxSkel $ txSkelTemplate {txSkelOuts = [paysScript aValidator ADatum (Pl.lovelaceValueOf 2_000_000)]}
-      validateTxSkel $ txSkelTemplate {txSkelOuts = [paysScript aValidator ADatum (Pl.lovelaceValueOf 3_000_000)]}
-      validateTxSkel $ txSkelTemplate {txSkelOuts = [paysScript aValidator ADatum (Pl.lovelaceValueOf 4_000_000)]}
-      validateTxSkel $ txSkelTemplate {txSkelOuts = [paysScript aValidator ADatum (Pl.lovelaceValueOf 5_000_000)]}
-      validateTxSkel $ txSkelTemplate {txSkelOuts = [paysScript bValidator BDatum (Pl.lovelaceValueOf 6_000_000)]}
-      validateTxSkel $ txSkelTemplate {txSkelOuts = [paysScript bValidator BDatum (Pl.lovelaceValueOf 7_000_000)]}
+      validateTxSkel $ txSkelTemplate {txSkelSigners = [wallet 1], txSkelOuts = [paysScript aValidator ADatum (Pl.lovelaceValueOf 2_000_000)]}
+      validateTxSkel $ txSkelTemplate {txSkelSigners = [wallet 1], txSkelOuts = [paysScript aValidator ADatum (Pl.lovelaceValueOf 3_000_000)]}
+      validateTxSkel $ txSkelTemplate {txSkelSigners = [wallet 1], txSkelOuts = [paysScript aValidator ADatum (Pl.lovelaceValueOf 4_000_000)]}
+      validateTxSkel $ txSkelTemplate {txSkelSigners = [wallet 1], txSkelOuts = [paysScript aValidator ADatum (Pl.lovelaceValueOf 5_000_000)]}
+      validateTxSkel $ txSkelTemplate {txSkelSigners = [wallet 1], txSkelOuts = [paysScript bValidator BDatum (Pl.lovelaceValueOf 6_000_000)]}
+      validateTxSkel $ txSkelTemplate {txSkelSigners = [wallet 1], txSkelOuts = [paysScript bValidator BDatum (Pl.lovelaceValueOf 7_000_000)]}
 
 tests :: TestTree
 tests =
@@ -160,7 +160,8 @@ tests =
                   skelIn aOrefs =
                     txSkelTemplate
                       { txSkelIns = Map.fromSet (const (TxSkelRedeemerForScript ARedeemer)) $ Set.fromList aOrefs,
-                        txSkelOuts = [paysPK (walletPKHash (wallet 2)) (Pl.lovelaceValueOf 2_500_000)]
+                        txSkelOuts = [paysPK (walletPKHash (wallet 2)) (Pl.lovelaceValueOf 2_500_000)],
+                        txSkelSigners = [wallet 1]
                       }
 
                   -- apply the 'doubleSatAttack' to the input skeleton to
@@ -235,7 +236,8 @@ tests =
                         txSkelOuts =
                           [ paysPK (walletPKHash (wallet 2)) (Pl.lovelaceValueOf 2_500_000),
                             paysPK (walletPKHash (wallet 6)) (foldMap (outputValue . snd . snd) bUtxos)
-                          ]
+                          ],
+                        txSkelSigners = [wallet 1]
                       }
                in [ testGroup "with 'AllSeparate'" $
                       let thePredicate :: [(Pl.TxOutRef, Pl.TxOut)] -> [[(BRedeemer, (Pl.TxOutRef, Pl.TxOut))]] -> Assertion

--- a/cooked-validators/tests/Cooked/Attack/DupTokenSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DupTokenSpec.hs
@@ -61,7 +61,8 @@ dupTokenTrace pol tName amount recipient = void $ validateTxSkel skel
        in txSkelTemplate
             { txSkelOpts = def {txOptEnsureMinAda = True},
               txSkelMints = mints,
-              txSkelOuts = [paysPK (walletPKHash recipient) mintedValue]
+              txSkelOuts = [paysPK (walletPKHash recipient) mintedValue],
+              txSkelSigners = [wallet 3]
             }
 
 tests :: TestTree
@@ -86,7 +87,8 @@ tests =
                   txSkelOuts =
                     [ paysPK (walletPKHash (wallet 1)) (Pl.assetClassValue ac1 1 <> Pl.lovelaceValueOf 1234),
                       paysPK (walletPKHash (wallet 2)) (Pl.assetClassValue ac2 2)
-                    ]
+                    ],
+                  txSkelSigners = [wallet 3]
                 }
             skelOut select = runTweak (dupTokenAttack select attacker) skelIn
             skelExpected v1 v2 =
@@ -104,7 +106,8 @@ tests =
                               [ paysPK (walletPKHash (wallet 1)) (Pl.assetClassValue ac1 1 <> Pl.lovelaceValueOf 1234),
                                 paysPK (walletPKHash (wallet 2)) (Pl.assetClassValue ac2 2),
                                 paysPK (walletPKHash attacker) increment
-                              ]
+                              ],
+                            txSkelSigners = [wallet 3]
                           }
                       )
                   ]
@@ -146,7 +149,8 @@ tests =
                     [ paysPK
                         (walletPKHash (wallet 1))
                         (Pl.assetClassValue ac1 1 <> Pl.assetClassValue ac2 2)
-                    ]
+                    ],
+                  txSkelSigners = [wallet 2]
                 }
             skelExpected =
               [ Right
@@ -161,7 +165,8 @@ tests =
                             paysPK
                               (walletPKHash attacker)
                               (Pl.assetClassValue ac1 1)
-                          ]
+                          ],
+                        txSkelSigners = [wallet 2]
                       }
                   )
               ]

--- a/cooked-validators/tests/Cooked/InlineDatumsSpec.hs
+++ b/cooked-validators/tests/Cooked/InlineDatumsSpec.hs
@@ -128,7 +128,8 @@ listUtxosTestTrace useInlineDatum validator =
                   else paysScript validator FirstPaymentDatum
               )
                 (Pl.lovelaceValueOf 3_000_000)
-            ]
+            ],
+          txSkelSigners = [wallet 1]
         }
 
 -- | This defines two traces of two transactions each: @spendOutputTestTrace
@@ -150,7 +151,8 @@ spendOutputTestTrace useInlineDatum validator = do
     validateTxSkel
       txSkelTemplate
         { txSkelOpts = def {txOptEnsureMinAda = True},
-          txSkelIns = Map.singleton theTxOutRef $ TxSkelRedeemerForScript ()
+          txSkelIns = Map.singleton theTxOutRef $ TxSkelRedeemerForScript (),
+          txSkelSigners = [wallet 1]
         }
 
 -- | This defines two traces of two transactions each: On the first transaction,
@@ -182,7 +184,8 @@ continuingOutputTestTrace datumKindOnSecondPayment validator = do
                   Inline -> paysScriptInlineDatum validator SecondPaymentDatum
               )
                 (outputValue theOutput)
-            ]
+            ],
+          txSkelSigners = [wallet 1]
         }
 
 tests :: TestTree

--- a/cooked-validators/tests/Cooked/MinAdaSpec.hs
+++ b/cooked-validators/tests/Cooked/MinAdaSpec.hs
@@ -36,7 +36,8 @@ paymentWithMinAda = do
                   mempty
                   (TxSkelOutDatum heavyDatum)
                   (Nothing @(Pl.Versioned Pl.Script))
-            ]
+            ],
+          txSkelSigners = [wallet 1]
         }
 
 paymentWithoutMinAda :: MonadBlockChain m => Integer -> m ()
@@ -52,7 +53,8 @@ paymentWithoutMinAda paidLovelaces = do
                   (Pl.lovelaceValueOf paidLovelaces)
                   (TxSkelOutDatum heavyDatum)
                   (Nothing @(Pl.Versioned Pl.Script))
-            ]
+            ],
+          txSkelSigners = [wallet 1]
         }
 
 tests :: TestTree

--- a/cooked-validators/tests/Cooked/ReferenceInputsSpec.hs
+++ b/cooked-validators/tests/Cooked/ReferenceInputsSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/cooked-validators/tests/Cooked/ReferenceScriptsSpec.hs
+++ b/cooked-validators/tests/Cooked/ReferenceScriptsSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
@@ -107,7 +106,8 @@ putRefScriptOnWalletOutput recipient referencedScript =
                 (walletPKHash recipient)
                 (Pl.lovelaceValueOf 1)
                 referencedScript
-            ]
+            ],
+          txSkelSigners = [wallet 1]
         }
 
 putRefScriptOnScriptOutput ::
@@ -128,7 +128,8 @@ putRefScriptOnScriptOutput recipient referencedScript =
                   (Pl.lovelaceValueOf 1)
                   (TxSkelOutDatum ())
                   (Just referencedScript)
-            ]
+            ],
+          txSkelSigners = [wallet 1]
         }
 
 retrieveRefScriptHash :: MonadBlockChain m => Pl.TxOutRef -> m (Maybe Pl.ScriptHash)
@@ -153,13 +154,15 @@ checkReferenceScriptOnOref expectedScriptHash refScriptOref = do
                   (requireRefScriptValidator expectedScriptHash)
                   ()
                   (Pl.lovelaceValueOf 42_000_000)
-              ]
+              ],
+            txSkelSigners = [wallet 1]
           }
   void $
     validateTxSkel
       txSkelTemplate
         { txSkelIns = Map.singleton oref $ TxSkelRedeemerForScript (),
-          txSkelInsReference = Set.singleton refScriptOref
+          txSkelInsReference = Set.singleton refScriptOref,
+          txSkelSigners = [wallet 1]
         }
 
 useReferenceScript :: MonadBlockChain m => Wallet -> Pl.TypedValidator MockContract -> m ()
@@ -174,7 +177,8 @@ useReferenceScript spendingSubmitter theScript = do
                   theScript
                   ()
                   (Pl.lovelaceValueOf 42_000_000)
-              ]
+              ],
+            txSkelSigners = [wallet 1]
           }
   void $
     validateTxSkel
@@ -250,12 +254,14 @@ tests =
                                 yesValidator
                                 ()
                                 (Pl.lovelaceValueOf 42_000_000)
-                            ]
+                            ],
+                          txSkelSigners = [wallet 1]
                         }
                 void $
                   validateTxSkel
                     txSkelTemplate
-                      { txSkelIns = Map.singleton oref (TxSkelRedeemerForReferencedScript ())
+                      { txSkelIns = Map.singleton oref (TxSkelRedeemerForReferencedScript ()),
+                        txSkelSigners = [wallet 1]
                       },
           testCase "phase 1 - fail if using a reference script with 'TxSkelRedeemerForScript'" $
             testFailsFrom'
@@ -277,13 +283,15 @@ tests =
                                 yesValidator
                                 ()
                                 (Pl.lovelaceValueOf 42_000_000)
-                            ]
+                            ],
+                          txSkelSigners = [wallet 1]
                         }
                 void $
                   validateTxSkel
                     txSkelTemplate
                       { txSkelIns = Map.singleton oref (TxSkelRedeemerForScript ()),
-                        txSkelInsReference = Set.singleton scriptOref
+                        txSkelInsReference = Set.singleton scriptOref,
+                        txSkelSigners = [wallet 1]
                       },
           testCase
             "fail if referenced script's requirement is violated"

--- a/examples/src/Auction/Offchain.hs
+++ b/examples/src/Auction/Offchain.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Auction.Offchain where


### PR DESCRIPTION
This PR changes the type of `txSkelSigners` to a regular list of wallets instead of a nonempty list. This arguably makes the type `TxSkel` less "safe", in the sense that there's now another way to write invalid transactions (by forgetting to add signers), but we gain a clearer [`txSkelTemplate`](https://github.com/tweag/plutus-libs/blob/2f694f46989e21f5148b748dee0426fa0430a26c/cooked-validators/src/Cooked/Skeleton.hs#L725), which doesn't any more contain a "hidden default" `wallet 1` signer.

We initially thought that we could have both the type safety of nonempty lists and the convenience and clarity of vanilla lists by using `OverloadedLists`, but we recently learned that this laguage extension affords no compile-time checks. But then, if an empty list of signers will lead to a run time error anyway, we can just throw it ourselves in the [two](https://github.com/tweag/plutus-libs/blob/2f694f46989e21f5148b748dee0426fa0430a26c/cooked-validators/src/Cooked/MockChain/GenerateTx.hs#L87) [places](https://github.com/tweag/plutus-libs/blob/2f694f46989e21f5148b748dee0426fa0430a26c/cooked-validators/src/Cooked/MockChain/Balancing.hs#L42) that make sense.