### PR TITLE
Safer testing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@
 
 - `Cooked.holdingInState` is relpaced by `Cooked.holdsInState` which takes an
   address instead of a wallet as argument.
+- Failure testing is slightly modified so that every test has to check that the
+  right error is thrown
+  * `Cooked.testFailsFrom'` is renamed to `Cooked.testFailsFrom`
+  * `Cooked.testFails` is (the new) `Cooked.testFailsFrom` with the default
+    distribution.
+
+  To update their code, users must
+  1. Adapt invokations of `Cooked.testFails` and `Cooked.testFailsFrom` adding
+     a predicate that must hold on the error returned by running the
+     transaction,
+  2. Rename `Cooked.testFailsFrom'` into `Cooked.testFailsFrom`.
+  3. (Bonus) simplify, knowing that ``Cooked.testFailsFrom o x def ==
+     Cooked.testFails o x``
 
 ## [[2.0.0]](https://github.com/tweag/cooked-validators/releases/tag/v2.0.0) - 2023-02-28
 

--- a/tests/Cooked/Attack/DatumHijackingSpec.hs
+++ b/tests/Cooked/Attack/DatumHijackingSpec.hs
@@ -237,10 +237,9 @@ tests =
                   @=? skelOut x2 (1 ==)
             ],
       testCase "careful validator" $
-        testFailsFrom'
+        testFails
           def
           (isCekEvaluationFailure def)
-          def
           ( somewhere
               ( datumHijackingAttack @MockContract
                   ( \(ConcreteOutput v _ _ d _) ->

--- a/tests/Cooked/Attack/DupTokenSpec.hs
+++ b/tests/Cooked/Attack/DupTokenSpec.hs
@@ -121,10 +121,9 @@ tests =
       testCase "careful minting policy" $
         let tName = Pl.tokenName "MockToken"
             pol = carefulPolicy tName 1
-         in testFailsFrom'
+         in testFails
               def
               (isCekEvaluationFailure def)
-              def
               ( somewhere
                   (dupTokenAttack (\_ n -> n + 1) (wallet 6))
                   (dupTokenTrace pol tName 1 (wallet 1))

--- a/tests/Cooked/InlineDatumsSpec.hs
+++ b/tests/Cooked/InlineDatumsSpec.hs
@@ -224,13 +224,13 @@ tests =
                     testSucceeds def $
                       spendOutputTestTrace True (inputDatumValidator True),
                   testCase "...and gets a datum hash, expecting script failure" $
-                    testFailsFrom' def (isCekEvaluationFailure def) def $
+                    testFails def (isCekEvaluationFailure def) $
                       spendOutputTestTrace False (inputDatumValidator True)
                 ],
               testGroup
                 "validator expects a datum hash..."
                 [ testCase "...and gets an inline datum, expecting script failure" $
-                    testFailsFrom' def (isCekEvaluationFailure def) def $
+                    testFails def (isCekEvaluationFailure def) $
                       spendOutputTestTrace True (inputDatumValidator False),
                   testCase "...and gets a datum hash, expecting success" $
                     testSucceeds def $
@@ -245,31 +245,31 @@ tests =
                     testSucceeds def $
                       continuingOutputTestTrace Datum (outputDatumValidator Datum),
                   testCase "...and gets an inline datum, expecting script failure" $
-                    testFailsFrom' def (isCekEvaluationFailure def) def $
+                    testFails def (isCekEvaluationFailure def) $
                       continuingOutputTestTrace Inline (outputDatumValidator Datum),
                   testCase "...and gets a datum hash, expecting script failure" $
-                    testFailsFrom' def (isCekEvaluationFailure def) def $
+                    testFails def (isCekEvaluationFailure def) $
                       continuingOutputTestTrace OnlyHash (outputDatumValidator Datum)
                 ],
               testGroup
                 "validator expects an inline datum..."
                 [ testCase "...and gets a regular datum, expecting script failure" $
-                    testFailsFrom' def (isCekEvaluationFailure def) def $
+                    testFails def (isCekEvaluationFailure def) $
                       continuingOutputTestTrace Datum (outputDatumValidator Inline),
                   testCase "...and gets an inline datum, expecting success" $
                     testSucceeds def $
                       continuingOutputTestTrace Inline (outputDatumValidator Inline),
                   testCase "...and gets a datum hash, expecting script failure" $
-                    testFailsFrom' def (isCekEvaluationFailure def) def $
+                    testFails def (isCekEvaluationFailure def) $
                       continuingOutputTestTrace OnlyHash (outputDatumValidator Inline)
                 ],
               testGroup
                 "validator expects a datum hash..."
                 [ testCase "...and gets a regular datum, expecting script failure" $
-                    testFailsFrom' def (isCekEvaluationFailure def) def $
+                    testFails def (isCekEvaluationFailure def) $
                       continuingOutputTestTrace Datum (outputDatumValidator OnlyHash),
                   testCase "...and gets an inline datum, expecting script failure" $
-                    testFailsFrom' def (isCekEvaluationFailure def) def $
+                    testFails def (isCekEvaluationFailure def) $
                       continuingOutputTestTrace Inline (outputDatumValidator OnlyHash),
                   testCase "...and gets a datum hash, expecting success" $
                     testSucceeds def $

--- a/tests/Cooked/MinAdaSpec.hs
+++ b/tests/Cooked/MinAdaSpec.hs
@@ -54,13 +54,12 @@ tests =
     "automatic minAda adjustment of transaction outputs"
     [ testCase "adjusted transaction passes" $ testSucceeds def paymentWithMinAda,
       testCase "adjusted transaction contains minimal amount" $
-        testFailsFrom'
+        testFails
           def
           ( \case
               MCEValidationError (Pl.Phase1, _) -> testSuccess
               MCECalcFee (MCEValidationError (Pl.Phase1, _)) -> testSuccess
               _ -> testFailure
           )
-          def
           $ paymentWithMinAda >>= paymentWithoutMinAda . (+ (-1))
     ]

--- a/tests/Cooked/ReferenceScriptsSpec.hs
+++ b/tests/Cooked/ReferenceScriptsSpec.hs
@@ -226,13 +226,12 @@ tests =
       testGroup
         "checking the presence of reference scripts on the TxInfo"
         [ testCase "fail if wrong reference script" $
-            testFailsFrom'
+            testFails
               def
               ( isCekEvaluationFailureWithMsg
                   def
                   (== "there is no reference input with the correct script hash")
               )
-              def
               $ putRefScriptOnWalletOutput (wallet 3) noValidator
                 >>= checkReferenceScriptOnOref (toScriptHash yesValidator),
           testCase "succeed if correct reference script" $
@@ -243,14 +242,13 @@ tests =
       testGroup
         "using reference scripts"
         [ testCase "fail from transaction generation for missing reference scripts" $
-            testFailsFrom'
+            testFails
               def
               ( \case
                   MCEGenerationError _ -> testSuccess
                   MCECalcFee (MCEGenerationError _) -> testSuccess
                   _ -> testFailure
               )
-              def
               $ do
                 (oref, _) : _ <-
                   utxosFromCardanoTx
@@ -271,14 +269,13 @@ tests =
                         txSkelSigners = [wallet 1]
                       },
           testCase "phase 1 - fail if using a reference script with 'TxSkelRedeemerForScript'" $
-            testFailsFrom'
+            testFails
               def
               ( \case
                   MCEValidationError (Pl.Phase1, _) -> testSuccess
                   MCECalcFee (MCEValidationError (Pl.Phase1, _)) -> testSuccess
                   _ -> testFailure
               )
-              def
               $ do
                 scriptOref <- putRefScriptOnWalletOutput (wallet 3) yesValidator
                 (oref, _) : _ <-
@@ -302,13 +299,12 @@ tests =
                       },
           testCase
             "fail if referenced script's requirement is violated"
-            $ testFailsFrom'
+            $ testFails
               def
               ( isCekEvaluationFailureWithMsg
                   def
                   (== "the required signer is missing")
               )
-              def
               $ useReferenceScript (wallet 1) (requireSignerValidator (walletPKHash $ wallet 2)),
           testCase "succeed if referenced script's requirement is met" $
             testSucceeds def $

--- a/tests/Cooked/ShowBSSpec.hs
+++ b/tests/Cooked/ShowBSSpec.hs
@@ -112,12 +112,11 @@ tests =
                       *> string "\")"
                   )
                   ""
-         in testFailsFrom'
+         in testFails
               (def @PrettyCookedOpts)
               ( isCekEvaluationFailureWithMsg
                   (def @PrettyCookedOpts)
                   isExpectedString
               )
-              (def @InitialDistribution)
               printTrace
     ]


### PR DESCRIPTION
To promote proper error testing, discard `testFails` which is unsafe because it doesn't distinguish errors (so an assertion failure in the testing code is as successful as a validation error). All failure testing functions must be provided a predicate to check the error returned by the blockchain.