### PR TITLE
Fix package version to match v9.0.0 release tag

### DIFF
--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -5,7 +5,7 @@ cabal-version: 3.4
 -- see: https://github.com/sol/hpack
 
 name:           cooked-validators
-version:        8.0.0
+version:        9.0.0
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@ verbatim:
   cabal-version: 3.4
 
 name: cooked-validators
-version: 8.0.0
+version: 9.0.0
     
 library:
   source-dirs: src


### PR DESCRIPTION
The package version in package.yaml (and the generated .cabal) was left at 8.0.0 even though the latest release, CHANGELOG entry, and git tag are all 9.0.0. Bump it to 9.0.0 to remove the discrepancy.