### PR TITLE
Homogenize tweaks (#491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,31 @@
 
 ### Added
 
+- New module `Cooked.Tweak.Redeemers` homogenizing redeemer tweaks across all
+  five redeemer positions (spending, minting, proposing, withdrawing,
+  certifying):
+  - `modifyRedeemersOfTypeAtTweak`, the position-agnostic building block;
+  - per-position `modify{Spend,Mint,Proposal,Withdrawal,Certificate}RedeemersOfTypeTweak`;
+  - `modifyRedeemersOfTypeTweak`, ranging over all positions at once;
+  - `tamperRedeemerTweak` and `malformRedeemerTweak`, the redeemer counterparts
+    of the existing `tamperDatumTweak` and `malformDatumTweak`.
+- New `addMintTweak` to add a single mint entry (singular counterpart of
+  `addMintsTweak`).
+- New `doc/TWEAKS.md` describing the naming and branching conventions tweaks
+  follow.
+
 ### Removed
 
 ### Changed
+
+- Tweaks were homogenized for naming consistency (see `doc/TWEAKS.md`). The
+  following predicate-based removal tweaks were renamed to plural form:
+  - `removeInputTweak` → `removeInputsTweak`
+  - `removeOutputTweak` → `removeOutputsTweak`
+  - `removeMintTweak` → `removeMintsTweak`
+- `modifySpendRedeemersOfTypeTweak` moved from `Cooked.Tweak.Inputs` to the new
+  `Cooked.Tweak.Redeemers` module (re-exported from `Cooked.Tweak`, so imports
+  of `Cooked` are unaffected).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ handling fees or balancing.
 - The [OPTICS](doc/OPTICS.md) file describes our usage of optics to navigate our
   data structures.
 
+- The [TWEAKS](doc/TWEAKS.md) file describes the conventions our tweaks (the
+  building blocks of the attack DSL) follow, regarding naming and branching
+  behavior.
+
 ## Blog posts
 
 Several blog posts have been written about `cooked-validators`. As the library

--- a/cooked-validators.cabal
+++ b/cooked-validators.cabal
@@ -76,6 +76,7 @@ library
       Cooked.Tweak.Mint
       Cooked.Tweak.OutPermutations
       Cooked.Tweak.Outputs
+      Cooked.Tweak.Redeemers
       Cooked.Tweak.Signatories
       Cooked.Tweak.ValidityRange
       Cooked.Wallet
@@ -183,6 +184,7 @@ test-suite spec
       Spec.Tweak.Common
       Spec.Tweak.Labels
       Spec.Tweak.OutPermutations
+      Spec.Tweak.Redeemers
       Spec.Tweak.TamperDatum
       Spec.Tweak.ValidityRange
       Spec.Withdrawals

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -864,9 +864,9 @@ myTrace = do
 ```haskell
 foo = do
   addOutputTweak $ bazValidator `receives` bazPayment
-  removeOutputTweak (\(Pays out) -> somePredicate out)
+  removeOutputsTweak (\(Pays out) -> somePredicate out)
   addInputTweak somePkTxOutRef txSkelEmptyRedeemer
-  removeInputTweak (\txOutRef redeemer -> somePredicate txOutRef redeemer)
+  removeInputsTweak (\txOutRef redeemer -> somePredicate txOutRef redeemer)
 ```
 
 * Tamper with signatories

--- a/doc/TWEAKS.md
+++ b/doc/TWEAKS.md
@@ -1,0 +1,73 @@
+# Tweaks in `cooked-validators`
+
+A *tweak* is a state-aware modification of a transaction skeleton (`TxSkel`),
+expressed as a `Polysemy` computation with the `Tweak` effect in scope (see
+`Cooked.Tweak.Common`). Tweaks are the building blocks of the attack DSL and can
+be deployed over time using `Cooked.Ltl`.
+
+This document describes the conventions every tweak in the library follows, so
+that their names and behaviors are predictable. If you add a tweak, follow these
+rules; if you find a tweak that breaks them, it is a bug.
+
+## Naming
+
+Every tweak is suffixed with `Tweak` (e.g. `addOutputTweak`). The body of the
+name is `<verb><Subject>`, optionally followed by a branching marker (see
+below). The verb comes from a fixed vocabulary:
+
+| Verb | Meaning |
+|------|---------|
+| `get` | Read a value out of the skeleton (no modification). |
+| `set` | Replace a value wholesale. |
+| `modify` | Apply a function to a value. |
+| `add` | Insert into a collection. |
+| `remove` | Delete from a collection. |
+| `ensure` | Make a property hold, doing nothing if it already does. |
+| `has` / `is` | Predicate returning `Bool`. |
+| `<subject>Satisfies` | Predicate parameterized by a user function. |
+
+### Singular vs. plural
+
+The subject is **singular** when the tweak acts on exactly one element
+(`addInputTweak`, `removeSignatoryTweak`) and **plural** when it takes a list or
+a predicate ranging over the whole collection (`addSignatoriesTweak`,
+`removeInputsTweak`, `removeMintsTweak`). The `Signatories` module is the
+reference example of this convention.
+
+## Branching vs. applying to all foci
+
+Many tweaks target an optic with several foci. There are three possible
+behaviors, and the name and type must make clear which one applies:
+
+1. **Apply-to-all (deterministic).** The modification is applied to every
+   matching focus and a single modified skeleton results. These tweaks do *not*
+   require `NonDet`. They carry no branching marker, e.g. `removeInputsTweak`,
+   `tamperDatumTweak`.
+
+2. **Branching (non-deterministic multiplicity).** The tweak produces several
+   skeletons, typically one per focus or per combination of foci. These tweaks
+   require `Polysemy.NonDet` and are marked `...Any` (one focus chosen per
+   skeleton) or keep an explicit combinatorial name (`combineModsTweak`,
+   `allOutPermutsTweak`, `malformDatumTweak`). The `redirectOutputTweakAll` /
+   `redirectOutputTweakAny` pair in `Cooked.Attack.DatumHijacking` illustrates
+   the `All` / `Any` contrast.
+
+3. **Fallible (zero-or-one).** The tweak may fail, yielding either the single
+   modified skeleton or nothing. It uses `NonDet` (via `guard`) but does *not*
+   multiply skeletons. This is *not* considered branching for naming purposes:
+   such tweaks carry no `Any` marker (e.g. `addInputTweak`, which fails if the
+   input is already present; `intersectValidityRangeTweak`, which fails on an
+   empty intersection).
+
+In short: `...Any` in a name always means "this multiplies the number of
+skeletons". The presence of `NonDet` alone does not, since it is also used for
+plain failure.
+
+## Redeemers
+
+Redeemers occur in five positions of a skeleton: spending (inputs), minting,
+proposing, withdrawing, and certifying. Tweaks that modify redeemers are
+position-aware and live in `Cooked.Tweak.Redeemers`. The datum-style
+`tamper`/`malform` pair has redeemer counterparts (`tamperRedeemerTweak`,
+`malformRedeemerTweak`) with the same apply-all/branching semantics as their
+datum equivalents.

--- a/src/Cooked/Tweak.hs
+++ b/src/Cooked/Tweak.hs
@@ -9,5 +9,6 @@ import Cooked.Tweak.Labels as X
 import Cooked.Tweak.Mint as X
 import Cooked.Tweak.OutPermutations as X
 import Cooked.Tweak.Outputs as X
+import Cooked.Tweak.Redeemers as X
 import Cooked.Tweak.Signatories as X
 import Cooked.Tweak.ValidityRange as X

--- a/src/Cooked/Tweak/Common.hs
+++ b/src/Cooked/Tweak/Common.hs
@@ -2,6 +2,15 @@
 
 -- | This module defines 'Tweak's which are the building blocks of our DSL for
 -- attacks. They are skeleton modifications aware of the mockchain state.
+--
+-- Tweaks follow a set of naming and behavioral conventions described in
+-- @doc/TWEAKS.md@. In short: every tweak is suffixed with @Tweak@ and built as
+-- @\<verb\>\<Subject\>@ using a fixed verb vocabulary
+-- (@get@\/@set@\/@modify@\/@add@\/@remove@\/@ensure@\/@has@\/@is@); the subject
+-- is singular when acting on a single element and plural when acting on a list
+-- or via a predicate; and a tweak that multiplies the number of resulting
+-- skeletons (true non-deterministic branching) is marked @...Any@, as opposed
+-- to merely failing, which is not.
 module Cooked.Tweak.Common
   ( -- * Tweak effect
     Tweak (..),

--- a/src/Cooked/Tweak/Inputs.hs
+++ b/src/Cooked/Tweak/Inputs.hs
@@ -3,8 +3,7 @@
 module Cooked.Tweak.Inputs
   ( ensureInputTweak,
     addInputTweak,
-    removeInputTweak,
-    modifySpendRedeemersOfTypeTweak,
+    removeInputsTweak,
   )
 where
 
@@ -12,7 +11,6 @@ import Control.Monad
 import Cooked.Skeleton
 import Cooked.Tweak.Common
 import Data.Map qualified as Map
-import Optics.Core
 import PlutusLedgerApi.V3 qualified as Api
 import Polysemy
 import Polysemy.NonDet
@@ -47,28 +45,12 @@ addInputTweak oref howConsumed = do
 
 -- | Remove transaction inputs according to a given predicate. The returned list
 -- contains all removed inputs.
-removeInputTweak ::
+removeInputsTweak ::
   (Member Tweak effs) =>
   (Api.TxOutRef -> TxSkelRedeemer -> Bool) ->
   Sem effs [(Api.TxOutRef, TxSkelRedeemer)]
-removeInputTweak removePred = do
+removeInputsTweak removePred = do
   presentInputs <- viewTweak txSkelInsL
   let (removed, kept) = Map.partitionWithKey removePred presentInputs
   setTweak txSkelInsL kept
   return $ Map.toList removed
-
--- | Applies an optional modification to all spend redeemers of type a. Returns
--- the list of modified spending redemeers, as they were before being modified.
-modifySpendRedeemersOfTypeTweak ::
-  forall a b effs.
-  ( RedeemerConstrs a,
-    RedeemerConstrs b,
-    Member Tweak effs
-  ) =>
-  (a -> Maybe b) ->
-  Sem effs [TxSkelRedeemer]
-modifySpendRedeemersOfTypeTweak f =
-  overMaybeTweak (txSkelInsL % iso Map.toList Map.fromList % traversed % _2) $ \red -> do
-    typedRedeemer <- red ^? txSkelRedeemerTypedAT
-    typedRedeemerModified <- f typedRedeemer
-    return $ red & txSkelRedeemerTypedAT @a .~ typedRedeemerModified

--- a/src/Cooked/Tweak/Mint.hs
+++ b/src/Cooked/Tweak/Mint.hs
@@ -1,7 +1,8 @@
 -- | 'Tweak's working on the minting part of a 'TxSkel'
 module Cooked.Tweak.Mint
-  ( addMintsTweak,
-    removeMintTweak,
+  ( addMintTweak,
+    addMintsTweak,
+    removeMintsTweak,
   )
 where
 
@@ -10,6 +11,14 @@ import Cooked.Tweak.Common
 import Data.List (partition)
 import Optics.Core
 import Polysemy
+
+-- | Adds a single entry to the 'TxSkelMints' of the transaction skeleton under
+-- modification.
+addMintTweak ::
+  (Member Tweak effs) =>
+  Mint ->
+  Sem effs ()
+addMintTweak = addMintsTweak . (: [])
 
 -- | Adds new entries to the 'TxSkelMints' of the transaction skeleton under
 -- modification.
@@ -21,11 +30,11 @@ addMintsTweak newMints = overTweak (txSkelMintsL % txSkelMintsListI) (++ newMint
 
 -- | Remove some entries from the 'TxSkelMints' of a transaction, according to
 -- some predicate. The returned list holds the removed entries.
-removeMintTweak ::
+removeMintsTweak ::
   (Member Tweak effs) =>
   (Mint -> Bool) ->
   Sem effs [Mint]
-removeMintTweak removePred = do
+removeMintsTweak removePred = do
   presentMints <- viewTweak $ txSkelMintsL % txSkelMintsListI
   let (removed, kept) = partition removePred presentMints
   setTweak (txSkelMintsL % txSkelMintsListI) kept

--- a/src/Cooked/Tweak/Outputs.hs
+++ b/src/Cooked/Tweak/Outputs.hs
@@ -2,7 +2,7 @@
 module Cooked.Tweak.Outputs
   ( ensureOutputTweak,
     addOutputTweak,
-    removeOutputTweak,
+    removeOutputsTweak,
     tamperDatumTweak,
     TamperDatumLbl (..),
     malformDatumTweak,
@@ -46,11 +46,11 @@ addOutputTweak txSkelOut = overTweak txSkelOutsL (++ [txSkelOut])
 
 -- | Removes transaction outputs according to some predicate. The returned list
 -- contains all the removed outputs.
-removeOutputTweak ::
+removeOutputsTweak ::
   (Member Tweak effs) =>
   (TxSkelOut -> Bool) ->
   Sem effs [TxSkelOut]
-removeOutputTweak removePred = do
+removeOutputsTweak removePred = do
   presentOutputs <- viewTweak txSkelOutsL
   let (removed, kept) = partition removePred presentOutputs
   setTweak txSkelOutsL kept

--- a/src/Cooked/Tweak/Redeemers.hs
+++ b/src/Cooked/Tweak/Redeemers.hs
@@ -1,0 +1,207 @@
+-- | This module provides 'Tweak's that modify the redeemers of a 'TxSkel'.
+--
+-- Redeemers occur in five positions of a skeleton: spending (inputs), minting,
+-- proposing, withdrawing, and certifying. This module exposes a tweak for each
+-- position, a tweak ranging over all positions at once, and the
+-- 'tamperRedeemerTweak' / 'malformRedeemerTweak' counterparts of the datum
+-- tweaks from "Cooked.Tweak.Outputs".
+module Cooked.Tweak.Redeemers
+  ( -- * Per-position redeemer modifications
+    modifyRedeemersOfTypeAtTweak,
+    modifySpendRedeemersOfTypeTweak,
+    modifyMintRedeemersOfTypeTweak,
+    modifyProposalRedeemersOfTypeTweak,
+    modifyWithdrawalRedeemersOfTypeTweak,
+    modifyCertificateRedeemersOfTypeTweak,
+
+    -- * All-position redeemer modifications
+    modifyRedeemersOfTypeTweak,
+
+    -- * Tampering and malforming redeemers
+    tamperRedeemerTweak,
+    TamperRedeemerLbl (..),
+    malformRedeemerTweak,
+    MalformRedeemerLbl (..),
+  )
+where
+
+import Control.Monad
+import Cooked.Pretty.Class
+import Cooked.Skeleton
+import Cooked.Tweak.Common
+import Cooked.Tweak.Labels
+import Data.Map qualified as Map
+import Optics.Core
+import PlutusLedgerApi.V3 qualified as Api
+import Polysemy
+import Polysemy.NonDet
+
+-- | Applies an optional modification to all redeemers of type @a@ focused by a
+-- given optic. Returns the list of modified redeemers, as they were before
+-- being modified. This is the position-agnostic building block from which the
+-- per-position tweaks below are derived.
+modifyRedeemersOfTypeAtTweak ::
+  forall a b k is effs.
+  ( RedeemerConstrs a,
+    RedeemerConstrs b,
+    Member Tweak effs,
+    Is k A_Traversal
+  ) =>
+  -- | An optic focusing the redeemers to consider
+  Optic' k is TxSkel TxSkelRedeemer ->
+  -- | The modification to attempt on each typed redeemer
+  (a -> Maybe b) ->
+  Sem effs [TxSkelRedeemer]
+modifyRedeemersOfTypeAtTweak optic f =
+  overMaybeTweak optic $ \red -> do
+    typedRedeemer <- red ^? txSkelRedeemerTypedAT
+    typedRedeemerModified <- f typedRedeemer
+    return $ red & txSkelRedeemerTypedAT @a .~ typedRedeemerModified
+
+-- | Applies an optional modification to all spending redeemers of type @a@.
+-- Returns the list of modified redeemers, as they were before being modified.
+modifySpendRedeemersOfTypeTweak ::
+  forall a b effs.
+  (RedeemerConstrs a, RedeemerConstrs b, Member Tweak effs) =>
+  (a -> Maybe b) ->
+  Sem effs [TxSkelRedeemer]
+modifySpendRedeemersOfTypeTweak =
+  modifyRedeemersOfTypeAtTweak (txSkelInsL % iso Map.toList Map.fromList % traversed % _2)
+
+-- | Applies an optional modification to all minting redeemers of type @a@.
+-- Returns the list of modified redeemers, as they were before being modified.
+modifyMintRedeemersOfTypeTweak ::
+  forall a b effs.
+  (RedeemerConstrs a, RedeemerConstrs b, Member Tweak effs) =>
+  (a -> Maybe b) ->
+  Sem effs [TxSkelRedeemer]
+modifyMintRedeemersOfTypeTweak =
+  modifyRedeemersOfTypeAtTweak (txSkelMintsL % txSkelMintsListI % traversed % mintRedeemedScriptL % userTxSkelRedeemerL)
+
+-- | Applies an optional modification to all proposing redeemers of type @a@.
+-- Returns the list of modified redeemers, as they were before being modified.
+modifyProposalRedeemersOfTypeTweak ::
+  forall a b effs.
+  (RedeemerConstrs a, RedeemerConstrs b, Member Tweak effs) =>
+  (a -> Maybe b) ->
+  Sem effs [TxSkelRedeemer]
+modifyProposalRedeemersOfTypeTweak =
+  modifyRedeemersOfTypeAtTweak (txSkelProposalsL % traversed % txSkelProposalMConstitutionAT % _Just % userTxSkelRedeemerL)
+
+-- | Applies an optional modification to all withdrawing redeemers of type @a@.
+-- Returns the list of modified redeemers, as they were before being modified.
+modifyWithdrawalRedeemersOfTypeTweak ::
+  forall a b effs.
+  (RedeemerConstrs a, RedeemerConstrs b, Member Tweak effs) =>
+  (a -> Maybe b) ->
+  Sem effs [TxSkelRedeemer]
+modifyWithdrawalRedeemersOfTypeTweak =
+  modifyRedeemersOfTypeAtTweak (txSkelWithdrawalsL % txSkelWithdrawalsListI % traversed % withdrawalUserL % userTxSkelRedeemerAT)
+
+-- | Applies an optional modification to all certifying redeemers of type @a@.
+-- Returns the list of modified redeemers, as they were before being modified.
+modifyCertificateRedeemersOfTypeTweak ::
+  forall a b effs.
+  (RedeemerConstrs a, RedeemerConstrs b, Member Tweak effs) =>
+  (a -> Maybe b) ->
+  Sem effs [TxSkelRedeemer]
+modifyCertificateRedeemersOfTypeTweak =
+  modifyRedeemersOfTypeAtTweak (txSkelCertificatesL % traversed % txSkelCertificateOwnerAT % userTxSkelRedeemerL)
+
+-- | Applies an optional modification to all redeemers of type @a@, regardless
+-- of their position in the skeleton (spending, minting, proposing, withdrawing
+-- or certifying). Returns the list of modified redeemers, as they were before
+-- being modified.
+modifyRedeemersOfTypeTweak ::
+  forall a b effs.
+  (RedeemerConstrs a, RedeemerConstrs b, Member Tweak effs) =>
+  (a -> Maybe b) ->
+  Sem effs [TxSkelRedeemer]
+modifyRedeemersOfTypeTweak f =
+  concat
+    <$> sequence
+      [ modifySpendRedeemersOfTypeTweak f,
+        modifyMintRedeemersOfTypeTweak f,
+        modifyProposalRedeemersOfTypeTweak f,
+        modifyWithdrawalRedeemersOfTypeTweak f,
+        modifyCertificateRedeemersOfTypeTweak f
+      ]
+
+-- | A label added to a 'TxSkel' on which the 'tamperRedeemerTweak' has been
+-- successfully applied
+data TamperRedeemerLbl = TamperRedeemerLbl deriving (Show, Eq, Ord)
+
+instance PrettyCooked TamperRedeemerLbl where
+  prettyCooked _ = "TamperRedeemer"
+
+-- | A tweak that tries to change the redeemers of a certain type, in any
+-- position of the skeleton, with a prescribed tampering function. The tampering
+-- function ignores redeemers of other types and those for which it returns
+-- @Nothing@. This is the redeemer counterpart of
+-- 'Cooked.Tweak.Outputs.tamperDatumTweak'.
+--
+-- The tweak returns a list of the modified redeemers, as they were *before* the
+-- modification was applied to them.
+tamperRedeemerTweak ::
+  forall a effs.
+  (Members '[Tweak, NonDet] effs, RedeemerConstrs a) =>
+  (a -> Maybe a) ->
+  Sem effs [TxSkelRedeemer]
+tamperRedeemerTweak change = do
+  beforeModification <- modifyRedeemersOfTypeTweak change
+  guard . not . null $ beforeModification
+  addLabelTweak TamperRedeemerLbl
+  return beforeModification
+
+-- | A label added to a 'TxSkel' on which the 'malformRedeemerTweak' has been
+-- successfully applied
+data MalformRedeemerLbl = MalformRedeemerLbl deriving (Show, Eq, Ord)
+
+instance PrettyCooked MalformRedeemerLbl where
+  prettyCooked _ = "MalformRedeemer"
+
+-- | A tweak that tries to change the redeemers of a certain type, in any
+-- position of the skeleton, with a prescribed tampering function. There are two
+-- main differences with 'tamperRedeemerTweak'. First, the tampering function
+-- returns 'Api.BuiltinData', allowing it to do pretty much anything with the
+-- redeemers. Second, for every redeemer there are zero or more options for how
+-- to modify it, and all combinations of these modifications are tried. This is
+-- the redeemer counterpart of 'Cooked.Tweak.Outputs.malformDatumTweak'.
+malformRedeemerTweak ::
+  forall a effs.
+  (Members '[Tweak, NonDet] effs, RedeemerConstrs a) =>
+  (a -> [Api.BuiltinData]) ->
+  Sem effs ()
+malformRedeemerTweak change = do
+  redeemers <- viewAllTweak redeemersT
+  let modifiedRedeemers = map (\red -> red : changeRedeemer red) redeemers
+      -- We remove the first combination because it consists of all the heads
+      -- and therefore it is the combination consisting of no changes at all.
+      modifiedRedeemerGroups = tail $ allCombinations modifiedRedeemers
+  msum $ map (setTweak (partsOf redeemersT)) modifiedRedeemerGroups
+  addLabelTweak MalformRedeemerLbl
+  where
+    changeRedeemer :: TxSkelRedeemer -> [TxSkelRedeemer]
+    changeRedeemer red = do
+      typedRed <- red ^.. txSkelRedeemerTypedAT @a
+      modifiedData <- change typedRed
+      return $ red & txSkelRedeemerBuiltinDataL .~ modifiedData
+
+-- | A traversal focusing every 'TxSkelRedeemer' of a skeleton, in all five
+-- positions (spending, minting, proposing, withdrawing and certifying). The
+-- five positions focus disjoint parts of the skeleton, so they can be safely
+-- combined with 'adjoin'.
+redeemersT :: Traversal' TxSkel TxSkelRedeemer
+redeemersT =
+  (txSkelInsL % iso Map.toList Map.fromList % traversed % _2)
+    `adjoin` (txSkelMintsL % txSkelMintsListI % traversed % mintRedeemedScriptL % userTxSkelRedeemerL)
+    `adjoin` (txSkelProposalsL % traversed % txSkelProposalMConstitutionAT % _Just % userTxSkelRedeemerL)
+    `adjoin` (txSkelWithdrawalsL % txSkelWithdrawalsListI % traversed % withdrawalUserL % userTxSkelRedeemerAT)
+    `adjoin` (txSkelCertificatesL % traversed % txSkelCertificateOwnerAT % userTxSkelRedeemerL)
+
+-- | All combinations of a list of lists: see
+-- 'Cooked.Tweak.Outputs.allCombinations'.
+allCombinations :: [[a]] -> [[a]]
+allCombinations [] = [[]]
+allCombinations [[]] = []
+allCombinations (first : rest) = [x : xs | x <- first, xs <- allCombinations rest]

--- a/tests/Spec/Tweak.hs
+++ b/tests/Spec/Tweak.hs
@@ -3,6 +3,7 @@ module Spec.Tweak (tests) where
 import Spec.Tweak.Common qualified as Common
 import Spec.Tweak.Labels qualified as Labels
 import Spec.Tweak.OutPermutations qualified as OutPermutations
+import Spec.Tweak.Redeemers qualified as Redeemers
 import Spec.Tweak.TamperDatum qualified as TamperDatum
 import Spec.Tweak.ValidityRange qualified as ValidityRange
 import Test.Tasty
@@ -13,6 +14,7 @@ tests =
     "Tweaks"
     [ Common.tests,
       OutPermutations.tests,
+      Redeemers.tests,
       TamperDatum.tests,
       ValidityRange.tests,
       Labels.tests

--- a/tests/Spec/Tweak/Redeemers.hs
+++ b/tests/Spec/Tweak/Redeemers.hs
@@ -1,0 +1,93 @@
+-- | Tests for 'Cooked.Tweak.Redeemers'.
+module Spec.Tweak.Redeemers where
+
+import Cooked
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Optics.Core
+import PlutusLedgerApi.V3 qualified as Api
+import PlutusTx qualified
+import Polysemy
+import Polysemy.NonDet
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
+
+-- | A fabricated 'Api.TxOutRef' for building spending inputs in pure tweak
+-- tests (no mockchain needed).
+oref :: Integer -> Api.TxOutRef
+oref = Api.TxOutRef (Api.TxId "")
+
+-- | A skeleton spending three inputs: two with 'Integer' redeemers and one with
+-- a redeemer of a different type, which redeemer tweaks targeting 'Integer'
+-- must leave untouched.
+baseSkel :: TxSkel
+baseSkel =
+  txSkelTemplate
+    { txSkelIns =
+        Map.fromList
+          [ (oref 0, someTxSkelRedeemer (10 :: Integer)),
+            (oref 1, someTxSkelRedeemer (20 :: Integer)),
+            (oref 2, someTxSkelRedeemer True)
+          ]
+    }
+
+-- | The list of 'Integer'-typed spending redeemers of a skeleton.
+integerRedeemers :: TxSkel -> [Integer]
+integerRedeemers = toListOf (txSkelInsL % to Map.elems % folded % txSkelRedeemerTypedAT @Integer)
+
+modifySpendRedeemersTest :: TestTree
+modifySpendRedeemersTest =
+  testCase "modifySpendRedeemersOfTypeTweak only touches redeemers of the right type" $
+    [11, 21]
+      @=? ( integerRedeemers . fst . run $
+              runTweak
+                baseSkel
+                (modifySpendRedeemersOfTypeTweak @Integer @Integer (\n -> Just (n + 1)))
+          )
+
+modifyAllRedeemersTest :: TestTree
+modifyAllRedeemersTest =
+  testCase "modifyRedeemersOfTypeTweak reaches the spending redeemers" $
+    [0, 0]
+      @=? ( integerRedeemers . fst . run $
+              runTweak baseSkel (modifyRedeemersOfTypeTweak @Integer @Integer (const $ Just 0))
+          )
+
+tamperRedeemerTest :: TestTree
+tamperRedeemerTest =
+  testCase "tamperRedeemerTweak modifies redeemers and adds its label" $
+    [(Set.singleton (TxSkelLabel TamperRedeemerLbl), [11, 21])]
+      @=? ( fmap (\(skel, _) -> (view txSkelLabelsL skel, integerRedeemers skel)) . run . runNonDet $
+              runTweak
+                baseSkel
+                (tamperRedeemerTweak @Integer (\n -> Just (n + 1)))
+          )
+
+malformRedeemerTest :: TestTree
+malformRedeemerTest =
+  testCase "malformRedeemerTweak tries all combinations of redeemer modifications" $
+    let allData :: TxSkel -> [PlutusTx.BuiltinData]
+        allData = toListOf (txSkelInsL % to Map.elems % folded % txSkelRedeemerBuiltinDataL)
+        d :: (PlutusTx.ToData a) => a -> PlutusTx.BuiltinData
+        d = PlutusTx.toBuiltinData
+     in assertSameSets
+          [ [d False, d (20 :: Integer), d True], -- only the first integer redeemer changed
+            [d (10 :: Integer), d False, d True], -- only the second integer redeemer changed
+            [d False, d False, d True] -- both integer redeemers changed
+          ]
+          ( (fmap allData . run . runNonDet)
+              ( execTweak
+                  baseSkel
+                  (malformRedeemerTweak @Integer (const [PlutusTx.toBuiltinData False]))
+              )
+          )
+
+tests :: TestTree
+tests =
+  testGroup
+    "Redeemer tweaks"
+    [ modifySpendRedeemersTest,
+      modifyAllRedeemersTest,
+      tamperRedeemerTest,
+      malformRedeemerTest
+    ]


### PR DESCRIPTION
Address the three shortcomings of the tweak DSL described in #491:

- Naming consistency: rename predicate-based removal tweaks to plural form (removeInputTweak -> removeInputsTweak, removeOutputTweak -> removeOutputsTweak, removeMintTweak -> removeMintsTweak) and add a singular addMintTweak.
- Missing redeemer tweaks: introduce Cooked.Tweak.Redeemers with redeemer modification tweaks for all five redeemer positions (spending, minting, proposing, withdrawing, certifying), an all-position variant, and tamperRedeemerTweak / malformRedeemerTweak mirroring the datum tweaks. modifySpendRedeemersOfTypeTweak moves here from Cooked.Tweak.Inputs.
- Branch vs apply-all clarity: document the naming and branching conventions in doc/TWEAKS.md and summarize them in the Cooked.Tweak.Common haddock.

Add tests for the new redeemer tweaks and update CHEATSHEET and CHANGELOG.