### PR TITLE
Fix call to removed `utxoValueSetTotal` function

### DIFF
--- a/examples/tests/AuctionSpec.hs
+++ b/examples/tests/AuctionSpec.hs
@@ -118,7 +118,7 @@ twoAuctions = do
 -- given state
 holdingInState :: UtxoState -> Wallet -> Value
 holdingInState (UtxoState m) w
-  | Just vs <- M.lookup (walletAddress w) m = utxoValueSetTotal vs
+  | Just vs <- M.lookup (walletAddress w) m = utxoPayloadSetTotal vs
   | otherwise = mempty
 
 successfulSingle :: TestTree


### PR DESCRIPTION
**URGENT**

This fixes an error in `AuctionSpec` introduced by PR #270 that the CI did not catch.
Function `utxoValueSetTotal` had not been renamed to `utxoPayloadSetTotal`.