### PR TITLE
Handle reference scripts in `UtxoState` and pretty-print them

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Direct.hs
@@ -62,13 +62,13 @@ mcstToUtxoState :: MockChainSt -> UtxoState
 mcstToUtxoState MockChainSt {mcstIndex, mcstDatums} =
   UtxoState
     . foldr (\(address, utxoValueSet) acc -> Map.insertWith (<>) address utxoValueSet acc) Map.empty
-    . mapMaybe go
+    . mapMaybe extractPayload
     . Map.toList
     . utxoIndexToTxOutMap
     $ mcstIndex
   where
-    go :: (Pl.TxOutRef, PV2.TxOut) -> Maybe (Pl.Address, UtxoPayloadSet)
-    go (txOutRef, out@PV2.TxOut {PV2.txOutAddress, PV2.txOutValue, PV2.txOutDatum}) =
+    extractPayload :: (Pl.TxOutRef, PV2.TxOut) -> Maybe (Pl.Address, UtxoPayloadSet)
+    extractPayload (txOutRef, out@PV2.TxOut {PV2.txOutAddress, PV2.txOutValue, PV2.txOutDatum}) =
       do
         let mRefScript = outputReferenceScript out
         txSkelOutDatum <-

--- a/cooked-validators/src/Cooked/MockChain/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Direct.hs
@@ -67,16 +67,19 @@ mcstToUtxoState MockChainSt {mcstIndex, mcstDatums} =
     . utxoIndexToTxOutMap
     $ mcstIndex
   where
-    go :: (Pl.TxOutRef, PV2.TxOut) -> Maybe (Pl.Address, UtxoValueSet)
-    go (txOutRef, PV2.TxOut {PV2.txOutAddress, PV2.txOutValue, PV2.txOutDatum}) =
-      case txOutDatum of
-        Pl.NoOutputDatum -> return (txOutAddress, UtxoValueSet [(txOutValue, TxSkelOutNoDatum)])
-        Pl.OutputDatum datum -> do
-          txSkelOutDatum <- Map.lookup (Pl.datumHash datum) mcstDatums
-          return (txOutAddress, UtxoValueSet [(txOutValue, txSkelOutDatum)])
-        Pl.OutputDatumHash hash -> do
-          txSkelOutDatum <- Map.lookup hash mcstDatums
-          return (txOutAddress, UtxoValueSet [(txOutValue, txSkelOutDatum)])
+    go :: (Pl.TxOutRef, PV2.TxOut) -> Maybe (Pl.Address, UtxoPayloadSet)
+    go (txOutRef, out@PV2.TxOut {PV2.txOutAddress, PV2.txOutValue, PV2.txOutDatum}) =
+      do
+        let mRefScript = outputReferenceScript out
+        txSkelOutDatum <-
+          case txOutDatum of
+            Pl.NoOutputDatum -> Just TxSkelOutNoDatum
+            Pl.OutputDatum datum -> Map.lookup (Pl.datumHash datum) mcstDatums
+            Pl.OutputDatumHash hash -> Map.lookup hash mcstDatums
+        return
+          ( txOutAddress,
+            UtxoPayloadSet [UtxoPayload txOutValue txSkelOutDatum mRefScript]
+          )
 
 -- | Slightly more concrete version of 'UtxoState', used to actually run the simulation.
 --  We keep a map from datum hash to datum, then a map from txOutRef to datumhash

--- a/cooked-validators/src/Cooked/MockChain/UtxoState.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoState.hs
@@ -12,35 +12,44 @@ import qualified Plutus.V1.Ledger.Value as Pl1
 
 -- | A 'UtxoState' provides us with the mental picture of the state of the UTxO graph:
 -- Each address has a set of UTxOs that consist in a value and some potential datum.
-newtype UtxoState = UtxoState {utxoState :: Map Pl.Address UtxoValueSet}
+newtype UtxoState = UtxoState {utxoState :: Map Pl.Address UtxoPayloadSet}
   deriving (Eq)
 
 instance Semigroup UtxoState where
   (UtxoState a) <> (UtxoState b) = UtxoState $ Map.unionWith (<>) a b
 
--- | Represents a /set/ of values, yet, we use a list instead of a set because 'Pl.Value'
--- doesn't implement 'Ord' and because it is possible that we want to distinguish between utxo states
--- that have additional utxos, even if these could have been merged together.
-newtype UtxoValueSet = UtxoValueSet {utxoValueSet :: [(Pl1.Value, TxSkelOutDatum)]}
+-- | Represents a /set/ of payloads. Payloads are the name we give to the
+-- information we care about on a UTxO: value, datum, and reference script. We
+-- use a list instead of a set because 'Pl.Value' doesn't implement 'Ord' and
+-- because it is possible that we want to distinguish between utxo states that
+-- have additional utxos, even if these could have been merged together.
+newtype UtxoPayloadSet = UtxoPayloadSet {utxoPayloadSet :: [UtxoPayload]}
   deriving (Show)
 
-instance Eq UtxoValueSet where
-  (UtxoValueSet xs) == (UtxoValueSet ys) = xs' == ys'
+data UtxoPayload = UtxoPayload
+  { utxoPayloadValue :: Pl1.Value,
+    utxoPayloadSkelOutDatum :: TxSkelOutDatum,
+    utxoPayloadReferenceScript :: Maybe Pl.ScriptHash
+  }
+  deriving (Eq, Show)
+
+instance Eq UtxoPayloadSet where
+  (UtxoPayloadSet xs) == (UtxoPayloadSet ys) = xs' == ys'
     where
-      k (val, m) = (Pl1.flattenValue val, m)
+      k (UtxoPayload val dat rs) = (Pl1.flattenValue val, dat, rs)
       xs' = List.sortBy (compare `on` k) xs
       ys' = List.sortBy (compare `on` k) ys
 
-instance Semigroup UtxoValueSet where
-  UtxoValueSet a <> UtxoValueSet b = UtxoValueSet $ a ++ b
+instance Semigroup UtxoPayloadSet where
+  UtxoPayloadSet a <> UtxoPayloadSet b = UtxoPayloadSet $ a ++ b
 
-instance Monoid UtxoValueSet where
-  mempty = UtxoValueSet []
+instance Monoid UtxoPayloadSet where
+  mempty = UtxoPayloadSet []
 
 -- | Computes the total value in a set
-utxoValueSetTotal :: UtxoValueSet -> Pl1.Value
-utxoValueSetTotal = mconcat . map fst . utxoValueSet
+utxoPayloadSetTotal :: UtxoPayloadSet -> Pl1.Value
+utxoPayloadSetTotal = mconcat . fmap utxoPayloadValue . utxoPayloadSet
 
 -- | Computes the total value in the entire state
 utxoStateTotal :: UtxoState -> Pl1.Value
-utxoStateTotal = mconcat . map utxoValueSetTotal . Map.elems . utxoState
+utxoStateTotal = mconcat . fmap utxoPayloadSetTotal . Map.elems . utxoState


### PR DESCRIPTION
This fixes the lack of pretty-printing for reference scripts in utxos.

## Changes

* In `Cooked.UtxoState`, `UtxoValueSet` is renamed to `UtxoPayloadSet` and reference scripts are added to a now explicit `UtxoPayload` type.
* Generation of `UtxoState` in `Cooked.Direct` is adapted accordingly.
* Pretty-printing in `Cooked.Pretty.Cooked` also takes these changes into account and implement printing of reference script hash when applicable.