### PR TITLE
Improve docs, error handling, and ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,25 @@
 
 ### Added
 
+- New `withReferenceInput` helper to attach a reference input to a
+  `TxSkelRedeemer`, replacing the more verbose
+  `set txSkelRedeemerMReferenceInputL (Just …)` idiom.
+
 ### Removed
 
 ### Changed
 
+- Building a `ParameterChange` governance action containing a `CostModels`
+  parameter update now fails with an explicit `MCEUnsupportedFeature` error
+  instead of silently ignoring the requested change.
+
 ### Fixed
+
+- Pretty-printing a `TxSkel` with `pcOptPrintDefaultTxSkelOpts` enabled no longer
+  crashes when `txSkelOptMaxNbOfBalancingUtxos` is left at its default (`Nothing`).
+- Transaction-generation failures while assigning execution units and while
+  computing a pool-retirement epoch now include the underlying error detail in
+  their message.
 
 ## [[9.0.0]](https://github.com/tweag/cooked-validators/releases/tag/v9.0.0) - 2026-05-28
 

--- a/doc/BALANCING.md
+++ b/doc/BALANCING.md
@@ -62,7 +62,7 @@ specifies which wallet to use as the balancing wallet.
 
 ``` haskell
 data BalancingPolicy
-  = BalanceWithFirstSigner -- default
+  = BalanceWithFirstSignatory -- default
   | BalanceWith Wallet
   | DoNotBalance
 ```
@@ -75,7 +75,7 @@ necessitates it, the balancing wallet also supplies UTXOs to cover any missing
 inputs in the transaction.
 
 Here are the options available:
-* `BalanceWithFirstSigner`: Enables auto-balancing and uses the first wallet in
+* `BalanceWithFirstSignatory`: Enables auto-balancing and uses the first wallet in
   the list of signers as the balancing wallet. If the list of signers is empty,
   an error is thrown:
   
@@ -102,7 +102,7 @@ skeleton.
 
 ``` haskell
 data BalancingUtxos
-  = BalancingUtxosFromBalancingWallet -- default
+  = BalancingUtxosFromBalancingUser -- default
   | BalancingUtxosFromSet (Set Api.TxOutRef)
 ```
 
@@ -113,7 +113,7 @@ set of UTXOs considered for balancing is not necessarily the same as the final
 set used; rather, the final set is a subset of the initially considered UTXOs.
 
 Here is the semantics of the constructors:
-* `BalancingUtxosFromBalancingWallet`: The UTXOs considered for balancing will be those
+* `BalancingUtxosFromBalancingUser`: The UTXOs considered for balancing will be those
   owned by the balancing wallet and containing only a value. UTXOs with a
   reference script, a datum, or a staking credential will not be considered for
   balancing.
@@ -211,8 +211,8 @@ Which utxos to pick from as collateral inputs.
 
 ``` haskell
 data CollateralUtxos
-  = CollateralUtxosFromBalancingWallet -- default
-  | CollateralUtxosFromWallet Wallet
+  = CollateralUtxosFromBalancingUser -- default
+  | CollateralUtxosFromUser Wallet
   | CollateralUtxosFromSet (Set Api.TxOutRef) Wallet
 ```
 
@@ -232,11 +232,11 @@ number of allowable collateral UTXOs (typically 3).
 
 Here are the options available:
 
-* `CollateralUtxosFromBalancingWallet`: Use UTXOs containing only value from the
+* `CollateralUtxosFromBalancingUser`: Use UTXOs containing only value from the
   balancing wallet. The return collateral will be directed back to the balancing
-  wallet. This option is synonymous with `CollateralUtxosFromWallet
+  wallet. This option is synonymous with `CollateralUtxosFromUser
   balancingWallet`.
-* `CollateralUtxosFromWallet Wallet`: Use UTXOs containing only value from the
+* `CollateralUtxosFromUser Wallet`: Use UTXOs containing only value from the
   specified wallet. Transactions using these UTXOs will require the signing of
   the wallet owner for validation. The return collateral will also be sent to
   this same wallet.

--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -146,10 +146,12 @@ printCooked $ runMockChainFromConf myConf myTrace
   `mustSucceedTest myTrace`
 * Expect a failure from a trace:
   `mustFailTest myTrace`
-* Expect a failure within a specific validation phase/with a specific error message:
-  `mustFailInPhase[1|2](withMessage?) (expectedMessage?) myTrace`
+* Expect a failure within a specific validation phase:
+  `mustFailInPhase1Test myTrace` or `mustFailInPhase2Test myTrace`
+* Expect a failure within a specific validation phase with a specific error message:
+  `mustFailInPhase1WithMsgTest expectedMessage myTrace` or `mustFailInPhase2WithMsgTest expectedMessage myTrace`
 * Manually customize the:
-  * initial distribution: `withInitiDist myPaymentsList`
+  * initial distribution: `withInitDist myPaymentsList`
   * pretty printing options: `withPrettyOpts myOptions`
   * expectations on the log: `withLogProp myLogProp`
   * expectations on the resulting state: `withStateProp myStateProp`
@@ -565,7 +567,7 @@ when applicable.
 * No redeemer, forbid auto fill of reference script: `emptyTxSkelRedeemerNoAutoFill`
 * Some redeemer, auto fill of reference script: `someTxSkelRedeemer myRedeemer`
 * Some redeemer, forbid auto fill of reference script: `someTxSkelRedeemerNoAutoFill myRedeemer`
-* Attach a reference input manually (with a reference script): ``txSkelRedeemer `withReferenceInput` txOutRefContainingRefScript``
+* Attach a reference input manually (with a reference script): ``withReferenceInput txSkelRedeemer txOutRefContainingRefScript``
 * Build the redeemer as a record manually:
 ```haskell
 myRedeemer :: TxSkelRedeemer
@@ -584,7 +586,7 @@ txSkelTemplate
   { ...
     txSkelIns = Map.fromList 
 	  [ (txOutRef1, someTxSkelRedeemer red), 
-        (txOutRef2, emptyTxSkelRedeemer `withReferenceInput` txOutRef),
+        (txOutRef2, withReferenceInput emptyTxSkelRedeemer txOutRef),
 	    (txOutRef3, someTxSkelRedeemerNoAutoFill red2)
 	  ]
     ...
@@ -615,7 +617,7 @@ txSkelTemplate
 ## Reference inputs
 
 * Within redeemers automatically `myTxSkelRedeemer`
-* Within redeemers manually ``myTxSkelRedeemer `withReferenceInput` myRefInput``
+* Within redeemers manually ``withReferenceInput myTxSkelRedeemer myRefInput``
 * Additional reference inputs not bound to redeemers:
 ```haskell
 txSkelTemplate
@@ -643,8 +645,8 @@ txSkelTemplate
 ```
 txSkelTemplate
   { ...
-    txSkelSignatories = [TxSkelSignatory user1 ... , TxSkelSignatory user2 ... ],
-	txSkelCollateralUtxos = CollateralUtxosFromUser user2
+    txSkelSignatories = [TxSkelSignatory user1 ... , TxSkelSignatory user2 ...],
+	txSkelOpts = def {txSkelOptCollateralUtxos = CollateralUtxosFromUser user2}
     ...
   }
 ```
@@ -653,7 +655,7 @@ txSkelTemplate
 ```
 txSkelTemplate
   { ...
-	txSkelCollateralUtxos = CollateralUtxosFromSet (Set.fromList [txOutRef1, txOutRef2])
+	txSkelOpts = def {txSkelOptCollateralUtxos = CollateralUtxosFromSet (Set.fromList [txOutRef1, txOutRef2]) user2}
     ...
   }
 ```
@@ -689,16 +691,19 @@ txSkelTemplate
   { ...
     txSkelProposals =
       [ TxSkelProposal
-          { txSkelProposalAddress = walletAddress (wallet 1),
-            txSkelProposalAction =
-              TxGovActionTreasuryWithdrawals $
+          { -- The credential that should be used for the return account
+            txSkelProposalReturnCredential = wallet 1,
+            txSkelProposalGovernanceAction =
+              TreasuryWithdrawals $
                 Map.fromList
                   [ (toCredential $ wallet 1, Api.Lovelace 100),
                     (toCredential $ wallet 2, Api.Lovelace 10_000)
                   ],
-            txSkelProposalWitness = Just (myConstitutionScript, myTxSkelRedeemer),
-            txSkelProposalAnchor = Nothing,
-			txSkelProposalAutoConstitution = False
+            -- The constitution witness, only relevant for witnessed
+            -- governance actions; use 'Nothing' for unwitnessed ones
+            txSkelProposalConstitution = Just (UserRedeemedScript myConstitutionScript myTxSkelRedeemer),
+            -- An optional anchor (use 'simpleURLAnchor' to build one)
+            txSkelProposalAnchor = Nothing
           }
       ]
     ...
@@ -711,21 +716,22 @@ txSkelTemplate
 txSkelTemplate
   { ...
     txSkelProposals =
-      [ simpleTxSkelProposal
+      [ simpleProposal
           (wallet 1)
-          (TxGovActionParameterChange [FeePerByte 100, FeeFixed 1_000])
-          `withWitness` (myScript, myTxSkelRedeemer)
-          `withAnchor` "https://www.tweag.io/"
+          (ParameterChange [FeePerByte 100, FeeFixed 1_000])
+          & fillConstitution myConstitutionScript
+          & set txSkelProposalAnchorL (simpleURLAnchor "https://www.tweag.io/")
       ]
     ...
   } 
 ```
 
-* Enable auto filling of the current offical constitution script.
+* Auto filling of the current official constitution script.
 
-```haskell 
-   txSkelProposalAutoConstitution = True
-```
+Leave a witnessed proposal's constitution unset (i.e. `Nothing`). During
+transaction generation the current official constitution script (the one set
+with `setConstitutionScript`) is automatically filled in with an empty
+redeemer, logging an `MCLogAutoFilledConstitution` event.
 
 ## Withdrawals
 
@@ -747,7 +753,7 @@ txSkelTemplate
 ```haskell 
     txSkelTemplate
       { txSkelWithdrawals = txSkelWithdrawalsFromList 
-	      [ TxSkelWithdrawal myWithdrawingPeer (Just 2_000_000),
+	      [ Withdrawal (UserPubKey myWithdrawingPeer) (Just $ Api.Lovelace 2_000_000),
 		    ...
 	      ]
 	    ...
@@ -795,7 +801,7 @@ txSkelTemplate
 txSkelTemplate
   { ...
     txSkelSignatories = [signatory1, signatory2],
-    txOpts = def {txOptBalancingPolicy = BalanceWith (wallet 2)}
+    txSkelOpts = def {txSkelOptBalancingPolicy = BalanceWith (wallet 2)}
     ...
   }
 ```
@@ -805,7 +811,7 @@ txSkelTemplate
 ```haskell
 txSkelTemplate
   { ...
-    txOpts = def {txOptBalancingPolicy = DoNotBalance}
+    txSkelOpts = def {txSkelOptBalancingPolicy = DoNotBalance}
     ...
   }
 ```
@@ -865,7 +871,7 @@ myTrace = do
 foo = do
   addOutputTweak $ bazValidator `receives` bazPayment
   removeOutputTweak (\(Pays out) -> somePredicate out)
-  addInputTweak somePkTxOutRef txSkelEmptyRedeemer
+  addInputTweak somePkTxOutRef emptyTxSkelRedeemer
   removeInputTweak (\txOutRef redeemer -> somePredicate txOutRef redeemer)
 ```
 

--- a/doc/OPTICS.md
+++ b/doc/OPTICS.md
@@ -58,6 +58,25 @@ optics kind.
   vice-versa. Isos can be reversed using `re` in addition to being used with
   `view`, `review`, `over`, and `set`.
 
+## Documentation convention
+
+Every exported optic carries a Haddock comment whose leading verb is determined
+by the optic kind, so that the comment reinforces the capability already encoded
+in the name suffix. The focused part is always described as being "of a
+`'Structure'`", using a Haddock link to the containing structure:
+
+- Getters (`G`): `-- | Retrieves the \<part\> of a '\<Structure\>'`
+- Affine folds (`AF`): `-- | Retrieves the optional \<part\> of a '\<Structure\>'`
+- Lenses (`L`): `-- | Focuses on the \<part\> of a '\<Structure\>'`
+- Affine traversals (`AT`) and lenses onto a `Maybe`: `-- | Focuses on the
+  optional \<part\> of a '\<Structure\>'`
+- Prisms (`P`): `-- | Builds or retrieves the \<part\> of a '\<Structure\>'`
+- Isos (`I`): `-- | An isomorphism between '\<Structure\>' and \<part\>`
+
+For example, `txSkelOutCredentialG` reads "Retrieves the credential of a
+`'TxSkelOut'`", while `txSkelOutStakingCredentialAT` reads "Focuses on the
+optional staking credential of a `'TxSkelOut'`".
+
 ## Combining optics
 
 Optics can be combined arbitrarily, as long as the parts they focus

--- a/src/Cooked/Attack/DoubleSat.hs
+++ b/src/Cooked/Attack/DoubleSat.hs
@@ -129,7 +129,7 @@ doubleSatAttack groupings optic change target = do
     -- calculate its balance
     deltaBalance :: DoubleSatDelta -> Sem effs Api.Value
     deltaBalance (inputs, outputs, mints) = do
-      inValue <- foldMap (view txSkelOutValueL . snd) . filter ((`elem` Map.keys inputs) . fst) <$> allUtxos
+      inValue <- foldMap (view txSkelOutValueL . snd) . filter ((`Map.member` inputs) . fst) <$> allUtxos
       return $ inValue <> PlutusTx.negate (foldOf (traversed % txSkelOutValueL) outputs) <> Script.toValue mints
 
     -- Helper tweak to add a 'DoubleSatDelta' to a transaction

--- a/src/Cooked/MockChain/AutoFilling.hs
+++ b/src/Cooked/MockChain/AutoFilling.hs
@@ -14,7 +14,6 @@ import Cooked.Skeleton
 import Cooked.Tweak.Common
 import Data.List (find)
 import Data.Map qualified as Map
-import Data.Maybe
 import Ledger.Tx qualified as Ledger
 import Optics.Core
 import Plutus.Script.Utils.Address qualified as Script
@@ -36,22 +35,22 @@ autoFillWithdrawalAmounts = do
   withdrawals <- viewTweak (txSkelWithdrawalsL % txSkelWithdrawalsListI)
   newWithdrawals <- forM withdrawals $ \withdrawal -> do
     currentReward <- getCurrentReward $ view withdrawalUserL withdrawal
-    let (changed, newWithdrawal) = case currentReward of
-          Nothing -> (False, withdrawal)
-          Just reward -> (isn't withdrawalAmountAT withdrawal, fillAmount reward withdrawal)
-    when changed $
-      logEvent $
-        MCLogAutoFilledWithdrawalAmount
-          (view (withdrawalUserL % to Script.toCredential) newWithdrawal)
-          (fromJust (preview withdrawalAmountAT newWithdrawal))
-    return newWithdrawal
+    case currentReward of
+      Just reward | isn't withdrawalAmountAT withdrawal -> do
+        let newWithdrawal = fillAmount reward withdrawal
+        logEvent $
+          MCLogAutoFilledWithdrawalAmount
+            (view (withdrawalUserL % to Script.toCredential) newWithdrawal)
+            reward
+        return newWithdrawal
+      _ -> return withdrawal
   setTweak (txSkelWithdrawalsL % txSkelWithdrawalsListI) newWithdrawals
 
 -- * Auto filling constitution script
 
 -- | Goes through all the proposals of the input skeleton and attempts to fill
 -- out the constitution scripts with the current one. Does not tamper with an
--- existing specified script in such withdrawals. Logs an event when the
+-- existing specified script in such proposals. Logs an event when the
 -- constitution script has been successfully auto-filled.
 autoFillConstitution ::
   (Members '[MockChainRead, Tweak, MockChainLog] effs) =>
@@ -70,7 +69,7 @@ autoFillConstitution = do
         return (fillConstitution constitutionScript prop)
       setTweak txSkelProposalsL newProposals
 
--- -- * Auto filling reference scripts
+-- * Auto filling reference scripts
 
 -- | Attempts to find in the index a utxo containing a reference script with the
 -- given script hash, and attaches it to a redeemer when it does not yet have a

--- a/src/Cooked/MockChain/GenerateTx/Body.hs
+++ b/src/Cooked/MockChain/GenerateTx/Body.hs
@@ -133,7 +133,7 @@ txSkelToTxBody txSkel fee mCollaterals = do
       -- We can then assign the right execution units to the body content
       case Cardano.substituteExecutionUnits exUnits txBodyContent' of
         -- This can only be a @TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap@
-        Left _ -> fail "Error while assigning execution units"
+        Left err -> fail $ "Error while assigning execution units: " <> show err
         -- We now have a body content with proper execution units and can create
         -- the final body from it
         Right txBodyContent -> txBodyContentToTxBody txBodyContent

--- a/src/Cooked/MockChain/GenerateTx/Body.hs
+++ b/src/Cooked/MockChain/GenerateTx/Body.hs
@@ -133,7 +133,7 @@ txSkelToTxBody txSkel fee mCollaterals = do
       -- We can then assign the right execution units to the body content
       case Cardano.substituteExecutionUnits exUnits txBodyContent' of
         -- This can only be a @TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap@
-        Left err -> fail $ "Error while assigning execution units: " <> show err
+        Left err -> throw $ MCEFailure $ "Error while assigning execution units: " <> show err
         -- We now have a body content with proper execution units and can create
         -- the final body from it
         Right txBodyContent -> txBodyContentToTxBody txBodyContent

--- a/src/Cooked/MockChain/GenerateTx/Certificate.hs
+++ b/src/Cooked/MockChain/GenerateTx/Certificate.hs
@@ -41,7 +41,7 @@ toDelegatee (Api.DelegVote dRep) = Conway.DelegVote <$> toDRep dRep
 toDelegatee (Api.DelegStakeVote pkh dRep) = liftA2 Conway.DelegStakeVote (toStakePoolKeyHash pkh) (toDRep dRep)
 
 toCertificate ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError, Fail] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
   TxSkelCertificate ->
   Sem effs (Cardano.Certificate Cardano.ConwayEra)
 toCertificate txSkelCert =
@@ -81,7 +81,7 @@ toCertificate txSkelCert =
                 case Cardano.slotToEpoch (fromIntegral slot) eeh of
                   -- TODO: we could have a dedicated error for this case if the
                   -- can occur at several places in the codebase
-                  Left err -> fail $ "Too far away in the future: " <> show err
+                  Left err -> throw $ MCEFailure $ "Too far away in the future: " <> show err
                   Right (epoch, _, _) -> return epoch
             )
       TxSkelCertificate (Script.toCredential -> coldCred) (CommitteeRegisterHot hotCred) ->

--- a/src/Cooked/MockChain/GenerateTx/Certificate.hs
+++ b/src/Cooked/MockChain/GenerateTx/Certificate.hs
@@ -81,7 +81,7 @@ toCertificate txSkelCert =
                 case Cardano.slotToEpoch (fromIntegral slot) eeh of
                   -- TODO: we could have a dedicated error for this case if the
                   -- can occur at several places in the codebase
-                  Left _ -> fail "Too far away in the future"
+                  Left err -> fail $ "Too far away in the future: " <> show err
                   Right (epoch, _, _) -> return epoch
             )
       TxSkelCertificate (Script.toCredential -> coldCred) (CommitteeRegisterHot hotCred) ->

--- a/src/Cooked/MockChain/GenerateTx/Proposal.hs
+++ b/src/Cooked/MockChain/GenerateTx/Proposal.hs
@@ -32,15 +32,20 @@ import Polysemy.Error
 -- | Transorms a `Cooked.Skeleton.Proposal.ParamChange` into an actual change
 -- over a Cardano parameter update
 toPParamsUpdate ::
+  forall effs.
+  (Member (Error MockChainError) effs) =>
   ParamChange ->
   Conway.PParamsUpdate Emulator.EmulatorEra ->
-  Conway.PParamsUpdate Emulator.EmulatorEra
-toPParamsUpdate pChange =
+  Sem effs (Conway.PParamsUpdate Emulator.EmulatorEra)
+toPParamsUpdate pChange ppu =
   -- From rational to bounded rational
   let toBR :: (Cardano.BoundedRational r) => Rational -> r
       toBR = fromMaybe minBound . Cardano.boundRational
-      -- Helper to set one of the param update with a lens
-      setL l = MicroLens.set l . SJust
+      -- Helper to set one of the param update with a lens. The explicit
+      -- signature is needed so that it stays polymorphic in @a@ under
+      -- @MonoLocalBinds@ despite closing over @effs@ and @ppu@.
+      setL :: forall a. MicroLens.ASetter' (Conway.PParamsUpdate Emulator.EmulatorEra) (StrictMaybe a) -> a -> Sem effs (Conway.PParamsUpdate Emulator.EmulatorEra)
+      setL l v = return $ MicroLens.set l (SJust v) ppu
    in case pChange of
         FeePerByte n -> setL Conway.ppuMinFeeAL $ fromIntegral n
         FeeFixed n -> setL Conway.ppuMinFeeBL $ fromIntegral n
@@ -56,7 +61,7 @@ toPParamsUpdate pChange =
         TreasuryCut q -> setL Conway.ppuTauL $ toBR q
         MinPoolCost n -> setL Conway.ppuMinPoolCostL $ fromIntegral n
         CoinsPerUTxOByte n -> setL Conway.ppuCoinsPerUTxOByteL $ Conway.CoinPerByte $ fromIntegral n
-        CostModels _pv1 _pv2 _pv3 -> id -- TODO unsupported for now
+        CostModels _pv1 _pv2 _pv3 -> throw $ MCEUnsupportedFeature "CostModels"
         Prices q r -> setL Conway.ppuPricesL $ Cardano.Prices (toBR q) (toBR r)
         MaxTxExUnits n m -> setL Conway.ppuMaxTxExUnitsL $ Cardano.ExUnits (fromIntegral n) (fromIntegral m)
         MaxBlockExUnits n m -> setL Conway.ppuMaxBlockExUnitsL $ Cardano.ExUnits (fromIntegral n) (fromIntegral m)
@@ -87,8 +92,9 @@ toGovAction NoConfidence _ = return $ Conway.NoConfidence SNothing
 toGovAction UpdateCommittee {} _ = throw $ MCEUnsupportedFeature "UpdateCommittee"
 toGovAction NewConstitution {} _ = throw $ MCEUnsupportedFeature "TxGovActionNewConstitution"
 toGovAction HardForkInitiation {} _ = throw $ MCEUnsupportedFeature "TxGovActionHardForkInitiation"
-toGovAction (ParameterChange changes) sHash =
-  return $ Conway.ParameterChange SNothing (foldl (flip toPParamsUpdate) (Conway.PParamsUpdate Cardano.emptyPParamsStrictMaybe) changes) sHash
+toGovAction (ParameterChange changes) sHash = do
+  ppu <- foldM (flip toPParamsUpdate) (Conway.PParamsUpdate Cardano.emptyPParamsStrictMaybe) changes
+  return $ Conway.ParameterChange SNothing ppu sHash
 toGovAction (TreasuryWithdrawals (Map.toList -> withdrawals)) sHash =
   (`Conway.TreasuryWithdrawals` sHash) . Map.fromList <$> mapM (\(cred, Api.Lovelace lv) -> (,Cardano.Coin lv) <$> toRewardAccount cred) withdrawals
 

--- a/src/Cooked/MockChain/State.hs
+++ b/src/Cooked/MockChain/State.hs
@@ -256,7 +256,7 @@ utxoPayloadSetTotal = foldOf (utxoPayloadSetListI % folded % utxoPayloadValueL)
 -- | Builds a 'UtxoState' from a 'MockChainState'
 mcstToUtxoState :: MockChainState -> UtxoState
 mcstToUtxoState =
-  foldl extractPayload mempty . Map.toList . mcstOutputs
+  List.foldl' extractPayload mempty . Map.toList . mcstOutputs
   where
     extractPayload :: UtxoState -> (Api.TxOutRef, (TxSkelOut, Bool)) -> UtxoState
     extractPayload utxoState (txOutRef, (txSkelOut, bool)) =

--- a/src/Cooked/MockChain/State.hs
+++ b/src/Cooked/MockChain/State.hs
@@ -80,16 +80,16 @@ data MockChainState where
     MockChainState
   deriving (Show)
 
--- | A lens to set or get the parameters of the 'MockChainState'
+-- | Focuses on the parameters of a 'MockChainState'
 makeLensesFor [("mcstParams", "mcstParamsL")] ''MockChainState
 
--- | A lens to set or get the ledger state of the 'MockChainState'
+-- | Focuses on the ledger state of a 'MockChainState'
 makeLensesFor [("mcstLedgerState", "mcstLedgerStateL")] ''MockChainState
 
--- | A lens to set or get the outputs of the 'MockChainState'
+-- | Focuses on the outputs of a 'MockChainState'
 makeLensesFor [("mcstOutputs", "mcstOutputsL")] ''MockChainState
 
--- | A lens to set or get the constitution script of the 'MockChainState'
+-- | Focuses on the constitution script of a 'MockChainState'
 makeLensesFor [("mcstConstitution", "mcstConstitutionL")] ''MockChainState
 
 instance Default MockChainState where
@@ -117,7 +117,7 @@ data UtxoPayloadDatum where
   NoUtxoPayloadDatum :: UtxoPayloadDatum
   SomeUtxoPayloadDatum :: (DatumConstrs dat) => dat -> Bool -> UtxoPayloadDatum
 
--- | Focuses on whether on not this `UtxoPayloadDatum` isHashed
+-- | Focuses on the optional hashed flag of a 'UtxoPayloadDatum'
 utxoPayloadDatumKindAT :: AffineTraversal' UtxoPayloadDatum Bool
 utxoPayloadDatumKindAT =
   atraversal
@@ -178,20 +178,19 @@ data UtxoPayload where
     UtxoPayload
   deriving (Eq, Show)
 
--- | A lens to set or get the UTxO reference from this `UtxoPayload`
+-- | Focuses on the UTxO reference of a 'UtxoPayload'
 makeLensesFor [("utxoPayloadTxOutRef", "utxoPayloadTxOutRefL")] ''UtxoPayload
 
--- | A lens to set or get the value from this `UtxoPayload`
+-- | Focuses on the value of a 'UtxoPayload'
 makeLensesFor [("utxoPayloadValue", "utxoPayloadValueL")] ''UtxoPayload
 
--- | A lens to set or get the datum from this `UtxoPayload`
+-- | Focuses on the datum of a 'UtxoPayload'
 makeLensesFor [("utxoPayloadDatum", "utxoPayloadDatumL")] ''UtxoPayload
 
--- | A lens to set or get the optional reference script hash from this
--- `UtxoPayload`
+-- | Focuses on the optional reference script hash of a 'UtxoPayload'
 makeLensesFor [("utxoPayloadReferenceScriptHash", "utxoPayloadMReferenceScriptHashL")] ''UtxoPayload
 
--- | Focusing on the optional reference script hash of a `UtxoPayload`
+-- | Focuses on the optional reference script hash of a 'UtxoPayload'
 utxoPayloadReferenceScriptHashAT :: AffineTraversal' UtxoPayload Api.ScriptHash
 utxoPayloadReferenceScriptHashAT = utxoPayloadMReferenceScriptHashL % _Just
 
@@ -205,7 +204,7 @@ newtype UtxoPayloadSet = UtxoPayloadSet
   }
   deriving (Show)
 
--- | Going back and forth between a list of `UtxoPayload` and a `UtxoPayloadSet`
+-- | An isomorphism between a 'UtxoPayloadSet' and a list of 'UtxoPayload'
 utxoPayloadSetListI :: Iso' UtxoPayloadSet [UtxoPayload]
 utxoPayloadSetListI = iso utxoPayloadSet UtxoPayloadSet
 
@@ -234,10 +233,10 @@ data UtxoState where
     UtxoState
   deriving (Eq)
 
--- | A lens to set or get the available UTxOs from a `UtxoState`
+-- | Focuses on the available UTxOs of a 'UtxoState'
 makeLensesFor [("availableUtxos", "availableUtxosL")] ''UtxoState
 
--- | A lens to set or get the consumed UTxOs from a `UtxoState`
+-- | Focuses on the consumed UTxOs of a 'UtxoState'
 makeLensesFor [("consumedUtxos", "consumedUtxosL")] ''UtxoState
 
 instance Semigroup UtxoState where

--- a/src/Cooked/Pretty/Skeleton.hs
+++ b/src/Cooked/Pretty/Skeleton.hs
@@ -12,7 +12,7 @@ import Cooked.Wallet (Wallet)
 import Data.Default
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (catMaybes, fromJust)
+import Data.Maybe (catMaybes)
 import Data.Set qualified as Set
 import Ledger.Slot qualified as Ledger
 import Optics.Core
@@ -302,7 +302,7 @@ instance PrettyCookedList TxSkelOpts where
         prettyIfNot def prettyBalancingUtxos txSkelOptBalancingUtxos,
         prettyIfNot def prettyCollateralUtxos txSkelOptCollateralUtxos,
         prettyIfNot False (const "Defer Phase 2 failures during balancing") txSkelOptDeferFailures,
-        prettyIfNot Nothing (("Limit the number of balancing Utxos to " <>) . PP.pretty . fromJust) txSkelOptMaxNbOfBalancingUtxos
+        (("Limit the number of balancing Utxos to " <>) . PP.pretty <$> txSkelOptMaxNbOfBalancingUtxos)
       ]
       where
         prettyIfNot :: (Eq a) => a -> (a -> DocCooked) -> a -> Maybe DocCooked

--- a/src/Cooked/Skeleton.hs
+++ b/src/Cooked/Skeleton.hs
@@ -80,7 +80,7 @@ data TxSkel where
       -- this list must contain at least one element, which is always expected
       -- to be case in practice anyway. By default, the first signatory will pay
       -- for fees and balancing. You can change that with
-      -- 'Cooked.Skeleton.Option.txOptBalancingPolicy'.
+      -- 'Cooked.Skeleton.Option.txSkelOptBalancingPolicy'.
       txSkelSignatories :: [TxSkelSignatory],
       txSkelValidityRange :: Ledger.SlotRange,
       -- | To each 'Api.TxOutRef' the transaction should consume, add a redeemer
@@ -112,40 +112,38 @@ data TxSkel where
     TxSkel
   deriving (Show, Eq)
 
--- | Focusing on the labels of a 'TxSkel'
+-- | Focuses on the labels of a 'TxSkel'
 makeLensesFor [("txSkelLabels", "txSkelLabelsL")] ''TxSkel
 
--- | Focusing on the optics of a 'TxSkel'
+-- | Focuses on the options of a 'TxSkel'
 makeLensesFor [("txSkelOpts", "txSkelOptsL")] ''TxSkel
 
--- | Focusing on the minted value of a 'TxSkel'
+-- | Focuses on the minted value of a 'TxSkel'
 makeLensesFor [("txSkelMints", "txSkelMintsL")] ''TxSkel
 
--- | Focusing on the validity range of a 'TxSkel'
+-- | Focuses on the validity range of a 'TxSkel'
 makeLensesFor [("txSkelValidityRange", "txSkelValidityRangeL")] ''TxSkel
 
--- | Focusing on the signatories of a 'TxSkel'
+-- | Focuses on the signatories of a 'TxSkel'
 makeLensesFor [("txSkelSignatories", "txSkelSignatoriesL")] ''TxSkel
 
--- | Focusing on the inputs of a 'TxSkel'
+-- | Focuses on the inputs of a 'TxSkel'
 makeLensesFor [("txSkelIns", "txSkelInsL")] ''TxSkel
 
--- | Focusing on the reference inputs of a 'TxSkel'
+-- | Focuses on the reference inputs of a 'TxSkel'
 makeLensesFor [("txSkelInsReference", "txSkelInsReferenceL")] ''TxSkel
 
--- | Focusing on the outputs of a 'TxSkel'
+-- | Focuses on the outputs of a 'TxSkel'
 makeLensesFor [("txSkelOuts", "txSkelOutsL")] ''TxSkel
 
--- | Focusing on the proposals of a 'TxSkel'
+-- | Focuses on the proposals of a 'TxSkel'
 makeLensesFor [("txSkelProposals", "txSkelProposalsL")] ''TxSkel
 
--- | Focusing on the withdrawals of a 'TxSkel'
+-- | Focuses on the withdrawals of a 'TxSkel'
 makeLensesFor [("txSkelWithdrawals", "txSkelWithdrawalsL")] ''TxSkel
 
--- | Focusing on the certificates of a 'TxSkel'
+-- | Focuses on the certificates of a 'TxSkel'
 makeLensesFor [("txSkelCertificates", "txSkelCertificatesL")] ''TxSkel
-
--- | A lens to set or
 
 -- | A convenience template of an empty transaction skeleton.
 txSkelTemplate :: TxSkel

--- a/src/Cooked/Skeleton/Anchor.hs
+++ b/src/Cooked/Skeleton/Anchor.hs
@@ -25,15 +25,15 @@ type TxSkelAnchor =
       Maybe ByteString -- The optional anchor resolved page
     )
 
--- | Focusing on the URL of a 'TxSkelAnchor'
+-- | Focuses on the optional URL of a 'TxSkelAnchor'
 txSkelAnchorURLAT :: AffineTraversal' TxSkelAnchor String
 txSkelAnchorURLAT = _Just % _1
 
--- | Focusing on the optional resolved page of a 'TxSkelAnchor'
+-- | Focuses on the optional resolved page of a 'TxSkelAnchor'
 txSkelAnchorMResolvedPageAT :: AffineTraversal' TxSkelAnchor (Maybe ByteString)
 txSkelAnchorMResolvedPageAT = _Just % _2
 
--- | Focusing on the existing resolved page of a 'TxSkelAnchor'
+-- | Focuses on the optional resolved page of a 'TxSkelAnchor'
 txSkelAnchorResolvedPageAT :: AffineTraversal' TxSkelAnchor ByteString
 txSkelAnchorResolvedPageAT = txSkelAnchorMResolvedPageAT % _Just
 

--- a/src/Cooked/Skeleton/Datum.hs
+++ b/src/Cooked/Skeleton/Datum.hs
@@ -60,7 +60,7 @@ data DatumKind
     Hashed DatumResolved
   deriving (Show, Eq, Ord)
 
--- | Builds a 'DatumKind' from a 'DatumResolved' or optionally retrieves it
+-- | Builds or retrieves the 'DatumResolved' of a 'DatumKind'
 datumKindResolvedP :: Prism' DatumKind DatumResolved
 datumKindResolvedP =
   prism
@@ -98,7 +98,7 @@ instance Ord TxSkelOutDatum where
 
 -- * Optics working on 'TxSkelOutDatum'
 
--- | Extracts or changes the 'DatumKind' of a 'TxSkelOutDatum'
+-- | Focuses on the optional 'DatumKind' of a 'TxSkelOutDatum'
 txSkelOutDatumKindAT :: AffineTraversal' TxSkelOutDatum DatumKind
 txSkelOutDatumKindAT =
   atraversal
@@ -113,7 +113,7 @@ txSkelOutDatumKindAT =
         )
     )
 
--- | Extracts or changes the 'DatumResolved' of a 'TxSkelOutDatum'
+-- | Focuses on the optional 'DatumResolved' of a 'TxSkelOutDatum'
 txSkelOutDatumResolvedAT :: AffineTraversal' TxSkelOutDatum DatumResolved
 txSkelOutDatumResolvedAT = txSkelOutDatumKindAT % datumKindResolvedP
 
@@ -138,15 +138,15 @@ txSkelOutDatumTypedAT =
         )
     )
 
--- | Converts a 'TxSkelOutDatum' into a possible 'Api.Datum'
+-- | Retrieves the optional 'Api.Datum' of a 'TxSkelOutDatum'
 txSkelOutDatumDatumAF :: AffineFold TxSkelOutDatum Api.Datum
 txSkelOutDatumDatumAF = txSkelOutDatumTypedAT % to Api.Datum
 
--- | Converts a 'TxSkelOutDatum' into a possible 'Api.DatumHash'
+-- | Retrieves the optional 'Api.DatumHash' of a 'TxSkelOutDatum'
 txSkelOutDatumDatumHashAF :: AffineFold TxSkelOutDatum Api.DatumHash
 txSkelOutDatumDatumHashAF = txSkelOutDatumDatumAF % to Script.datumHash
 
--- | Converts a 'TxSkelOutDatum' into an 'Api.OutputDatum'
+-- | Retrieves the 'Api.OutputDatum' of a 'TxSkelOutDatum'
 txSkelOutDatumOutputDatumG :: Getter TxSkelOutDatum Api.OutputDatum
 txSkelOutDatumOutputDatumG = to Script.toOutputDatum
 

--- a/src/Cooked/Skeleton/Mint.hs
+++ b/src/Cooked/Skeleton/Mint.hs
@@ -28,6 +28,7 @@ where
 import Cooked.Skeleton.Redeemer
 import Cooked.Skeleton.User
 import Data.Bifunctor
+import Data.List (foldl')
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe
@@ -142,7 +143,7 @@ txSkelMintsPolicyTokensL mp@(Script.toScriptHash . toVScript -> mph) =
     (fmap (first (view userTxSkelRedeemerL)) . view (to unTxSkelMints % at mph))
     ( \mints -> \case
         Nothing -> TxSkelMints . Map.delete mph . unTxSkelMints $ mints
-        Just (red, Map.toList -> tokens) -> foldl (flip $ \(tk, n) -> set (txSkelMintsAssetClassAmountL mp tk) (Just red, n)) mints tokens
+        Just (red, Map.toList -> tokens) -> foldl' (flip $ \(tk, n) -> set (txSkelMintsAssetClassAmountL mp tk) (Just red, n)) mints tokens
     )
 
 instance Script.ToValue TxSkelMints where
@@ -166,9 +167,9 @@ txSkelMintsListI :: Iso' TxSkelMints [Mint]
 txSkelMintsListI =
   iso
     (map (\(user, m) -> Mint user (Map.toList m)) . Map.elems . unTxSkelMints)
-    ( foldl
+    ( foldl'
         ( \mints (Mint (UserRedeemedScript mp red) tks) ->
-            foldl
+            foldl'
               (\mints' (tk, n) -> mints' & txSkelMintsAssetClassAmountL mp tk %~ (\(_, n') -> (Just red, n + n')))
               mints
               tks

--- a/src/Cooked/Skeleton/Mint.hs
+++ b/src/Cooked/Skeleton/Mint.hs
@@ -70,13 +70,13 @@ burn mp red tn n = mint mp red tn (-n)
 
 -- * Optics to manipulate elements of 'Mint'
 
--- | A lens to set or get the redeemer of a 'Mint'
+-- | Focuses on the redeemer of a 'Mint'
 makeLensesFor [("mintRedeemedScript", "mintRedeemedScriptL")] ''Mint
 
--- | A lens to set or get the token list of a 'Mint'
+-- | Focuses on the token list of a 'Mint'
 makeLensesFor [("mintTokens", "mintTokensL")] ''Mint
 
--- | Returns the currency symbol associated with a `Mint`
+-- | Retrieves the currency symbol of a 'Mint'
 mintCurrencySymbolG :: Getter Mint Api.CurrencySymbol
 mintCurrencySymbolG =
   mintRedeemedScriptL
@@ -157,11 +157,11 @@ instance Script.ToValue TxSkelMints where
       . Map.toList
       . unTxSkelMints
 
--- | The list of assets classes contained in this 'TxSkelMints'
+-- | Retrieves the asset classes of a 'TxSkelMints'
 txSkelMintsAssetClassesG :: Getter TxSkelMints [(VScript, Api.TokenName)]
 txSkelMintsAssetClassesG = txSkelMintsListI % to (\l -> [(toVScript mp, tk) | Mint (UserRedeemedScript mp _) tks <- l, (tk, _) <- tks])
 
--- | Seeing a 'TxSkelMints' as a list of 'Mint'
+-- | An isomorphism between a 'TxSkelMints' and a list of 'Mint'
 txSkelMintsListI :: Iso' TxSkelMints [Mint]
 txSkelMintsListI =
   iso

--- a/src/Cooked/Skeleton/Option.hs
+++ b/src/Cooked/Skeleton/Option.hs
@@ -252,34 +252,34 @@ instance Show TxSkelOpts where
   show (TxSkelOpts slotIncrease _ balancingPol feePol balOutputPol balUtxos _ colUtxos deferFailures maxNbBalUtxos) =
     show [show slotIncrease, show balancingPol, show feePol, show balOutputPol, show balUtxos, show colUtxos, show deferFailures, show maxNbBalUtxos]
 
--- | A lens to get or set the automatic slot increase option
+-- | Focuses on the automatic slot increase option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptAutoSlotIncrease", "txSkelOptAutoSlotIncreaseL")] ''TxSkelOpts
 
--- | A lens to get or set the Cardano transaction modifications option
+-- | Focuses on the Cardano transaction modifications option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptModTx", "txSkelOptModTxL")] ''TxSkelOpts
 
--- | A lens to get or set the balancing policy option
+-- | Focuses on the balancing policy option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptBalancingPolicy", "txSkelOptBalancingPolicyL")] ''TxSkelOpts
 
--- | A lens to get or set the fee policy option
+-- | Focuses on the fee policy option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptFeePolicy", "txSkelOptFeePolicyL")] ''TxSkelOpts
 
--- | A lens to get or set the handling of balancing outputs option
+-- | Focuses on the handling of balancing outputs option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptBalanceOutputPolicy", "txSkelOptBalanceOutputPolicyL")] ''TxSkelOpts
 
--- | A lens to get or set the balancing utxos option
+-- | Focuses on the balancing utxos option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptBalancingUtxos", "txSkelOptBalancingUtxosL")] ''TxSkelOpts
 
--- | A lens to get or set the changes to protocol parameters option
+-- | Focuses on the changes to protocol parameters option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptModParams", "txSkelOptModParamsL")] ''TxSkelOpts
 
--- | A lens to get or set the collateral utxos option
+-- | Focuses on the collateral utxos option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptCollateralUtxos", "txSkelOptCollateralUtxosL")] ''TxSkelOpts
 
--- | A lens to get or set the deferring of the failures option
+-- | Focuses on the deferring of the failures option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptDeferPhase2FailuresDuringBalancing", "txSkelOptDeferPhase2FailuresDuringBalancingL")] ''TxSkelOpts
 
--- | A lens to get or set the max nb of balancing Utxos option
+-- | Focuses on the max nb of balancing Utxos option of a 'TxSkelOpts'
 makeLensesFor [("txSkelOptMaxNbOfBalancingUtxos", "txSkelOptMaxNbOfBalancingUtxosL")] ''TxSkelOpts
 
 instance Default TxSkelOpts where

--- a/src/Cooked/Skeleton/Output.hs
+++ b/src/Cooked/Skeleton/Output.hs
@@ -1,6 +1,6 @@
 -- | This module exposes the outputs constructs used in a
 -- 'Cooked.Skeleton.TxSkel' and their associated utilities. To build payments in
--- a skeleton, the usual way is to invoke @txSkelIns = [pk `receives` Value v,
+-- a skeleton, the usual way is to invoke @txSkelOuts = [pk `receives` Value v,
 -- script `receives` (InlineDatum dat <&&> ReferenceScript script)]@
 module Cooked.Skeleton.Output
   ( -- * Type constraints
@@ -70,53 +70,52 @@ data TxSkelOut where
 
 -- * Optics focusing on the reference script of a 'TxSkelOut'
 
--- | Focuses on the @Maybe VScript@ corresponding to the possible reference
--- script contained in this 'TxSkelOut'
+-- | Focuses on the optional reference script of a 'TxSkelOut'
 makeLensesFor [("txSkelOutReferenceScript", "txSkelOutMReferenceScriptL")] ''TxSkelOut
 
--- | Focuses on the reference script of this 'TxSkelOut'
+-- | Focuses on the reference script of a 'TxSkelOut'
 txSkelOutReferenceScriptAT :: AffineTraversal' TxSkelOut VScript
 txSkelOutReferenceScriptAT = txSkelOutMReferenceScriptL % _Just
 
--- | Returns the possible reference script has of this 'TxSkelOut'
+-- | Retrieves the optional reference script hash of a 'TxSkelOut'
 txSkelOutReferenceScriptHashAF :: AffineFold TxSkelOut Api.ScriptHash
 txSkelOutReferenceScriptHashAF = txSkelOutReferenceScriptAT % to Script.toScriptHash
 
 -- * Optics focusing on the staking credential of a 'TxSkelOut'
 
--- | Focuses on the @Maybe StakingCredential@ of this 'TxSkelOut'
+-- | Focuses on the optional staking credential of a 'TxSkelOut'
 makeLensesFor [("txSkelOutStakingCredential", "txSkelOutMStakingCredentialL")] ''TxSkelOut
 
--- | Focuses on the staking credential of this 'TxSkelOut'
+-- | Focuses on the staking credential of a 'TxSkelOut'
 txSkelOutStakingCredentialAT :: AffineTraversal' TxSkelOut Api.StakingCredential
 txSkelOutStakingCredentialAT = txSkelOutMStakingCredentialL % _Just
 
 -- | Optics focusing on the datum of a 'TxSkelOut'
 
--- | Focuses on the 'TxSkelOutDatum' of this 'TxSkelOut'
+-- | Focuses on the 'TxSkelOutDatum' of a 'TxSkelOut'
 makeLensesFor [("txSkelOutDatum", "txSkelOutDatumL")] ''TxSkelOut
 
--- * Optics focusing on the value of this 'TxSkelOut'
+-- * Optics focusing on the value of a 'TxSkelOut'
 
--- | Focuses on the 'Api.Value' of this 'TxSkelOut'
+-- | Focuses on the 'Api.Value' of a 'TxSkelOut'
 makeLensesFor [("txSkelOutValue", "txSkelOutValueL")] ''TxSkelOut
 
 -- | Focuses on whether the 'Api.Value' contained in this 'TxSkelOut' can be
 -- adjusted to min ADA during transaction generation
 makeLensesFor [("txSkelOutValueAutoAdjust", "txSkelOutValueAutoAdjustL")] ''TxSkelOut
 
--- * Optics focusing on the owner of this 'TxSkelOut'
+-- * Optics focusing on the owner of a 'TxSkelOut'
 
--- | Focuses on the user of this 'TxSkelOut'
+-- | Focuses on the user of a 'TxSkelOut'
 makeLensesFor [("txSkelOutOwner", "txSkelOutOwnerL")] ''TxSkelOut
 
 -- * Additional optics around a 'TxSkelOut'
 
--- | Returns the credential of this 'TxSkelOut'
+-- | Retrieves the credential of a 'TxSkelOut'
 txSkelOutCredentialG :: Getter TxSkelOut Api.Credential
 txSkelOutCredentialG = to $ \(TxSkelOut {txSkelOutOwner}) -> Script.toCredential txSkelOutOwner
 
--- | Returns the address of this 'TxSkelOut'
+-- | Retrieves the address of a 'TxSkelOut'
 txSkelOutAddressG :: Getter TxSkelOut Api.Address
 txSkelOutAddressG = to $ \txSkelOut ->
   Api.Address

--- a/src/Cooked/Skeleton/Proposal.hs
+++ b/src/Cooked/Skeleton/Proposal.hs
@@ -188,7 +188,7 @@ instance Eq TxSkelProposal where
 
 -- * Optics on 'TxSkelProposal'
 
--- | Focuses on the return credential from a 'TxSkelProposal'
+-- | Focuses on the return credential of a 'TxSkelProposal'
 txSkelProposalReturnCredentialL :: Lens' TxSkelProposal Api.Credential
 txSkelProposalReturnCredentialL =
   lens
@@ -202,18 +202,18 @@ txSkelProposalMConstitutionAT =
     (\prop@(TxSkelProposal {txSkelProposalConstitution}) -> maybe (Left prop) Right $ cast txSkelProposalConstitution)
     (\prop@(TxSkelProposal @kind' cred action _ anchor) constit' -> maybe prop (\Refl -> TxSkelProposal cred action constit' anchor) $ eqT @kind @kind')
 
--- | Focuses on the constitution of a 'TxSkelProposal'
+-- | Focuses on the optional constitution of a 'TxSkelProposal'
 txSkelProposalConstitutionAT :: AffineTraversal' TxSkelProposal (User IsScript Redemption)
 txSkelProposalConstitutionAT = txSkelProposalMConstitutionAT % _Just
 
--- | Focuses on the governance action of a 'TxSkelProposal'
+-- | Focuses on the optional governance action of a 'TxSkelProposal'
 txSkelProposalGovernanceActionAT :: forall req. (Typeable req) => AffineTraversal' TxSkelProposal (GovernanceAction req)
 txSkelProposalGovernanceActionAT =
   atraversal
     (\prop@(TxSkelProposal {txSkelProposalGovernanceAction}) -> maybe (Left prop) Right $ cast txSkelProposalGovernanceAction)
     (\prop@(TxSkelProposal @req' cred _ constit anchor) newAction -> maybe prop (\Refl -> TxSkelProposal cred newAction constit anchor) $ eqT @req @req')
 
--- | A lens to get or set the anchor of a 'TxSkelProposal'
+-- | Focuses on the anchor of a 'TxSkelProposal'
 makeLensesFor [("txSkelProposalAnchor", "txSkelProposalAnchorL")] ''TxSkelProposal
 
 -- * Smart constructors and updators

--- a/src/Cooked/Skeleton/Redeemer.hs
+++ b/src/Cooked/Skeleton/Redeemer.hs
@@ -22,6 +22,7 @@ module Cooked.Skeleton.Redeemer
 
     -- * Utilities
     fillReferenceInput,
+    withReferenceInput,
   )
 where
 
@@ -76,17 +77,17 @@ instance Ord TxSkelRedeemer where
 
 -- * Navigating within a 'TxSkelRedeemer'
 
--- | Focuses on the possible reference input from a redeemer
+-- | Focuses on the optional reference input of a 'TxSkelRedeemer'
 makeLensesFor [("txSkelRedeemerReferenceInput", "txSkelRedeemerMReferenceInputL")] ''TxSkelRedeemer
 
--- | Focuses on the reference input form a redeemer
+-- | Focuses on the optional reference input of a 'TxSkelRedeemer'
 txSkelRedeemerReferenceInputAT :: AffineTraversal' TxSkelRedeemer Api.TxOutRef
 txSkelRedeemerReferenceInputAT = txSkelRedeemerMReferenceInputL % _Just
 
--- | Sets or gets the autofill property from a redeemer
+-- | Focuses on the autofill property of a 'TxSkelRedeemer'
 makeLensesFor [("txSkelRedeemerAutoFill", "txSkelRedeemerAutoFillL")] ''TxSkelRedeemer
 
--- | Extracts, or sets, the typed redeemer of a 'TxSkelRedeemer'. This is
+-- | Focuses on the optional typed redeemer of a 'TxSkelRedeemer'. This is
 -- attempted in two ways: first, we try to simply cast the content, and then, if
 -- it fails, we serialise the content and then attempt to deserialise it to the
 -- right type. This second case is specifically useful when the current content
@@ -102,7 +103,7 @@ txSkelRedeemerTypedAT =
     )
     (\red content -> red {txSkelRedeemerContent = content})
 
--- | Extracts, or sets, the redeemer content as an `Api.BuiltinData`
+-- | Focuses on the 'Api.BuiltinData' content of a 'TxSkelRedeemer'
 txSkelRedeemerBuiltinDataL :: Lens' TxSkelRedeemer Api.BuiltinData
 txSkelRedeemerBuiltinDataL =
   lens
@@ -136,3 +137,10 @@ emptyTxSkelRedeemerNoAutoFill = someTxSkelRedeemerNoAutoFill ()
 -- transaction generation.
 fillReferenceInput :: Api.TxOutRef -> TxSkelRedeemer -> TxSkelRedeemer
 fillReferenceInput refInput = over txSkelRedeemerMReferenceInputL (maybe (Just refInput) Just)
+
+-- | Attaches a reference input to this 'TxSkelRedeemer', overriding any
+-- reference input that was already present. This is the user-facing way of
+-- providing the reference input from which the script will be fetched, as
+-- opposed to 'fillReferenceInput' which only acts when none is set yet.
+withReferenceInput :: TxSkelRedeemer -> Api.TxOutRef -> TxSkelRedeemer
+withReferenceInput red refInput = set txSkelRedeemerMReferenceInputL (Just refInput) red

--- a/src/Cooked/Skeleton/Signatory.hs
+++ b/src/Cooked/Skeleton/Signatory.hs
@@ -29,19 +29,19 @@ data TxSkelSignatory where
     { -- | Identifying the signatory with their pubkey hash
       txSkelSignatoryPubKeyHash :: pkh,
       -- | The private key with which this signatory should sign. If set to
-      -- @Nothing@ the signature won't be added (but will be needed later on).oiu clairement
+      -- @Nothing@ the signature won't be added (but will be needed later on).
       txSkelSignatoryPrivateKey :: Maybe Crypto.XPrv
     } ->
     TxSkelSignatory
 
--- | A lens focusing on the option private key for this signatory
+-- | Focuses on the optional private key of a 'TxSkelSignatory'
 makeLensesFor [("txSkelSignatoryPrivateKey", "txSkelSignatoryMPrivateKeyL")] ''TxSkelSignatory
 
--- | An affine traversal focusing on the existing private key for this signatory
+-- | Focuses on the optional private key of a 'TxSkelSignatory'
 txSkelSignatoryPrivateKeyAT :: AffineTraversal' TxSkelSignatory Crypto.XPrv
 txSkelSignatoryPrivateKeyAT = txSkelSignatoryMPrivateKeyL % _Just
 
--- | A lens focusing on the public key hash of this signatory
+-- | Focuses on the public key hash of a 'TxSkelSignatory'
 txSkelSignatoryPubKeyHashL :: Lens' TxSkelSignatory Api.PubKeyHash
 txSkelSignatoryPubKeyHashL =
   lens

--- a/src/Cooked/Skeleton/User.hs
+++ b/src/Cooked/Skeleton/User.hs
@@ -126,7 +126,7 @@ instance Script.ToAddress (User kind mode) where
 
 -- * Optics on various possible families of users
 
--- | Retrieves the hash of the script or pubkey represented by this user
+-- | Retrieves the script or pubkey hash of a 'User'
 userHashG :: forall kind mode. Getter (User kind mode) Api.BuiltinByteString
 userHashG =
   to
@@ -136,7 +136,7 @@ userHashG =
         UserRedeemedScript (Script.toScriptHash . toVScript -> Api.ScriptHash hs) _ -> hs
     )
 
--- | Retrieves a possible typed user from a 'User'
+-- | Retrieves the optional typed user of a 'User'
 userTypedAF :: forall user kind mode. (Typeable user) => AffineFold (User kind mode) user
 userTypedAF =
   afolding
@@ -147,7 +147,7 @@ userTypedAF =
         _ -> Nothing
     )
 
--- | Focuses on a possible typed script in this 'User'
+-- | Focuses on the optional typed script of a 'User'
 userTypedScriptAT :: forall userScript mode. (ToVScript userScript, Typeable userScript) => AffineTraversal' (User IsScript mode) userScript
 userTypedScriptAT =
   atraversal
@@ -161,7 +161,7 @@ userTypedScriptAT =
         UserRedeemedScript _ red -> (`UserRedeemedScript` red)
     )
 
--- | Focuses on a possible typed pubkey in this 'User'
+-- | Focuses on the optional typed pubkey of a 'User'
 userTypedPubKeyAT :: forall userPK mode. (Script.ToPubKeyHash userPK, Typeable userPK) => AffineTraversal' (User IsPubKey mode) userPK
 userTypedPubKeyAT =
   atraversal
@@ -171,7 +171,7 @@ userTypedPubKeyAT =
     )
     (\(UserPubKey _) -> UserPubKey)
 
--- | Builds a @User IsEither@ from a @User IsScript@
+-- | Builds or retrieves a @User IsScript@ from a @User IsEither@
 userEitherScriptP :: Prism' (User IsEither mode) (User IsScript mode)
 userEitherScriptP =
   prism
@@ -185,7 +185,7 @@ userEitherScriptP =
         user -> Left user
     )
 
--- | Builds a @User IsEither@ from a @User IsPubKey@
+-- | Builds or retrieves a @User IsPubKey@ from a @User IsEither@
 userEitherPubKeyP :: Prism' (User IsEither mode) (User IsPubKey mode)
 userEitherPubKeyP =
   prism
@@ -195,11 +195,11 @@ userEitherPubKeyP =
         user -> Left user
     )
 
--- | Extracts the 'Api.Credential' from a 'User'
+-- | Retrieves the 'Api.Credential' of a 'User'
 userCredentialG :: Getter (User kind mode) Api.Credential
 userCredentialG = to Script.toCredential
 
--- | Focusing on the possible 'TxSkelRedeemer' of this 'User'
+-- | Focuses on the optional 'TxSkelRedeemer' of a 'User'
 userTxSkelRedeemerAT :: AffineTraversal' (User kind mode) TxSkelRedeemer
 userTxSkelRedeemerAT =
   atraversal
@@ -212,7 +212,7 @@ userTxSkelRedeemerAT =
         user -> const user
     )
 
--- | Focusing on the possible 'VScript' of this 'User'
+-- | Focuses on the optional 'VScript' of a 'User'
 userVScriptAT :: AffineTraversal' (User kind mode) VScript
 userVScriptAT =
   atraversal
@@ -227,11 +227,11 @@ userVScriptAT =
         user -> const user
     )
 
--- | Focusing on the possible 'Api.ScriptHash' of this 'User'
+-- | Retrieves the optional 'Api.ScriptHash' of a 'User'
 userScriptHashAF :: AffineFold (User kind mode) Api.ScriptHash
 userScriptHashAF = userVScriptAT % to Script.toScriptHash
 
--- | Focusing on the possible 'Api.PubKeyHash' of this 'User'
+-- | Focuses on the optional 'Api.PubKeyHash' of a 'User'
 userPubKeyHashAT :: AffineTraversal' (User kind mode) Api.PubKeyHash
 userPubKeyHashAT =
   atraversal
@@ -244,14 +244,14 @@ userPubKeyHashAT =
         user -> const user
     )
 
--- | An isomorphism between users required to be pubkeys and 'Api.PubKeyHash'
+-- | An isomorphism between a @User IsPubKey@ and an 'Api.PubKeyHash'
 userPubKeyHashI :: Iso' (User IsPubKey mode) Api.PubKeyHash
 userPubKeyHashI =
   iso
     (\(UserPubKey (Script.toPubKeyHash -> pkh)) -> pkh)
     UserPubKey
 
--- | Focusing on the 'VScript' from a script
+-- | Focuses on the 'VScript' of a script
 userVScriptL :: Lens' (User IsScript mode) VScript
 userVScriptL =
   lens
@@ -264,11 +264,11 @@ userVScriptL =
         UserRedeemedScript _ red -> (`UserRedeemedScript` red)
     )
 
--- | Focusing on the 'Api.ScriptHash' from a script
+-- | Retrieves the 'Api.ScriptHash' of a script
 userScriptHashG :: Getter (User IsScript mode) Api.ScriptHash
 userScriptHashG = userVScriptL % to Script.toScriptHash
 
--- | Focus on the 'TxSkelRedeemer' from a script being redeemed
+-- | Focuses on the 'TxSkelRedeemer' of a script being redeemed
 userTxSkelRedeemerL :: Lens' (User IsScript Redemption) TxSkelRedeemer
 userTxSkelRedeemerL =
   lens

--- a/src/Cooked/Skeleton/Value.hs
+++ b/src/Cooked/Skeleton/Value.hs
@@ -17,7 +17,7 @@ import Plutus.Script.Utils.Scripts qualified as Script
 import PlutusLedgerApi.V1.Value qualified as Api
 import PlutusTx.AssocMap qualified as PMap
 
--- | A lens to get or set the amount of tokens of a certain 'Api.AssetClass'
+-- | Focuses on the amount of tokens of a certain 'Api.AssetClass'
 -- from a given 'Api.Value'. This removes the entry if the new amount is 0.
 valueAssetClassAmountL :: (Script.ToMintingPolicyHash mp) => mp -> Api.TokenName -> Lens' Api.Value Integer
 valueAssetClassAmountL (Script.toCurrencySymbol -> cs) tk =
@@ -39,11 +39,11 @@ valueAssetClassAmountL (Script.toCurrencySymbol -> cs) tk =
         Just tokenMap -> Api.Value $ PMap.insert cs (PMap.insert tk i tokenMap) val
     )
 
--- | Isomorphism between 'Api.Lovelace' and integers
+-- | An isomorphism between an 'Api.Lovelace' and an 'Integer'
 lovelaceIntegerI :: Iso' Api.Lovelace Integer
 lovelaceIntegerI = iso Api.getLovelace Api.Lovelace
 
--- | Focus the Lovelace part in a value.
+-- | Focuses on the 'Api.Lovelace' of an 'Api.Value'
 valueLovelaceL :: Lens' Api.Value Api.Lovelace
 valueLovelaceL = valueAssetClassAmountL Api.adaSymbol Api.adaToken % re lovelaceIntegerI
 
@@ -62,7 +62,7 @@ valueAssetClassAmountP (Script.toCurrencySymbol -> cs) tk
             i -> Right i
         )
 
--- | An instance of 'valueAssetClassAmountP' for 'Api.Lovelace'
+-- | Builds or retrieves the 'Api.Lovelace' of an 'Api.Value'
 valueLovelaceP :: Prism' Api.Value Api.Lovelace
 valueLovelaceP = valueAssetClassAmountP Api.adaSymbol Api.adaToken % re lovelaceIntegerI
 

--- a/src/Cooked/Skeleton/Withdrawal.hs
+++ b/src/Cooked/Skeleton/Withdrawal.hs
@@ -28,6 +28,7 @@ where
 
 import Cooked.Skeleton.Redeemer
 import Cooked.Skeleton.User
+import Data.List (foldl')
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe
@@ -74,7 +75,7 @@ txSkelWithdrawalsListI :: Iso' TxSkelWithdrawals [Withdrawal]
 txSkelWithdrawalsListI =
   iso
     (Map.elems . unTxSkelWithdrawals)
-    ( foldl
+    ( foldl'
         ( \(TxSkelWithdrawals withdrawals) withdrawal@(Withdrawal (view userCredentialG -> cred) amount) ->
             TxSkelWithdrawals $
               over
@@ -104,7 +105,7 @@ fillAmount newAmount = over withdrawalMAmountL (maybe (Just newAmount) Just)
 
 -- | Retrieves the total value withdrawn is this 'TxSkelWithdrawals'
 instance Script.ToValue TxSkelWithdrawals where
-  toValue = foldl (\val -> (val <>) . maybe mempty Script.toValue . view withdrawalMAmountL) mempty . unTxSkelWithdrawals
+  toValue = foldl' (\val -> (val <>) . maybe mempty Script.toValue . view withdrawalMAmountL) mempty . unTxSkelWithdrawals
 
 instance Semigroup TxSkelWithdrawals where
   txSkelW <> txSkelW' =

--- a/src/Cooked/Skeleton/Withdrawal.hs
+++ b/src/Cooked/Skeleton/Withdrawal.hs
@@ -67,8 +67,8 @@ makeLensesFor [("withdrawalUser", "withdrawalUserL")] ''Withdrawal
 withdrawalAmountAT :: AffineTraversal' Withdrawal Api.Lovelace
 withdrawalAmountAT = withdrawalMAmountL % _Just
 
--- | Transforms a @[Withdrawal]@ to a 'TxSkelWithdrawals and vice
--- versa. Accumulates amount of withdrawals with similar owners, and keep the
+-- | An isomorphism between a 'TxSkelWithdrawals' and a list of 'Withdrawal'.
+-- Accumulates amount of withdrawals with similar owners, and keeps the
 -- latest found redeemer in the case of scripts, discarding the previous ones.
 txSkelWithdrawalsListI :: Iso' TxSkelWithdrawals [Withdrawal]
 txSkelWithdrawalsListI =


### PR DESCRIPTION
Phase A — code quality:
- AutoFilling: drop fromJust in autoFillWithdrawalAmounts, fix constitution haddock and a malformed section header.
- Pretty/Skeleton: fix a latent fromJust crash when printing default TxSkelOpts.

Documentation:
- Reconcile doc/BALANCING.md and doc/CHEATSHEET.md with the current API.
- Fix source haddock typos (Output, Signatory, Skeleton).
- Homogenize optics haddock comments across the Skeleton modules, using a verb-per-kind convention (Retrieves/Focuses on/Builds or retrieves/An isomorphism) matching doc/OPTICS.md.

Robustness / error handling:
- Body and Certificate transaction generation now include the underlying error detail in their failure messages.
- A ParameterChange governance action carrying a CostModels update now fails with an explicit MCEUnsupportedFeature error instead of silently dropping it.

Ergonomics:
- Add withReferenceInput to attach a reference input to a TxSkelRedeemer, replacing the verbose set txSkelRedeemerMReferenceInputL (Just …) idiom, and update the CHEATSHEET accordingly.