### PR TITLE
Remove ownPaymentPubKeyHash and mceSigners

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/BlockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain/BlockChain.hs
@@ -86,11 +86,6 @@ class MonadBlockChainBalancing m => MonadBlockChainWithoutValidation m where
   -- | Returns a list of all currently known outputs.
   allUtxosLedger :: m [(PV2.TxOutRef, Ledger.TxOut)]
 
-  -- | Returns the hash of our own public key. When running in the "Plutus.Contract.Contract" monad,
-  --  this is a proxy to 'PV2.ownPubKey'; when running in mock mode, the return value can be
-  --  controlled with 'signingWith': the head of the non-empty list will be considered as the "ownPubkey".
-  ownPaymentPubKeyHash :: m PV2.PubKeyHash
-
   -- | Returns the current slot number
   currentSlot :: m Ledger.Slot
 
@@ -236,7 +231,6 @@ instance (MonadTrans t, MonadBlockChainBalancing m, Monad (t m), MonadError Mock
 
 instance (MonadTrans t, MonadBlockChainWithoutValidation m, Monad (t m), MonadError MockChainError (AsTrans t m)) => MonadBlockChainWithoutValidation (AsTrans t m) where
   allUtxosLedger = lift allUtxosLedger
-  ownPaymentPubKeyHash = lift ownPaymentPubKeyHash
   currentSlot = lift currentSlot
   currentTime = lift currentTime
   awaitSlot = lift . awaitSlot
@@ -281,7 +275,6 @@ instance MonadBlockChainBalancing m => MonadBlockChainBalancing (ListT m) where
 
 instance MonadBlockChainWithoutValidation m => MonadBlockChainWithoutValidation (ListT m) where
   allUtxosLedger = lift allUtxosLedger
-  ownPaymentPubKeyHash = lift ownPaymentPubKeyHash
   currentSlot = lift currentSlot
   currentTime = lift currentTime
   awaitSlot = lift . awaitSlot

--- a/cooked-validators/src/Cooked/MockChain/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Direct.hs
@@ -30,7 +30,6 @@ import Cooked.Output
 import Cooked.Skeleton
 import Cooked.Wallet
 import Data.Default
-import qualified Data.List.NonEmpty as NEList
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
@@ -109,14 +108,11 @@ utxoIndexToTxOutMap (Ledger.UtxoIndex utxoMap) = Map.map txOutV2FromLedger utxoM
 instance Default Ledger.Slot where
   def = Ledger.Slot 0
 
-data MockChainEnv = MockChainEnv
-  { mceParams :: Emulator.Params,
-    mceSigners :: NEList.NonEmpty Wallet
-  }
+newtype MockChainEnv = MockChainEnv {mceParams :: Emulator.Params}
   deriving (Show)
 
 instance Default MockChainEnv where
-  def = MockChainEnv def (wallet 1 NEList.:| [])
+  def = MockChainEnv def
 
 -- | The actual 'MockChainT' is a trivial combination of 'StateT' and 'ExceptT'
 newtype MockChainT m a = MockChainT
@@ -234,8 +230,6 @@ instance Monad m => MonadBlockChainBalancing (MockChainT m) where
   utxosAtLedger addr = filter ((addr ==) . outputAddress . txOutV2FromLedger . snd) <$> allUtxosLedger
 
 instance Monad m => MonadBlockChainWithoutValidation (MockChainT m) where
-  ownPaymentPubKeyHash = asks (walletPKHash . NEList.head . mceSigners)
-
   allUtxosLedger = gets $ Map.toList . Ledger.getIndex . mcstIndex
 
   currentSlot = gets mcstCurrentSlot

--- a/cooked-validators/src/Cooked/MockChain/Staged.hs
+++ b/cooked-validators/src/Cooked/MockChain/Staged.hs
@@ -80,7 +80,6 @@ data MockChainBuiltin a where
   GetCurrentTime :: MockChainBuiltin Pl.POSIXTime
   AwaitTime :: Pl.POSIXTime -> MockChainBuiltin Pl.POSIXTime
   DatumFromHash :: Pl.DatumHash -> MockChainBuiltin (Maybe Pl.Datum)
-  OwnPubKey :: MockChainBuiltin Pl.PubKeyHash
   AllUtxosLedger :: MockChainBuiltin [(Pl.TxOutRef, Ledger.TxOut)]
   UtxosAtLedger :: Pl.Address -> MockChainBuiltin [(Pl.TxOutRef, Ledger.TxOut)]
   ValidatorFromHash :: Pl.ValidatorHash -> MockChainBuiltin (Maybe (Pl.Versioned Pl.Validator))
@@ -152,7 +151,6 @@ instance InterpLtl (UntypedTweak InterpMockChain) MockChainBuiltin InterpMockCha
   interpBuiltin (AwaitTime t) = awaitTime t
   interpBuiltin (DatumFromHash h) = datumFromHash h
   interpBuiltin (ValidatorFromHash h) = validatorFromHash h
-  interpBuiltin OwnPubKey = ownPaymentPubKeyHash
   interpBuiltin AllUtxosLedger = allUtxosLedger
   interpBuiltin (UtxosAtLedger address) = utxosAtLedger address
   interpBuiltin Empty = mzero
@@ -222,7 +220,6 @@ instance MonadBlockChainBalancing StagedMockChain where
 
 instance MonadBlockChainWithoutValidation StagedMockChain where
   allUtxosLedger = singletonBuiltin AllUtxosLedger
-  ownPaymentPubKeyHash = singletonBuiltin OwnPubKey
   currentSlot = singletonBuiltin GetCurrentSlot
   currentTime = singletonBuiltin GetCurrentTime
   awaitSlot = singletonBuiltin . AwaitSlot

--- a/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
+++ b/cooked-validators/tests/Cooked/Attack/DatumHijackingSpec.hs
@@ -72,8 +72,7 @@ lockTxSkel o v =
 
 txLock :: MonadBlockChain m => Pl.TypedValidator MockContract -> m ()
 txLock v = do
-  me <- ownPaymentPubKeyHash
-  (oref, _) : _ <- filteredUtxos $ isPKOutputFrom me >=> isOutputWithValueSuchThat (`Pl.geq` lockValue)
+  (oref, _) : _ <- filteredUtxos $ isPKOutputFrom (walletPKHash $ wallet 1) >=> isOutputWithValueSuchThat (`Pl.geq` lockValue)
   void $ validateTxSkel $ lockTxSkel oref v
 
 relockTxSkel :: Pl.TypedValidator MockContract -> Pl.TxOutRef -> TxSkel


### PR DESCRIPTION
The current version of `MonadBlockChain` has no concept of "own wallet", hence we can remove the function that returns the (by now nonsensical) information about the own payment public key hash, and also the (completely unused) mechanism to keep track of it. This closes #232.