### PR TITLE
Improve error reporting for unbalanceable transactions

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Balancing.hs
+++ b/cooked-validators/src/Cooked/MockChain/Balancing.hs
@@ -331,11 +331,14 @@ balanceTxFromAux balanceWallet txskel fee = do
       throwError $
         MCEUnbalanceable
           ( MCEUnbalNotEnoughReturning
-              (fst <$> newInputs)
-              (fst <$> availableUtxos)
+              (valueAndRefs newInputs)
+              (valueAndRefs availableUtxos)
               returnValue
           )
           txskel
+  where
+    valueAndRefs :: [(PV2.TxOutRef, PV2.TxOut)] -> (PV2.Value, [PV2.TxOutRef])
+    valueAndRefs x = (mconcat (outputValue . snd <$> x), fst <$> x)
 
 data BalanceTxRes = BalanceTxRes
   { -- | Inputs that need to be added in order to cover the value in the

--- a/cooked-validators/src/Cooked/MockChain/BlockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain/BlockChain.hs
@@ -59,7 +59,10 @@ data MCEUnbalanceableError
   | -- | There is value to return to the balancing wallet but not enough to
     -- fullfill the min ada requirement and there is not enough in additional
     -- inputs to make it possible.
-    MCEUnbalNotEnoughReturning [PV2.TxOutRef] [PV2.TxOutRef] PV2.Value
+    MCEUnbalNotEnoughReturning
+      (PV2.Value, [PV2.TxOutRef]) -- What was spent
+      (PV2.Value, [PV2.TxOutRef]) -- What is left to spend
+      PV2.Value -- What cannot be given back
   deriving (Show)
 
 deriving instance Show MockChainError

--- a/cooked-validators/src/Cooked/MockChain/BlockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain/BlockChain.hs
@@ -53,7 +53,7 @@ data MockChainError where
   OtherMockChainError :: (Show err, Eq err) => err -> MockChainError
 
 data MCEUnbalanceableError
-  = -- | The balancing wallet miss some value to pay what is needed to balance
+  = -- | The balancing wallet misses some value to pay what is needed to balance
     -- the transaction.
     MCEUnbalNotEnoughFunds Wallet PV2.Value
   | -- | There is value to return to the balancing wallet but not enough to

--- a/cooked-validators/src/Cooked/MockChain/BlockChain.hs
+++ b/cooked-validators/src/Cooked/MockChain/BlockChain.hs
@@ -41,7 +41,7 @@ import qualified Plutus.V2.Ledger.Api as PV2
 -- | The errors that can be produced by the 'MockChainT' monad
 data MockChainError where
   MCEValidationError :: Ledger.ValidationErrorInPhase -> MockChainError
-  MCEUnbalanceable :: String -> BalanceStage -> TxSkel -> MockChainError
+  MCEUnbalanceable :: String -> TxSkel -> MockChainError
   MCENoSuitableCollateral :: MockChainError
   MCEGenerationError :: GenerateTxError -> MockChainError
   MCECalcFee :: MockChainError -> MockChainError
@@ -55,14 +55,6 @@ deriving instance Show MockChainError
 
 instance Eq MockChainError where
   (==) = undefined
-
--- | Describes us which stage of the balancing process are we at. This is needed
---  to distinguish the successive calls to balancing while computing fees from
---  the final call to balancing
-data BalanceStage
-  = BalCalcFee
-  | BalFinalizing
-  deriving (Show, Eq)
 
 class (MonadFail m, MonadError MockChainError m) => MonadBlockChainBalancing m where
   -- | Returns the paramters of the chain.

--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -58,14 +58,11 @@ instance PrettyCooked MockChainError where
     PP.vsep ["Validation error", PP.indent 2 (prettyCookedOpt opts plutusError)]
   -- Here we don't print the skel because we lack its context and this error is
   -- printed alongside the skeleton when a test fails
-  prettyCookedOpt _ (MCEUnbalanceable msg balanceStage _) =
+  prettyCookedOpt _ (MCEUnbalanceable msg _) =
     prettyItemize
       "Unbalanceable"
       "-"
-      [PP.pretty msg, prettyBalanceStage balanceStage]
-    where
-      prettyBalanceStage BalCalcFee = "Fee calculation stage"
-      prettyBalanceStage BalFinalizing = "Finalizing stage"
+      [PP.pretty msg]
   prettyCookedOpt _ MCENoSuitableCollateral =
     "No suitable collateral"
   prettyCookedOpt _ (MCEGenerationError (ToCardanoError msg cardanoError)) =

--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -65,20 +65,30 @@ instance PrettyCooked MockChainError where
       [ prettyCookedOpt opts (walletPKHash balWallet) <+> "has not enough funds",
         "Required payment is" <+> prettyCookedOpt opts targetValue
       ]
-  prettyCookedOpt opts (MCEUnbalanceable (MCEUnbalNotEnoughReturning spentTxOuts remainingTxOuts returnValue) _) =
+  prettyCookedOpt opts (MCEUnbalanceable (MCEUnbalNotEnoughReturning (spentValue, spentTxOuts) (remainingValue, remainingTxOuts) returnValue) _) =
     prettyItemize
       "Unbalanceable:"
       "-"
       [ "Value to return is below the min ada per UTxO:"
           <+> prettyCookedOpt opts returnValue,
         prettyItemize
-          "Outputs spent for balancing:"
+          "Spent for balancing:"
           "-"
-          (prettyCookedOpt opts <$> spentTxOuts),
+          [ prettyCookedOpt opts spentValue,
+            prettyItemize
+              "Outputs:"
+              "-"
+              (prettyCookedOpt opts <$> spentTxOuts)
+          ],
         prettyItemize
-          "Remaining candidate outputs (not enough):"
+          "Remaining candidates:"
           "-"
-          (prettyCookedOpt opts <$> remainingTxOuts)
+          [ prettyCookedOpt opts remainingValue,
+            prettyItemize
+              "Outputs:"
+              "-"
+              (prettyCookedOpt opts <$> remainingTxOuts)
+          ]
       ]
   prettyCookedOpt _ MCENoSuitableCollateral =
     "No suitable collateral"

--- a/cooked-validators/src/Cooked/Pretty/Cooked.hs
+++ b/cooked-validators/src/Cooked/Pretty/Cooked.hs
@@ -62,7 +62,7 @@ instance PrettyCooked MockChainError where
     prettyItemize
       "Unbalanceable:"
       "-"
-      [ prettyCookedOpt opts (walletPKHash balWallet) <+> "has not enough Ada",
+      [ prettyCookedOpt opts (walletPKHash balWallet) <+> "has not enough funds",
         "Required payment is" <+> prettyCookedOpt opts targetValue
       ]
   prettyCookedOpt opts (MCEUnbalanceable (MCEUnbalNotEnoughReturning spentTxOuts remainingTxOuts returnValue) _) =


### PR DESCRIPTION
This improves error reporting for unbalanceable transactions by storing relevant data in the `MCEUnbalanceable` error instead of a textual representation. This makes it possible to display the error in a more readable way that uses existing pretty printing of values instead of default Plutus' show for values.