### PR TITLE
Improve printing experience in the REPL

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Testing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Testing.hs
@@ -121,7 +121,7 @@ testFailsFrom' ::
   InitialDistribution ->
   StagedMockChain a ->
   prop
-testFailsFrom' pcOpts predi = testAllSatisfiesFrom pcOpts (either predi (testFailureMsg . renderString (prettyEndState pcOpts)))
+testFailsFrom' pcOpts predi = testAllSatisfiesFrom pcOpts (either predi (testFailureMsg . renderString (prettyCookedOpt pcOpts)))
 
 -- | Is satisfied when the given 'MockChainError' is wrapping a @CekEvaluationFailure@.
 -- This is particularly important when writing negative tests. For example, if we are simulating

--- a/cooked-validators/src/Cooked/Pretty/Class.hs
+++ b/cooked-validators/src/Cooked/Pretty/Class.hs
@@ -22,12 +22,24 @@ import qualified Plutus.Script.Utils.Value as Pl
 import qualified Plutus.V2.Ledger.Api as Pl
 import Prettyprinter ((<+>))
 import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.Text as PP
 
 class PrettyCooked a where
   prettyCooked :: a -> DocCooked
   prettyCooked = prettyCookedOpt def
   prettyCookedOpt :: PrettyCookedOpts -> a -> DocCooked
   prettyCookedOpt _ = prettyCooked
+
+-- | Use this in the REPL as an alternative to the default 'print' function
+-- when dealing with pretty-printable cooked values.
+--
+-- For example, @printCookedOpt def runMockChain i0 foo@
+printCookedOpt :: PrettyCooked a => PrettyCookedOpts -> a -> IO ()
+printCookedOpt opts = PP.putDoc . prettyCookedOpt opts
+
+-- | Version of 'printCookedOpt' that uses default pretty printing options.
+printCooked :: PrettyCooked a => a -> IO ()
+printCooked = printCookedOpt def
 
 instance PrettyCooked Pl.TxId where
   prettyCookedOpt opts = prettyHash (pcOptPrintedHashLength opts)

--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -108,12 +109,16 @@ instance PrettyCooked MockChainError where
       "-"
       [PP.viaShow err]
 
-prettyEndState :: Show a => PrettyCookedOpts -> (a, UtxoState) -> DocCooked
-prettyEndState opts (res, state) =
-  prettyItemize
-    "End state:"
-    "-"
-    ["Returns:" <+> PP.viaShow res, prettyUtxoState opts state]
+instance Show a => PrettyCooked (a, UtxoState) where
+  prettyCookedOpt opts (res, state) =
+    prettyItemize
+      "End state:"
+      "-"
+      ["Returns:" <+> PP.viaShow res, prettyUtxoState opts state]
+
+instance Show a => PrettyCooked (Either MockChainError (a, UtxoState)) where
+  prettyCookedOpt opts (Left err) = "🔴" <+> prettyCookedOpt opts err
+  prettyCookedOpt opts (Right endState) = "🟢" <+> prettyCookedOpt opts endState
 
 -- | This pretty prints a mock chain log that usually consists of the list of
 -- validated or submitted transactions. In the log, we know a transaction has

--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -19,7 +19,6 @@
 -- 'TxSkelContext').
 module Cooked.Pretty.Cooked where
 
-import Control.Arrow (second)
 import Cooked.MockChain.BlockChain
 import Cooked.MockChain.GenerateTx
 import Cooked.MockChain.Staged


### PR DESCRIPTION
This works around #266 by providing convenience functions (`printCooked` and `printCookedOpt`) to work in the REPL despite the lack of `Show` instances.

It makes it possible to use `printCooked $ runMockChainFrom foo bar` for instance.

It also implements `PrettyCooked` for the return type of `runMockChain`: `Show a = > Either MockChainError (a, UtxoState)`.