### PR TITLE
Introduce an option to display `TxOutRef`s in the state

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Direct.hs
@@ -78,7 +78,7 @@ mcstToUtxoState MockChainSt {mcstIndex, mcstDatums} =
             Pl.OutputDatumHash hash -> Map.lookup hash mcstDatums
         return
           ( txOutAddress,
-            UtxoPayloadSet [UtxoPayload txOutValue txSkelOutDatum mRefScript]
+            UtxoPayloadSet [UtxoPayload txOutRef txOutValue txSkelOutDatum mRefScript]
           )
 
 -- | Slightly more concrete version of 'UtxoState', used to actually run the simulation.

--- a/cooked-validators/src/Cooked/MockChain/UtxoState.hs
+++ b/cooked-validators/src/Cooked/MockChain/UtxoState.hs
@@ -27,7 +27,8 @@ newtype UtxoPayloadSet = UtxoPayloadSet {utxoPayloadSet :: [UtxoPayload]}
   deriving (Show)
 
 data UtxoPayload = UtxoPayload
-  { utxoPayloadValue :: Pl1.Value,
+  { utxoPayloadTxOutRef :: Pl.TxOutRef,
+    utxoPayloadValue :: Pl1.Value,
     utxoPayloadSkelOutDatum :: TxSkelOutDatum,
     utxoPayloadReferenceScript :: Maybe Pl.ScriptHash
   }
@@ -36,7 +37,7 @@ data UtxoPayload = UtxoPayload
 instance Eq UtxoPayloadSet where
   (UtxoPayloadSet xs) == (UtxoPayloadSet ys) = xs' == ys'
     where
-      k (UtxoPayload val dat rs) = (Pl1.flattenValue val, dat, rs)
+      k (UtxoPayload ref val dat rs) = (ref, Pl1.flattenValue val, dat, rs)
       xs' = List.sortBy (compare `on` k) xs
       ys' = List.sortBy (compare `on` k) ys
 

--- a/cooked-validators/src/Cooked/Pretty/Options.hs
+++ b/cooked-validators/src/Cooked/Pretty/Options.hs
@@ -7,6 +7,9 @@ data PrettyCookedOpts = PrettyCookedOpts
   { -- | Whether to print transaction ids of validated transactions.
     -- By default: False
     pcOptPrintTxHashes :: Bool,
+    -- | Whether to print transaction outputs references.
+    -- By default: hidden
+    pcOptPrintTxOutRefs :: PCOptTxOutRefs,
     -- | Whether to print tx options that have not been modified from their
     -- default.
     -- By default: False
@@ -17,10 +20,25 @@ data PrettyCookedOpts = PrettyCookedOpts
   }
   deriving (Eq, Show)
 
+-- | Whether to print transaction outputs references.
+data PCOptTxOutRefs
+  = -- | Hide them
+    PCOptTxOutRefsHidden
+  | -- | Always show them.
+    -- Warning: this will disable printing similar utxos as a group
+    -- (for instance @(×10) Lovelace: 100_000_000@)
+    PCOptTxOutRefsFull
+  | -- | Show them for utxos which are not grouped with similar others.
+    -- This avoids  the downside of 'PCOptTxOutRefsFull' which disables printing
+    -- utxos as a group.
+    PCOptTxOutRefsPartial
+  deriving (Eq, Show)
+
 instance Default PrettyCookedOpts where
   def =
     PrettyCookedOpts
       { pcOptPrintTxHashes = False,
+        pcOptPrintTxOutRefs = PCOptTxOutRefsHidden,
         pcOptPrintDefaultTxOpts = False,
         pcOptPrintedHashLength = 7
       }


### PR DESCRIPTION
This is how utxos at an address are currently displayed:

```
• pubkey #80a4f45 (wallet 2)
  - Value:
      - Permanent "Banana": 5
      - Lovelace: 20_000_000
  - Lovelace: 39_354_032
  - Lovelace: 59_354_032
  - Lovelace: 60_000_000
  - (×8) Lovelace: 100_000_000
```

This PR introduces a pretty-printing option `pcOptPrintTxOutRefs` which defaults to the above: `PCOptTxOutRefsHidden`.

Other options are `PCOptTxOutRefsPartial` to display txout refs of "unique" utxos

```
• pubkey #80a4f45 (wallet 2)
  - #fd7f323!54
    Value:
      - Permanent "Banana": 5
      - Lovelace: 20_000_000
  - #7c256b4!1
    Lovelace: 39_354_032
  - #9d8a31f!1
    Lovelace: 59_354_032
  - #008a15d!0
    Lovelace: 60_000_000
  - (×8) Lovelace: 100_000_000
```

And `PCOptTxOutRefsFull` to print them for all utxos (it disables grouping of similar utxos)

```
• pubkey #80a4f45 (wallet 2)
  - #fd7f323!54
    Value:
      - Permanent "Banana": 5
      - Lovelace: 20_000_000
  - #7c256b4!1
    Lovelace: 39_354_032
  - #9d8a31f!1
    Lovelace: 59_354_032
  - #008a15d!0
    Lovelace: 60_000_000
  - #fd7f323!46
    Lovelace: 100_000_000
  - #fd7f323!47
    Lovelace: 100_000_000
  - #fd7f323!48
    Lovelace: 100_000_000
  - #fd7f323!49
    Lovelace: 100_000_000
  - #fd7f323!50
    Lovelace: 100_000_000
  - #fd7f323!51
    Lovelace: 100_000_000
  - #fd7f323!52
    Lovelace: 100_000_000
  - #fd7f323!53
    Lovelace: 100_000_000

```