### PR TITLE
Enforce import conventions and add P.Ledger/C.Ledger pairing

### DIFF
--- a/doc/IMPORTS.md
+++ b/doc/IMPORTS.md
@@ -20,7 +20,7 @@ dependencies:
 ### [`cardano-node-emulator`](https://github.com/IntersectMBO/cardano-node-emulator)
 
 - package `plutus-script-utils`, prefix `Script`
-- package `plutus-ledger`, prefix `Ledger`
+- package `plutus-ledger`, prefix `P.Ledger`
 - package `cardano-node-emulator`, prefix `Emulator`
 
 ### [`plutus`](https://github.com/IntersectMBO/plutus)
@@ -40,6 +40,15 @@ dependencies:
 
 - package `cardano-ledger-shelley`, prefix `Shelley`
 - package `cardano-ledger-conway`, prefix `Conway`
+- the core packages (`cardano-ledger-core` and similar), whose modules live
+  directly under `Cardano.Ledger.*` (e.g. `Cardano.Ledger.BaseTypes`,
+  `Cardano.Ledger.Hashes`, `Cardano.Ledger.DRep`, `Cardano.Ledger.PoolParams`),
+  prefix `C.Ledger`.
+
+"Ledger" is the only ambiguous prefix, as it covers two unrelated package
+families. We thus use `P.Ledger` for `plutus-ledger` and `C.Ledger` for the
+`cardano-ledger` core packages. Every other dependency keeps a unique one-word
+prefix.
 
 ### Exception
 
@@ -76,4 +85,4 @@ plutus-ledger) should. For instance, `Value` should always be coming from
 definitions. It re-exports too many definitions so that it hides where they
 really come from, but not enough so that importing `Ledger` alone sufficies in
 most projects. Thus, we avoid importing it altogher and instead rely on
-`PlutusLedger.V3` and sub-modules `Ledger.*`.
+`PlutusLedgerApi.V3` and the sub-modules `Ledger.*` (aliased `P.Ledger`).

--- a/src/Cooked/MockChain/AutoFilling.hs
+++ b/src/Cooked/MockChain/AutoFilling.hs
@@ -14,7 +14,7 @@ import Cooked.Skeleton
 import Cooked.Tweak.Common
 import Data.List (find)
 import Data.Map qualified as Map
-import Ledger.Tx qualified as Ledger
+import Ledger.Tx qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Address qualified as Script
 import Plutus.Script.Utils.Scripts qualified as Script
@@ -133,7 +133,7 @@ autoFillReferenceScripts = do
 
 -- | Compute the required minimal ADA for a given output
 getTxSkelOutMinAda ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   TxSkelOut ->
   Sem effs Integer
 getTxSkelOutMinAda txSkelOut = do
@@ -150,7 +150,7 @@ getTxSkelOutMinAda txSkelOut = do
 -- will increase the size of the UTXO which in turn might need more ADA.
 toTxSkelOutWithMinAda ::
   forall effs.
-  (Members '[MockChainRead, MockChainLog, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, MockChainLog, Error P.Ledger.ToCardanoError] effs) =>
   TxSkelOut ->
   Sem effs TxSkelOut
 -- The auto adjustment is disabled so nothing is done here
@@ -177,6 +177,6 @@ toTxSkelOutWithMinAda txSkelOut = do
 -- their ada value when requested by the user and required by the protocol
 -- parameters. Logs an event whenever such a change occurs.
 autoFillMinAda ::
-  (Members '[Tweak, MockChainRead, MockChainLog, Error Ledger.ToCardanoError] effs) =>
+  (Members '[Tweak, MockChainRead, MockChainLog, Error P.Ledger.ToCardanoError] effs) =>
   Sem effs ()
 autoFillMinAda = traverseTweak (txSkelOutsL % traversed) toTxSkelOutWithMinAda

--- a/src/Cooked/MockChain/Balancing.hs
+++ b/src/Cooked/MockChain/Balancing.hs
@@ -31,10 +31,9 @@ import Data.Map qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Ratio qualified as Rat
 import Data.Set qualified as Set
-import Ledger.Tx qualified as Ledger
-import Ledger.Tx.CardanoAPI qualified as Ledger
-import Lens.Micro.Extras qualified as Micro
-import Lens.Micro.Extras qualified as MicroLens
+import Ledger.Tx qualified as P.Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
+import Lens.Micro.Extras qualified as Microlens
 import Optics.Core
 import Optics.Core.Extras
 import Plutus.Script.Utils.Address qualified as Script
@@ -68,7 +67,7 @@ data ExtendedTxSkel = ExtendedTxSkel
 -- skeleton control whether it should be balanced, and how to compute its
 -- associated elements.
 balanceTxSkel ::
-  (Members '[MockChainRead, MockChainLog, Error MockChainError, Error Ledger.ToCardanoError, Fail] effs) =>
+  (Members '[MockChainRead, MockChainLog, Error MockChainError, Error P.Ledger.ToCardanoError, Fail] effs) =>
   TxSkel ->
   Sem effs ExtendedTxSkel
 balanceTxSkel skelUnbal@TxSkel {..} = do
@@ -165,7 +164,7 @@ balanceTxSkel skelUnbal@TxSkel {..} = do
 -- | Computes optimal fee for a given skeleton and balances it around those fees.
 -- This uses a dichotomic search for an optimal "balanceable around" fee.
 computeFeeAndBalance ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError, Fail] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError, Fail] effs) =>
   Peer ->
   Fee ->
   Fee ->
@@ -222,7 +221,7 @@ computeFeeAndBalance balancingUser minFee maxFee balancingUtxos mCollaterals ske
 -- min ada requirements in the associated return collateral and the maximum
 -- number of collateral inputs authorized by protocol parameters.
 collateralsFromFee ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   -- | The fee from which these collaterals should be computed
   Fee ->
   -- | The optional candidate UTxOs to be used as collaterals, alongside the
@@ -237,9 +236,9 @@ collateralsFromFee fee (Just (collateralIns, returnCollateralUser)) = do
   params <- Emulator.pEmulatorPParams <$> getParams
   -- We retrieve the max number of collateral inputs, with a default of 10. In
   -- practice this will be around 3.
-  let nbMax = toInteger $ MicroLens.view Conway.ppMaxCollateralInputsL params
+  let nbMax = toInteger $ Microlens.view Conway.ppMaxCollateralInputsL params
   -- We retrieve the percentage to respect between fees and total collaterals
-  let percentage = toInteger $ MicroLens.view Conway.ppCollateralPercentageL params
+  let percentage = toInteger $ Microlens.view Conway.ppCollateralPercentageL params
   -- We compute the total collateral to be associated to the transaction as a
   -- value. This will be the target value to be reached by collateral inputs. We
   -- add one because of ledger requirement which seem to round up this value.
@@ -258,7 +257,7 @@ collateralsFromFee fee (Just (collateralIns, returnCollateralUser)) = do
 
 reachValue ::
   forall effs.
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   -- | The Utxos available to reach the value
   Utxos ->
   -- | The target value to reach
@@ -277,7 +276,7 @@ reachValue ::
 reachValue utxos target fuel outputOrUser = do
   -- We retrieve the current protocol version, which is going to be used to
   -- compute the size of the inputs and outputs added by this function
-  Cardano.ProtVer majorVersion _ <- Micro.view Conway.ppProtocolVersionL . Emulator.emulatorPParams <$> getParams
+  Cardano.ProtVer majorVersion _ <- Microlens.view Conway.ppProtocolVersionL . Emulator.emulatorPParams <$> getParams
   -- We annotate @outputOrUser@ with the size of the existing output, if any
   outputOrUser' <- case outputOrUser of
     Left output -> Left . (output,) <$> outputSize majorVersion output
@@ -387,12 +386,12 @@ reachValue utxos target fuel outputOrUser = do
     -- gonna be the same, but can theoretically vary if coming from a
     -- transaction with many outputs.
     inputSize :: Cardano.Version -> Api.TxOutRef -> Sem effs Integer
-    inputSize majorVersion = fmap (computeSize majorVersion . Cardano.toShelleyTxIn) . fromEither . Ledger.toCardanoTxIn
+    inputSize majorVersion = fmap (computeSize majorVersion . Cardano.toShelleyTxIn) . fromEither . P.Ledger.toCardanoTxIn
 
 -- | Estimates the required fee for a given skeleton with a given initial fee
 -- and collaterals
 estimateTxSkelFee ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError, Fail] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError, Fail] effs) =>
   TxSkel ->
   Fee ->
   Maybe Collaterals ->
@@ -415,7 +414,7 @@ estimateTxSkelFee skel fee mCollaterals = do
 -- words, this ensures that the following equation holds: input value + minted
 -- value + withdrawn value = output value + burned value + fee + deposits
 computeBalancedTxSkel ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   Peer ->
   Utxos ->
   TxSkel ->
@@ -506,12 +505,12 @@ getMinAndMaxFee nbOfScripts = do
   -- We retrieve the necessary parameters to compute the maximum possible fee
   -- for a transaction. There are quite a few of them.
   params <- Emulator.pEmulatorPParams <$> getParams
-  let maxTxSize = toInteger $ MicroLens.view Conway.ppMaxTxSizeL params
-      Cardano.Coin txFeePerByte = MicroLens.view Conway.ppMinFeeAL params
-      Cardano.Coin txFeeFixed = MicroLens.view Conway.ppMinFeeBL params
-      Cardano.Prices (Cardano.unboundRational -> priceESteps) (Cardano.unboundRational -> priceEMem) = MicroLens.view Conway.ppPricesL params
-      Cardano.ExUnits (toInteger -> eSteps) (toInteger -> eMem) = MicroLens.view Conway.ppMaxTxExUnitsL params
-      (Cardano.unboundRational -> refScriptFeePerByte) = MicroLens.view Conway.ppMinFeeRefScriptCostPerByteL params
+  let maxTxSize = toInteger $ Microlens.view Conway.ppMaxTxSizeL params
+      Cardano.Coin txFeePerByte = Microlens.view Conway.ppMinFeeAL params
+      Cardano.Coin txFeeFixed = Microlens.view Conway.ppMinFeeBL params
+      Cardano.Prices (Cardano.unboundRational -> priceESteps) (Cardano.unboundRational -> priceEMem) = Microlens.view Conway.ppPricesL params
+      Cardano.ExUnits (toInteger -> eSteps) (toInteger -> eMem) = Microlens.view Conway.ppMaxTxExUnitsL params
+      (Cardano.unboundRational -> refScriptFeePerByte) = Microlens.view Conway.ppMinFeeRefScriptCostPerByteL params
   -- We compute the components of the maximum possible fee, starting with the
   -- maximum fee associated with the transaction size
   let txSizeMaxFee = maxTxSize * txFeePerByte

--- a/src/Cooked/MockChain/Error.hs
+++ b/src/Cooked/MockChain/Error.hs
@@ -11,9 +11,9 @@ module Cooked.MockChain.Error
 where
 
 import Cooked.Skeleton.User
-import Ledger.Index qualified as Ledger
-import Ledger.Slot qualified as Ledger
-import Ledger.Tx qualified as Ledger
+import Ledger.Index qualified as P.Ledger
+import Ledger.Slot qualified as P.Ledger
+import Ledger.Tx qualified as P.Ledger
 import PlutusLedgerApi.V3 qualified as Api
 import Polysemy
 import Polysemy.Error
@@ -41,28 +41,28 @@ data BalancingError
 -- | Errors that can be produced by the blockchain
 data MockChainError
   = -- | Validation errors, either in Phase 1 or Phase 2
-    MCEValidationError Ledger.ValidationPhase Ledger.ValidationError
+    MCEValidationError P.Ledger.ValidationPhase P.Ledger.ValidationError
   | -- | Balancing errors
     MCEBalancingError BalancingError
   | -- | Translating a skeleton element to its Cardano counterpart failed
-    MCEToCardanoError Ledger.ToCardanoError
+    MCEToCardanoError P.Ledger.ToCardanoError
   | -- | The required reference script is missing from a witness utxo
     MCEWrongReferenceScriptError Api.TxOutRef Api.ScriptHash (Maybe Api.ScriptHash)
   | -- | A UTxO is missing from the mockchain state
     MCEUnknownOutRef Api.TxOutRef
   | -- | A jump in time would result in a past slot
-    MCEPastSlot Ledger.Slot Ledger.Slot
+    MCEPastSlot P.Ledger.Slot P.Ledger.Slot
   | -- | An attempt to invoke an unsupported feature has been made
     MCEUnsupportedFeature String
   | -- | Used to provide 'MonadFail' instances.
     MCEFailure String
   deriving (Show, Eq)
 
--- | Interpreting `Ledger.ToCardanoError` in terms of `MockChainError`
+-- | Interpreting `P.Ledger.ToCardanoError` in terms of `MockChainError`
 runToCardanoErrorInMockChainError ::
   forall effs a.
   (Member (Error MockChainError) effs) =>
-  Sem (Error Ledger.ToCardanoError : effs) a ->
+  Sem (Error P.Ledger.ToCardanoError : effs) a ->
   Sem effs a
 runToCardanoErrorInMockChainError = mapError MCEToCardanoError
 

--- a/src/Cooked/MockChain/GenerateTx/Anchor.hs
+++ b/src/Cooked/MockChain/GenerateTx/Anchor.hs
@@ -1,7 +1,7 @@
 -- | Transforming 'TxSkelAnchor' into its Cardano counterpart
 module Cooked.MockChain.GenerateTx.Anchor (toCardanoAnchor) where
 
-import Cardano.Ledger.BaseTypes qualified as Cardano
+import Cardano.Ledger.BaseTypes qualified as C.Ledger
 import Cardano.Ledger.Conway.Core qualified as Conway
 import Control.Monad.Catch
 import Cooked.Skeleton.Anchor
@@ -15,13 +15,13 @@ import Network.HTTP.Simple qualified as Network
 -- | This function transforms a 'TxSkelAnchor' into its Cardano counterpart. If
 -- the provided anchor does not provde a resolved page, it will be unsafely
 -- fetched online, so use at your own discretion.
-toCardanoAnchor :: TxSkelAnchor -> Cardano.Anchor
+toCardanoAnchor :: TxSkelAnchor -> C.Ledger.Anchor
 toCardanoAnchor txSkelAnchor =
   fromMaybe def $
     do
       (url, page) <- txSkelAnchor
-      anchorUrl <- Cardano.textToUrl (length url) (Text.pack url)
-      fmap (Cardano.Anchor anchorUrl . Conway.hashAnnotated . Cardano.AnchorData) $ case page of
+      anchorUrl <- C.Ledger.textToUrl (length url) (Text.pack url)
+      fmap (C.Ledger.Anchor anchorUrl . Conway.hashAnnotated . C.Ledger.AnchorData) $ case page of
         Just resolvedPage -> return resolvedPage
         Nothing ->
           -- WARNING: very unsafe and unreproducible

--- a/src/Cooked/MockChain/GenerateTx/Body.hs
+++ b/src/Cooked/MockChain/GenerateTx/Body.hs
@@ -29,8 +29,8 @@ import Cooked.Skeleton
 import Data.Map qualified as Map
 import Data.Maybe
 import Data.Set qualified as Set
-import Ledger.Address qualified as Ledger
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Address qualified as P.Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import Plutus.Script.Utils.Address qualified as Script
 import Polysemy
 import Polysemy.Error
@@ -38,7 +38,7 @@ import Polysemy.Fail
 
 -- | Generates a body content from a skeleton
 txSkelToTxBodyContent ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError, Fail] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError, Fail] effs) =>
   TxSkel ->
   Fee ->
   Maybe Collaterals ->
@@ -48,7 +48,7 @@ txSkelToTxBodyContent skel@TxSkel {..} fee mCollaterals = do
   txInsReference <- toInsReference skel
   (txInsCollateral, txTotalCollateral, txReturnCollateral) <- toCollateralTriplet mCollaterals
   txOuts <- mapM toCardanoTxOut txSkelOuts
-  (txValidityLowerBound, txValidityUpperBound) <- fromEither $ Ledger.toCardanoValidityRange txSkelValidityRange
+  (txValidityLowerBound, txValidityUpperBound) <- fromEither $ P.Ledger.toCardanoValidityRange txSkelValidityRange
   txMintValue <- toMintValue txSkelMints
   txExtraKeyWits <-
     if null txSkelSignatories
@@ -56,7 +56,7 @@ txSkelToTxBodyContent skel@TxSkel {..} fee mCollaterals = do
       else
         Cardano.TxExtraKeyWitnesses Cardano.AlonzoEraOnwardsConway
           <$> fromEither
-            (mapM (Ledger.toCardanoPaymentKeyHash . Ledger.PaymentPubKeyHash . Script.toPubKeyHash) txSkelSignatories)
+            (mapM (P.Ledger.toCardanoPaymentKeyHash . P.Ledger.PaymentPubKeyHash . Script.toPubKeyHash) txSkelSignatories)
   txProtocolParams <- Cardano.BuildTxWith . Just . Emulator.ledgerProtocolParameters <$> getParams
   txProposalProcedures <- Just . Cardano.Featured Cardano.ConwayEraOnwardsConway <$> toProposalProcedures txSkelProposals
   txWithdrawals <- toWithdrawals txSkelWithdrawals
@@ -73,17 +73,17 @@ txSkelToTxBodyContent skel@TxSkel {..} fee mCollaterals = do
 
 -- | Generates a transaction body from a body content
 txBodyContentToTxBody ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   Cardano.TxBodyContent Cardano.BuildTx Cardano.ConwayEra ->
   Sem effs (Cardano.TxBody Cardano.ConwayEra)
 txBodyContentToTxBody txBodyContent = do
   params <- getParams
   -- We create the associated Shelley TxBody
-  fromEither $ Emulator.createTransactionBody params $ Ledger.CardanoBuildTx txBodyContent
+  fromEither $ Emulator.createTransactionBody params $ P.Ledger.CardanoBuildTx txBodyContent
 
 -- | Generates an index with utxos known to a 'TxSkel'
 txSkelToIndex ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   TxSkel ->
   Maybe Collaterals ->
   Sem effs (Cardano.UTxO Cardano.ConwayEra)
@@ -96,14 +96,14 @@ txSkelToIndex txSkel mCollaterals = do
   -- We then compute their Cardano counterparts
   txOutL <- forM knownTxOuts toCardanoTxOut
   -- We build the index and handle the possible error
-  txInL <- fromEither $ forM knownTxORefs Ledger.toCardanoTxIn
+  txInL <- fromEither $ forM knownTxORefs P.Ledger.toCardanoTxIn
   return $ Cardano.UTxO $ Map.fromList $ zip txInL $ Cardano.toCtxUTxOTxOut <$> txOutL
 
 -- | Generates a transaction body from a 'TxSkel' and associated fee and
 -- collateral information. This transaction body accounts for the actual
 -- execution units of each of the scripts involved in the skeleton.
 txSkelToTxBody ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError, Fail] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError, Fail] effs) =>
   TxSkel ->
   Fee ->
   Maybe Collaterals ->
@@ -118,7 +118,7 @@ txSkelToTxBody txSkel fee mCollaterals = do
   index <- txSkelToIndex txSkel mCollaterals
   params <- getParams
   -- We retrieve the execution units associated with the transaction
-  case Emulator.getTxExUnitsWithLogs params (Ledger.fromPlutusIndex index) tx' of
+  case Emulator.getTxExUnitsWithLogs params (P.Ledger.fromPlutusIndex index) tx' of
     -- Computing the execution units can result in all kinds of phase 2
     -- validation failures, except for the ones related to the execution units
     -- themselves. Unless required in the options, we throw the validation
@@ -147,7 +147,7 @@ txSignatoriesAndBodyToCardanoTx signatories txBody = Cardano.Tx txBody $ mapMayb
 
 -- | Generates a full Cardano transaction from a skeleton, fees and collaterals
 txSkelToCardanoTx ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError, Fail] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError, Fail] effs) =>
   TxSkel ->
   Fee ->
   Maybe Collaterals ->

--- a/src/Cooked/MockChain/GenerateTx/Certificate.hs
+++ b/src/Cooked/MockChain/GenerateTx/Certificate.hs
@@ -4,8 +4,8 @@ module Cooked.MockChain.GenerateTx.Certificate (toCertificates) where
 
 import Cardano.Api qualified as Cardano
 import Cardano.Ledger.Conway.TxCert qualified as Conway
-import Cardano.Ledger.DRep qualified as Ledger
-import Cardano.Ledger.PoolParams qualified as Ledger
+import Cardano.Ledger.DRep qualified as C.Ledger
+import Cardano.Ledger.PoolParams qualified as C.Ledger
 import Cardano.Ledger.Shelley.TxCert qualified as Shelley
 import Cardano.Node.Emulator.Internal.Node qualified as Emulator
 import Cooked.MockChain.Error
@@ -16,7 +16,7 @@ import Cooked.Skeleton.Certificate
 import Cooked.Skeleton.User
 import Data.Default
 import Data.Maybe.Strict
-import Ledger.Tx qualified as Ledger
+import Ledger.Tx qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Address qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
@@ -25,15 +25,15 @@ import Polysemy.Error
 import Polysemy.Fail
 
 toDRep ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   Api.DRep ->
-  Sem effs Ledger.DRep
-toDRep Api.DRepAlwaysAbstain = return Ledger.DRepAlwaysAbstain
-toDRep Api.DRepAlwaysNoConfidence = return Ledger.DRepAlwaysNoConfidence
-toDRep (Api.DRep (Api.DRepCredential cred)) = Ledger.DRepCredential <$> toDRepCredential cred
+  Sem effs C.Ledger.DRep
+toDRep Api.DRepAlwaysAbstain = return C.Ledger.DRepAlwaysAbstain
+toDRep Api.DRepAlwaysNoConfidence = return C.Ledger.DRepAlwaysNoConfidence
+toDRep (Api.DRep (Api.DRepCredential cred)) = C.Ledger.DRepCredential <$> toDRepCredential cred
 
 toDelegatee ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   Api.Delegatee ->
   Sem effs Conway.Delegatee
 toDelegatee (Api.DelegStake pkh) = Conway.DelegStake <$> toStakePoolKeyHash pkh
@@ -41,7 +41,7 @@ toDelegatee (Api.DelegVote dRep) = Conway.DelegVote <$> toDRep dRep
 toDelegatee (Api.DelegStakeVote pkh dRep) = liftA2 Conway.DelegStakeVote (toStakePoolKeyHash pkh) (toDRep dRep)
 
 toCertificate ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   TxSkelCertificate ->
   Sem effs (Cardano.Certificate Cardano.ConwayEra)
 toCertificate txSkelCert =
@@ -68,7 +68,7 @@ toCertificate txSkelCert =
       TxSkelCertificate (UserPubKey (Script.toPubKeyHash -> poolHash)) (PoolRegister poolVrf) ->
         Conway.ConwayTxCertPool . Shelley.RegPool
           <$> liftA2
-            (\pId pVrf -> def {Ledger.ppId = pId, Ledger.ppVrf = pVrf})
+            (\pId pVrf -> def {C.Ledger.ppId = pId, C.Ledger.ppVrf = pVrf})
             (toStakePoolKeyHash poolHash)
             (toVRFVerKeyHash poolVrf)
       TxSkelCertificate (UserPubKey (Script.toPubKeyHash -> poolHash)) (PoolRetire slot) ->
@@ -90,7 +90,7 @@ toCertificate txSkelCert =
         Conway.ConwayTxCertGov . (`Conway.ConwayResignCommitteeColdKey` SNothing) <$> toColdCredential cred
 
 toCertificateWitness ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   TxSkelCertificate ->
   Sem effs (Maybe (Cardano.ScriptWitness Cardano.WitCtxStake Cardano.ConwayEra))
 toCertificateWitness =
@@ -104,7 +104,7 @@ toCertificateWitness =
 
 -- | Builds a 'Cardano.TxCertificates' from a list of 'TxSkelCertificate'
 toCertificates ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError, Fail] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError, Fail] effs) =>
   [TxSkelCertificate] ->
   Sem effs (Cardano.TxCertificates Cardano.BuildTx Cardano.ConwayEra)
 toCertificates =

--- a/src/Cooked/MockChain/GenerateTx/Collateral.hs
+++ b/src/Cooked/MockChain/GenerateTx/Collateral.hs
@@ -10,7 +10,7 @@ import Cooked.Skeleton.Output
 import Cooked.Skeleton.Value
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import Optics.Core
 import PlutusLedgerApi.V3 qualified as Api
 import Polysemy
@@ -28,7 +28,7 @@ import Polysemy.Error
 -- These quantity should satisfy the equation (in terms of their values):
 -- collateral inputs = total collateral + return collateral
 toCollateralTriplet ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   Maybe Collaterals ->
   Sem
     effs
@@ -42,7 +42,7 @@ toCollateralTriplet (Just (Set.toList -> collateralInsList, mReturnCollateral)) 
   txInsCollateral <-
     case collateralInsList of
       [] -> return Cardano.TxInsCollateralNone
-      l -> fromEither $ Cardano.TxInsCollateral Cardano.AlonzoEraOnwardsConway <$> mapM Ledger.toCardanoTxIn l
+      l -> fromEither $ Cardano.TxInsCollateral Cardano.AlonzoEraOnwardsConway <$> mapM P.Ledger.toCardanoTxIn l
   -- We collect the amount of lovelace in the collateral inputs
   Api.Lovelace collateralInsLovelace <- foldOf (folded % txSkelOutValueL % valueLovelaceL) . Map.elems <$> lookupUtxos collateralInsList
   -- We collect the amount of lovelace in the return collateral output

--- a/src/Cooked/MockChain/GenerateTx/Credential.hs
+++ b/src/Cooked/MockChain/GenerateTx/Credential.hs
@@ -18,14 +18,14 @@ import Cardano.Api qualified as Cardano
 import Cardano.Ledger.BaseTypes qualified as C.Ledger
 import Cardano.Ledger.Hashes qualified as C.Ledger
 import Cardano.Ledger.Shelley.API qualified as C.Ledger
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import PlutusLedgerApi.V3 qualified as Api
 import Polysemy
 import Polysemy.Error
 
 -- | Translates a given credential to a reward account.
 toRewardAccount ::
-  (Member (Error Ledger.ToCardanoError) effs) =>
+  (Member (Error P.Ledger.ToCardanoError) effs) =>
   Api.Credential ->
   Sem effs C.Ledger.RewardAccount
 toRewardAccount =
@@ -36,7 +36,7 @@ toRewardAccount =
 
 -- | Converts an 'Api.PubKeyHash' to any kind of key
 deserialiseFromBuiltinByteString ::
-  ( Member (Error Ledger.ToCardanoError) effs,
+  ( Member (Error P.Ledger.ToCardanoError) effs,
     Cardano.SerialiseAsRawBytes a
   ) =>
   Cardano.AsType a ->
@@ -44,12 +44,12 @@ deserialiseFromBuiltinByteString ::
   Sem effs a
 deserialiseFromBuiltinByteString asType =
   fromEither
-    . Ledger.deserialiseFromRawBytes asType
+    . P.Ledger.deserialiseFromRawBytes asType
     . Api.fromBuiltin
 
 -- | Converts a plutus script hash into a cardano ledger script hash
 toScriptHash ::
-  (Member (Error Ledger.ToCardanoError) effs) =>
+  (Member (Error P.Ledger.ToCardanoError) effs) =>
   Api.ScriptHash ->
   Sem effs C.Ledger.ScriptHash
 toScriptHash (Api.ScriptHash sHash) = do
@@ -58,7 +58,7 @@ toScriptHash (Api.ScriptHash sHash) = do
 
 -- | Converts a plutus pkhash into a certain cardano ledger hash
 toKeyHash ::
-  ( Member (Error Ledger.ToCardanoError) effs,
+  ( Member (Error P.Ledger.ToCardanoError) effs,
     Cardano.SerialiseAsRawBytes (Cardano.Hash key)
   ) =>
   Cardano.AsType key ->
@@ -72,14 +72,14 @@ toKeyHash asType unwrap =
 
 -- | Converts an 'Api.PubKeyHash' into a cardano ledger stake pool key hash
 toStakePoolKeyHash ::
-  (Member (Error Ledger.ToCardanoError) effs) =>
+  (Member (Error P.Ledger.ToCardanoError) effs) =>
   Api.PubKeyHash ->
   Sem effs (C.Ledger.KeyHash 'C.Ledger.StakePool)
 toStakePoolKeyHash = toKeyHash Cardano.AsStakePoolKey Cardano.unStakePoolKeyHash
 
 -- | Converts an 'Api.PubKeyHash' into a cardano ledger VRFVerKeyHash
 toVRFVerKeyHash ::
-  (Member (Error Ledger.ToCardanoError) effs) =>
+  (Member (Error P.Ledger.ToCardanoError) effs) =>
   Api.PubKeyHash ->
   Sem effs (C.Ledger.VRFVerKeyHash a)
 toVRFVerKeyHash (Api.PubKeyHash pkh) = do
@@ -88,7 +88,7 @@ toVRFVerKeyHash (Api.PubKeyHash pkh) = do
 
 -- | Converts an 'Api.Credential' to a Cardano Credential of the expected kind
 toCardanoCredential ::
-  ( Member (Error Ledger.ToCardanoError) effs,
+  ( Member (Error P.Ledger.ToCardanoError) effs,
     Cardano.SerialiseAsRawBytes (Cardano.Hash key)
   ) =>
   Cardano.AsType key ->
@@ -100,28 +100,28 @@ toCardanoCredential asType unwrap (Api.PubKeyCredential pkHash) = C.Ledger.KeyHa
 
 -- | Translates a credential into a Cardano stake credential
 toStakeCredential ::
-  (Member (Error Ledger.ToCardanoError) effs) =>
+  (Member (Error P.Ledger.ToCardanoError) effs) =>
   Api.Credential ->
   Sem effs (C.Ledger.Credential 'C.Ledger.Staking)
 toStakeCredential = toCardanoCredential Cardano.AsStakeKey Cardano.unStakeKeyHash
 
 -- | Translates a credential into a Cardano drep credential
 toDRepCredential ::
-  (Member (Error Ledger.ToCardanoError) effs) =>
+  (Member (Error P.Ledger.ToCardanoError) effs) =>
   Api.Credential ->
   Sem effs (C.Ledger.Credential 'C.Ledger.DRepRole)
 toDRepCredential = toCardanoCredential Cardano.AsDRepKey Cardano.unDRepKeyHash
 
 -- | Translates a credential into a Cardano cold committee credential
 toColdCredential ::
-  (Member (Error Ledger.ToCardanoError) effs) =>
+  (Member (Error P.Ledger.ToCardanoError) effs) =>
   Api.Credential ->
   Sem effs (C.Ledger.Credential 'C.Ledger.ColdCommitteeRole)
 toColdCredential = toCardanoCredential Cardano.AsCommitteeColdKey Cardano.unCommitteeColdKeyHash
 
 -- | Translates a credential into a Cardano hot committee credential
 toHotCredential ::
-  (Member (Error Ledger.ToCardanoError) effs) =>
+  (Member (Error P.Ledger.ToCardanoError) effs) =>
   Api.Credential ->
   Sem effs (C.Ledger.Credential 'C.Ledger.HotCommitteeRole)
 toHotCredential = toCardanoCredential Cardano.AsCommitteeHotKey Cardano.unCommitteeHotKeyHash

--- a/src/Cooked/MockChain/GenerateTx/Input.hs
+++ b/src/Cooked/MockChain/GenerateTx/Input.hs
@@ -6,7 +6,7 @@ import Cooked.MockChain.Error
 import Cooked.MockChain.GenerateTx.Witness
 import Cooked.MockChain.Read
 import Cooked.Skeleton
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import PlutusLedgerApi.V3 qualified as Api
 import Polysemy
 import Polysemy.Error
@@ -14,7 +14,7 @@ import Polysemy.Error
 -- | Converts a 'TxSkel' input, which consists of a 'Api.TxOutRef' and a
 -- 'TxSkelRedeemer', into a 'Cardano.TxIn', together with the appropriate witness.
 toTxInAndWitness ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   (Api.TxOutRef, TxSkelRedeemer) ->
   Sem
     effs
@@ -31,5 +31,5 @@ toTxInAndWitness (txOutRef, txSkelRedeemer) = do
           case txSkelOutDatum of
             NoTxSkelOutDatum -> Cardano.ScriptDatumForTxIn Nothing
             SomeTxSkelOutDatum _ Inline -> Cardano.InlineScriptDatum
-            SomeTxSkelOutDatum dat _ -> Cardano.ScriptDatumForTxIn $ Just $ Ledger.toCardanoScriptData $ Api.toBuiltinData dat
-  (,Cardano.BuildTxWith witness) <$> fromEither (Ledger.toCardanoTxIn txOutRef)
+            SomeTxSkelOutDatum dat _ -> Cardano.ScriptDatumForTxIn $ Just $ P.Ledger.toCardanoScriptData $ Api.toBuiltinData dat
+  (,Cardano.BuildTxWith witness) <$> fromEither (P.Ledger.toCardanoTxIn txOutRef)

--- a/src/Cooked/MockChain/GenerateTx/Mint.hs
+++ b/src/Cooked/MockChain/GenerateTx/Mint.hs
@@ -11,7 +11,7 @@ import Cooked.Skeleton.User
 import Data.Map qualified as Map
 import Data.Map.Strict qualified as SMap
 import GHC.Exts (fromList)
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import Plutus.Script.Utils.Scripts qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
 import PlutusTx.Builtins.Internal qualified as PlutusTx
@@ -20,13 +20,13 @@ import Polysemy.Error
 
 -- | Converts a 'TxSkelMints' into a 'Cardano.TxMintValue'
 toMintValue ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   TxSkelMints ->
   Sem effs (Cardano.TxMintValue Cardano.BuildTx Cardano.ConwayEra)
 toMintValue txSkelMints | txSkelMints == mempty = return Cardano.TxMintNone
 toMintValue (unTxSkelMints -> mints) = fmap (Cardano.TxMintValue Cardano.MaryEraOnwardsConway . SMap.fromList) $
   forM (Map.toList mints) $ \(policyHash, (UserRedeemedScript policy red, Map.toList -> assets)) -> do
-    policyId <- fromEither $ Ledger.toCardanoPolicyId $ Script.toMintingPolicyHash policyHash
+    policyId <- fromEither $ P.Ledger.toCardanoPolicyId $ Script.toMintingPolicyHash policyHash
     mintWitness <- Cardano.BuildTxWith <$> toScriptWitness policy red Cardano.NoScriptDatumForMint
     return
       ( policyId,

--- a/src/Cooked/MockChain/GenerateTx/Output.hs
+++ b/src/Cooked/MockChain/GenerateTx/Output.hs
@@ -6,7 +6,7 @@ import Cardano.Node.Emulator.Internal.Node.Params qualified as Emulator
 import Cooked.MockChain.Read
 import Cooked.Skeleton.Datum
 import Cooked.Skeleton.Output
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Data qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
@@ -15,7 +15,7 @@ import Polysemy.Error
 
 -- | Converts a 'TxSkelOut' to the corresponding 'Cardano.TxOut'
 toCardanoTxOut ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   TxSkelOut ->
   Sem effs (Cardano.TxOut Cardano.CtxTx Cardano.ConwayEra)
 toCardanoTxOut output = do
@@ -24,21 +24,21 @@ toCardanoTxOut output = do
       oDatum = view txSkelOutDatumL output
       oRefScript = view txSkelOutMReferenceScriptL output
   networkId <- Emulator.pNetworkId <$> getParams
-  address <- fromEither $ Ledger.toCardanoAddressInEra networkId oAddress
-  (Ledger.toCardanoTxOutValue -> value) <- fromEither $ Ledger.toCardanoValue oValue
+  address <- fromEither $ P.Ledger.toCardanoAddressInEra networkId oAddress
+  (P.Ledger.toCardanoTxOutValue -> value) <- fromEither $ P.Ledger.toCardanoValue oValue
   datum <- case oDatum of
     NoTxSkelOutDatum -> return Cardano.TxOutDatumNone
     SomeTxSkelOutDatum datum (Hashed NotResolved) ->
       Cardano.TxOutDatumHash Cardano.AlonzoEraOnwardsConway
-        <$> fromEither (Ledger.toCardanoScriptDataHash $ Script.datumHash $ Api.Datum $ Api.toBuiltinData datum)
+        <$> fromEither (P.Ledger.toCardanoScriptDataHash $ Script.datumHash $ Api.Datum $ Api.toBuiltinData datum)
     SomeTxSkelOutDatum datum (Hashed Resolved) ->
       return $
         Cardano.TxOutSupplementalDatum Cardano.AlonzoEraOnwardsConway $
-          Ledger.toCardanoScriptData $
+          P.Ledger.toCardanoScriptData $
             Api.toBuiltinData datum
     SomeTxSkelOutDatum datum Inline ->
       return $
         Cardano.TxOutDatumInline Cardano.BabbageEraOnwardsConway $
-          Ledger.toCardanoScriptData $
+          P.Ledger.toCardanoScriptData $
             Api.toBuiltinData datum
-  return $ Cardano.TxOut address value datum $ Ledger.toCardanoReferenceScript oRefScript
+  return $ Cardano.TxOut address value datum $ P.Ledger.toCardanoReferenceScript oRefScript

--- a/src/Cooked/MockChain/GenerateTx/Proposal.hs
+++ b/src/Cooked/MockChain/GenerateTx/Proposal.hs
@@ -3,7 +3,7 @@ module Cooked.MockChain.GenerateTx.Proposal (toProposalProcedures) where
 
 import Cardano.Api qualified as Cardano
 import Cardano.Api.Ledger qualified as Cardano
-import Cardano.Ledger.BaseTypes qualified as Cardano
+import Cardano.Ledger.BaseTypes qualified as C.Ledger
 import Cardano.Ledger.Conway.Core qualified as Conway
 import Cardano.Ledger.Conway.Governance qualified as Conway
 import Cardano.Ledger.Conway.PParams qualified as Conway
@@ -21,8 +21,8 @@ import Data.Map qualified as Map
 import Data.Map.Ordered.Strict qualified as OMap
 import Data.Maybe
 import Data.Maybe.Strict
-import Ledger.Tx.CardanoAPI qualified as Ledger
-import Lens.Micro qualified as MicroLens
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
+import Lens.Micro qualified as Microlens
 import Plutus.Script.Utils.Address qualified as Script
 import Plutus.Script.Utils.Scripts qualified as Script
 import PlutusLedgerApi.V1.Value qualified as Api
@@ -39,13 +39,13 @@ toPParamsUpdate ::
   Sem effs (Conway.PParamsUpdate Emulator.EmulatorEra)
 toPParamsUpdate pChange ppu =
   -- From rational to bounded rational
-  let toBR :: (Cardano.BoundedRational r) => Rational -> r
-      toBR = fromMaybe minBound . Cardano.boundRational
+  let toBR :: (C.Ledger.BoundedRational r) => Rational -> r
+      toBR = fromMaybe minBound . C.Ledger.boundRational
       -- Helper to set one of the param update with a lens. The explicit
       -- signature is needed so that it stays polymorphic in @a@ under
       -- @MonoLocalBinds@ despite closing over @effs@ and @ppu@.
-      setL :: forall a. MicroLens.ASetter' (Conway.PParamsUpdate Emulator.EmulatorEra) (StrictMaybe a) -> a -> Sem effs (Conway.PParamsUpdate Emulator.EmulatorEra)
-      setL l v = return $ MicroLens.set l (SJust v) ppu
+      setL :: forall a. Microlens.ASetter' (Conway.PParamsUpdate Emulator.EmulatorEra) (StrictMaybe a) -> a -> Sem effs (Conway.PParamsUpdate Emulator.EmulatorEra)
+      setL l v = return $ Microlens.set l (SJust v) ppu
    in case pChange of
         FeePerByte n -> setL Conway.ppuMinFeeAL $ fromIntegral n
         FeeFixed n -> setL Conway.ppuMinFeeBL $ fromIntegral n
@@ -54,10 +54,10 @@ toPParamsUpdate pChange ppu =
         MaxBlockHeaderSize n -> setL Conway.ppuMaxBHSizeL $ fromIntegral n
         KeyDeposit n -> setL Conway.ppuKeyDepositL $ fromIntegral n
         PoolDeposit n -> setL Conway.ppuPoolDepositL $ fromIntegral n
-        PoolRetirementMaxEpoch n -> setL Conway.ppuEMaxL $ Cardano.EpochInterval $ fromIntegral n
+        PoolRetirementMaxEpoch n -> setL Conway.ppuEMaxL $ C.Ledger.EpochInterval $ fromIntegral n
         PoolNumber n -> setL Conway.ppuNOptL $ fromIntegral n
-        PoolInfluence q -> setL Conway.ppuA0L $ fromMaybe minBound $ Cardano.boundRational q
-        MonetaryExpansion q -> setL Conway.ppuRhoL $ fromMaybe minBound $ Cardano.boundRational q
+        PoolInfluence q -> setL Conway.ppuA0L $ fromMaybe minBound $ C.Ledger.boundRational q
+        MonetaryExpansion q -> setL Conway.ppuRhoL $ fromMaybe minBound $ C.Ledger.boundRational q
         TreasuryCut q -> setL Conway.ppuTauL $ toBR q
         MinPoolCost n -> setL Conway.ppuMinPoolCostL $ fromIntegral n
         CoinsPerUTxOByte n -> setL Conway.ppuCoinsPerUTxOByteL $ Conway.CoinPerByte $ fromIntegral n
@@ -75,16 +75,16 @@ toPParamsUpdate pChange ppu =
           setL Conway.ppuDRepVotingThresholdsL $
             Conway.DRepVotingThresholds (toBR a) (toBR b) (toBR c) (toBR d) (toBR e) (toBR f) (toBR g) (toBR h) (toBR i) (toBR j)
         CommitteeMinSize n -> setL Conway.ppuCommitteeMinSizeL $ fromIntegral n
-        CommitteeMaxTermLength n -> setL Conway.ppuCommitteeMaxTermLengthL $ Cardano.EpochInterval $ fromIntegral n
-        GovActionLifetime n -> setL Conway.ppuGovActionLifetimeL $ Cardano.EpochInterval $ fromIntegral n
+        CommitteeMaxTermLength n -> setL Conway.ppuCommitteeMaxTermLengthL $ C.Ledger.EpochInterval $ fromIntegral n
+        GovActionLifetime n -> setL Conway.ppuGovActionLifetimeL $ C.Ledger.EpochInterval $ fromIntegral n
         GovActionDeposit n -> setL Conway.ppuGovActionDepositL $ fromIntegral n
         DRepRegistrationDeposit n -> setL Conway.ppuDRepDepositL $ fromIntegral n
-        DRepActivity n -> setL Conway.ppuDRepActivityL $ Cardano.EpochInterval $ fromIntegral n
-        MinFeeRefScriptCostPerByte q -> setL Conway.ppuMinFeeRefScriptCostPerByteL $ fromMaybe minBound $ Cardano.boundRational q
+        DRepActivity n -> setL Conway.ppuDRepActivityL $ C.Ledger.EpochInterval $ fromIntegral n
+        MinFeeRefScriptCostPerByte q -> setL Conway.ppuMinFeeRefScriptCostPerByteL $ fromMaybe minBound $ C.Ledger.boundRational q
 
 -- | Translates a given skeleton proposal into a governance action
 toGovAction ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   GovernanceAction a ->
   StrictMaybe Conway.ScriptHash ->
   Sem effs (Conway.GovAction Emulator.EmulatorEra)
@@ -100,7 +100,7 @@ toGovAction (TreasuryWithdrawals (Map.toList -> withdrawals)) sHash =
 
 -- | Translates a list of skeleton proposals into a proposal procedures
 toProposalProcedures ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   [TxSkelProposal] ->
   Sem effs (Cardano.TxProposalProcedures Cardano.BuildTx Cardano.ConwayEra)
 toProposalProcedures props | null props = return Cardano.TxProposalProceduresNone
@@ -114,7 +114,7 @@ toProposalProcedures props =
           (Cardano.BuildTxWith -> mConstitutionWitness, mConstitutionHash) <- case mConstitution of
             Just (UserRedeemedScript (toVScript -> script) redeemer) -> do
               scriptWitness <- toScriptWitness script redeemer Cardano.NoScriptDatumForStake
-              Cardano.ScriptHash scriptHash <- fromEither $ Ledger.toCardanoScriptHash $ Script.toScriptHash script
+              Cardano.ScriptHash scriptHash <- fromEither $ P.Ledger.toCardanoScriptHash $ Script.toScriptHash script
               return (Just scriptWitness, SJust scriptHash)
             _ -> return (Nothing, SNothing)
           cardanoGovAction <- toGovAction govAction mConstitutionHash

--- a/src/Cooked/MockChain/GenerateTx/ReferenceInputs.hs
+++ b/src/Cooked/MockChain/GenerateTx/ReferenceInputs.hs
@@ -6,7 +6,7 @@ import Cooked.MockChain.Read
 import Cooked.Skeleton
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import PlutusLedgerApi.V3 qualified as Api
 import Polysemy
 import Polysemy.Error
@@ -17,7 +17,7 @@ import Polysemy.Error
 -- redeemers of the transaction, which can be gathered with
 -- 'txSkelInsReferenceInRedeemers'.
 toInsReference ::
-  (Members '[MockChainRead, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error P.Ledger.ToCardanoError] effs) =>
   TxSkel ->
   Sem effs (Cardano.TxInsReference Cardano.BuildTx Cardano.ConwayEra)
 toInsReference skel = do
@@ -30,10 +30,10 @@ toInsReference skel = do
   if null refInputs
     then return Cardano.TxInsReferenceNone
     else do
-      cardanoRefInputs <- fromEither $ mapM Ledger.toCardanoTxIn refInputs
+      cardanoRefInputs <- fromEither $ mapM P.Ledger.toCardanoTxIn refInputs
       resolvedDatums <- mapM (viewByRef txSkelOutDatumL) refInputs
       return $
         Cardano.TxInsReference Cardano.BabbageEraOnwardsConway cardanoRefInputs $
           Cardano.BuildTxWith $
             Set.fromList
-              [Ledger.toCardanoScriptData $ Api.toBuiltinData dat | SomeTxSkelOutDatum dat (Hashed _) <- resolvedDatums]
+              [P.Ledger.toCardanoScriptData $ Api.toBuiltinData dat | SomeTxSkelOutDatum dat (Hashed _) <- resolvedDatums]

--- a/src/Cooked/MockChain/GenerateTx/Withdrawals.hs
+++ b/src/Cooked/MockChain/GenerateTx/Withdrawals.hs
@@ -10,7 +10,7 @@ import Cooked.MockChain.Read
 import Cooked.Skeleton.User
 import Cooked.Skeleton.Withdrawal
 import Data.Coerce
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Address qualified as Script
 import Plutus.Script.Utils.Scripts qualified as Script
@@ -20,7 +20,7 @@ import Polysemy.Error
 
 -- | Takes a 'TxSkelWithdrawals' and transforms it into a 'Cardano.TxWithdrawals'
 toWithdrawals ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   TxSkelWithdrawals ->
   Sem effs (Cardano.TxWithdrawals Cardano.BuildTx Cardano.ConwayEra)
 toWithdrawals withdrawals | withdrawals == mempty = return Cardano.TxWithdrawalsNone
@@ -30,13 +30,13 @@ toWithdrawals (view txSkelWithdrawalsListI -> withdrawals) = do
     let coinAmount = maybe (Cardano.Coin 0) coerce amount
     (sCred, witness) <- case user of
       UserPubKey (Script.toPubKeyHash -> pkh) -> do
-        sCred <- fromEither $ Cardano.StakeCredentialByKey <$> Ledger.toCardanoStakeKeyHash pkh
+        sCred <- fromEither $ Cardano.StakeCredentialByKey <$> P.Ledger.toCardanoStakeKeyHash pkh
         return (sCred, Cardano.KeyWitness Cardano.KeyWitnessForStakeAddr)
       UserRedeemedScript (toVScript -> vScript) red -> do
         witness <-
           Cardano.ScriptWitness Cardano.ScriptWitnessForStakeAddr
             <$> toScriptWitness vScript red Cardano.NoScriptDatumForStake
-        sCred <- fromEither $ Cardano.StakeCredentialByScript <$> Ledger.toCardanoScriptHash (Script.toScriptHash vScript)
+        sCred <- fromEither $ Cardano.StakeCredentialByScript <$> P.Ledger.toCardanoScriptHash (Script.toScriptHash vScript)
         return (sCred, witness)
     return (Cardano.makeStakeAddress networkId sCred, coinAmount, Cardano.BuildTxWith witness)
   return $ Cardano.TxWithdrawals Cardano.ShelleyBasedEraConway cardanoWithdrawals

--- a/src/Cooked/MockChain/GenerateTx/Witness.hs
+++ b/src/Cooked/MockChain/GenerateTx/Witness.hs
@@ -9,8 +9,8 @@ import Cardano.Api qualified as Cardano
 import Cooked.MockChain.Error
 import Cooked.MockChain.Read
 import Cooked.Skeleton
-import Ledger.Address qualified as Ledger
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Address qualified as P.Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Scripts qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
@@ -20,7 +20,7 @@ import Polysemy.Error
 -- | Translates a script and a reference script utxo into either a plutus script
 -- or a reference input containing the right script
 toPlutusScriptOrReferenceInput ::
-  (Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs) =>
+  (Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs) =>
   VScript ->
   Maybe Api.TxOutRef ->
   Sem effs (Cardano.PlutusScriptOrReferenceInput lang)
@@ -31,17 +31,17 @@ toPlutusScriptOrReferenceInput (Script.toScriptHash -> scriptHash) (Just scriptO
   case mScriptHash of
     Just scriptHash'
       | scriptHash == scriptHash' -> do
-          s <- fromEither $ Ledger.toCardanoTxIn scriptOutRef
+          s <- fromEither $ P.Ledger.toCardanoTxIn scriptOutRef
           return $ Cardano.PReferenceScript s
     _ -> throw $ MCEWrongReferenceScriptError scriptOutRef scriptHash mScriptHash
 
 -- | Translates a script with its associated redeemer and datum to a script
--- witness. Note on the usage of 'Ledger.zeroExecutionUnits': at this stage of
+-- witness. Note on the usage of 'P.Ledger.zeroExecutionUnits': at this stage of
 -- the transaction create, we cannot know the execution units used by the
 -- script. They will be filled out later on once the full body has been
 -- generated. So, for now, we temporarily leave them to 0.
 toScriptWitness ::
-  ( Members '[MockChainRead, Error MockChainError, Error Ledger.ToCardanoError] effs,
+  ( Members '[MockChainRead, Error MockChainError, Error P.Ledger.ToCardanoError] effs,
     ToVScript a
   ) =>
   a ->
@@ -49,16 +49,16 @@ toScriptWitness ::
   Cardano.ScriptDatum b ->
   Sem effs (Cardano.ScriptWitness b Cardano.ConwayEra)
 toScriptWitness (toVScript -> script@(Script.Versioned _ version)) (TxSkelRedeemer {..}) datum = do
-  let scriptData = Ledger.toCardanoScriptData $ Api.toBuiltinData txSkelRedeemerContent
+  let scriptData = P.Ledger.toCardanoScriptData $ Api.toBuiltinData txSkelRedeemerContent
   case version of
     Script.PlutusV1 ->
-      (\x -> Cardano.PlutusScriptWitness Cardano.PlutusScriptV1InConway Cardano.PlutusScriptV1 x datum scriptData Ledger.zeroExecutionUnits)
+      (\x -> Cardano.PlutusScriptWitness Cardano.PlutusScriptV1InConway Cardano.PlutusScriptV1 x datum scriptData P.Ledger.zeroExecutionUnits)
         <$> toPlutusScriptOrReferenceInput script txSkelRedeemerReferenceInput
     Script.PlutusV2 ->
-      (\x -> Cardano.PlutusScriptWitness Cardano.PlutusScriptV2InConway Cardano.PlutusScriptV2 x datum scriptData Ledger.zeroExecutionUnits)
+      (\x -> Cardano.PlutusScriptWitness Cardano.PlutusScriptV2InConway Cardano.PlutusScriptV2 x datum scriptData P.Ledger.zeroExecutionUnits)
         <$> toPlutusScriptOrReferenceInput script txSkelRedeemerReferenceInput
     Script.PlutusV3 ->
-      (\x -> Cardano.PlutusScriptWitness Cardano.PlutusScriptV3InConway Cardano.PlutusScriptV3 x datum scriptData Ledger.zeroExecutionUnits)
+      (\x -> Cardano.PlutusScriptWitness Cardano.PlutusScriptV3InConway Cardano.PlutusScriptV3 x datum scriptData P.Ledger.zeroExecutionUnits)
         <$> toPlutusScriptOrReferenceInput script txSkelRedeemerReferenceInput
 
 -- | Generates a key witnesses for a given signatory and body, when the
@@ -70,7 +70,7 @@ toKeyWitness ::
 toKeyWitness txBody =
   fmap
     ( Cardano.makeShelleyKeyWitness Cardano.ShelleyBasedEraConway txBody
-        . Ledger.toWitness
-        . Ledger.PaymentPrivateKey
+        . P.Ledger.toWitness
+        . P.Ledger.PaymentPrivateKey
     )
     . preview txSkelSignatoryPrivateKeyAT

--- a/src/Cooked/MockChain/Instances.hs
+++ b/src/Cooked/MockChain/Instances.hs
@@ -57,7 +57,7 @@ import Cooked.MockChain.Runnable
 import Cooked.MockChain.State
 import Cooked.MockChain.Tweak
 import Cooked.MockChain.Write
-import Ledger.Tx qualified as Ledger
+import Ledger.Tx qualified as P.Ledger
 import Polysemy
 import Polysemy.Bundle
 import Polysemy.Error
@@ -91,7 +91,7 @@ instance RunnableMockChain DirectEffs where
       . runMockChainRead
       . runMockChainWrite
       . insertAt @4
-        @[ Error Ledger.ToCardanoError,
+        @[ Error P.Ledger.ToCardanoError,
            Error MockChainError,
            State MockChainState,
            MockChainLog,
@@ -104,7 +104,7 @@ type FullTweakEffs =
   '[ MockChainMisc,
      MockChainRead,
      Fail,
-     Error Ledger.ToCardanoError,
+     Error P.Ledger.ToCardanoError,
      Error MockChainError,
      State MockChainState,
      MockChainLog,
@@ -124,7 +124,7 @@ type FullEffs =
      MockChainMisc,
      MockChainRead,
      Fail,
-     Error Ledger.ToCardanoError,
+     Error P.Ledger.ToCardanoError,
      Error MockChainError,
      State MockChainState,
      MockChainLog,
@@ -204,7 +204,7 @@ instance (InterpretAlone extraEff) => RunnableMockChain (ExtendedStagedEffs extr
       . runModifyLocally
       . runMockChainWrite
       . insertAt @7
-        @[ Error Ledger.ToCardanoError,
+        @[ Error P.Ledger.ToCardanoError,
            Error MockChainError,
            State MockChainState,
            MockChainLog,

--- a/src/Cooked/MockChain/Read.hs
+++ b/src/Cooked/MockChain/Read.hs
@@ -58,9 +58,9 @@ import Data.Coerce (coerce)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe
-import Ledger.Slot qualified as Ledger
-import Ledger.Tx qualified as Ledger
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Slot qualified as P.Ledger
+import Ledger.Tx qualified as P.Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Address qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
@@ -75,7 +75,7 @@ import Polysemy.State
 data MockChainRead :: Effect where
   GetParams :: MockChainRead m Emulator.Params
   TxSkelOutByRef :: Api.TxOutRef -> MockChainRead m TxSkelOut
-  CurrentSlot :: MockChainRead m Ledger.Slot
+  CurrentSlot :: MockChainRead m P.Ledger.Slot
   AllUtxos :: MockChainRead m Utxos
   UtxosAt :: (Script.ToCredential a) => a -> MockChainRead m Utxos
   GetConstitutionScript :: MockChainRead m (Maybe VScript)
@@ -88,7 +88,7 @@ runMockChainRead ::
   forall effs a.
   ( Members
       '[ State MockChainState,
-         Error Ledger.ToCardanoError,
+         Error P.Ledger.ToCardanoError,
          Error MockChainError
        ]
       effs
@@ -258,7 +258,7 @@ txSkelInputValue =
 -- | Returns the current slot
 currentSlot ::
   (Member MockChainRead effs) =>
-  Sem effs Ledger.Slot
+  Sem effs P.Ledger.Slot
 
 -- | Returns the closed ms interval corresponding to the current slot
 currentMSRange ::
@@ -271,7 +271,7 @@ currentMSRange = slotToMSRange =<< currentSlot
 getEnclosingSlot ::
   (Member MockChainRead effs) =>
   Api.POSIXTime ->
-  Sem effs Ledger.Slot
+  Sem effs P.Ledger.Slot
 getEnclosingSlot t =
   getParams
     <&> (`Emulator.posixTimeToEnclosingSlot` t)
@@ -281,7 +281,7 @@ getEnclosingSlot t =
 slotRangeBefore ::
   (Members '[MockChainRead, Fail] effs) =>
   Api.POSIXTime ->
-  Sem effs Ledger.SlotRange
+  Sem effs P.Ledger.SlotRange
 slotRangeBefore t = do
   n <- getEnclosingSlot t
   (_, b) <- slotToMSRange n
@@ -294,7 +294,7 @@ slotRangeBefore t = do
 slotRangeAfter ::
   (Members '[MockChainRead, Fail] effs) =>
   Api.POSIXTime ->
-  Sem effs Ledger.SlotRange
+  Sem effs P.Ledger.SlotRange
 slotRangeAfter t = do
   n <- getEnclosingSlot t
   (a, _) <- slotToMSRange n
@@ -356,12 +356,12 @@ txSkelOutByRef ::
 -- afterwards using 'allUtxos' or similar functions.
 utxosFromCardanoTx ::
   (Member MockChainRead effs) =>
-  Ledger.CardanoTx ->
+  P.Ledger.CardanoTx ->
   Sem effs [(Api.TxOutRef, TxSkelOut)]
 utxosFromCardanoTx =
   mapM (\txOutRef -> (txOutRef,) <$> txSkelOutByRef txOutRef)
-    . fmap (Ledger.fromCardanoTxIn . snd)
-    . Ledger.getCardanoTxOutRefs
+    . fmap (P.Ledger.fromCardanoTxIn . snd)
+    . P.Ledger.getCardanoTxOutRefs
 
 -- | Go through all of the 'Api.TxOutRef's in the list and look them up in the
 -- state of the blockchain, throwing an error if one of them cannot be resolved.

--- a/src/Cooked/MockChain/Testing.hs
+++ b/src/Cooked/MockChain/Testing.hs
@@ -17,8 +17,9 @@ import Data.Default
 import Data.List (isInfixOf)
 import Data.Set qualified as Set
 import Data.Text qualified as T
-import Ledger qualified
+import Ledger.Index qualified as P.Ledger
 import Plutus.Script.Utils.Address qualified as Script
+import PlutusLedgerApi.V1.Scripts qualified as Api
 import PlutusLedgerApi.V1.Value qualified as Api
 import Polysemy
 import Test.QuickCheck qualified as QC
@@ -477,7 +478,7 @@ withErrorProp test errorProp = withFailureProp test (\_ _ err _ -> errorProp err
 isPhase1Failure ::
   (IsProp prop) =>
   FailureProp prop
-isPhase1Failure _ _ (MCEValidationError Ledger.Phase1 _) _ = testSuccess
+isPhase1Failure _ _ (MCEValidationError P.Ledger.Phase1 _) _ = testSuccess
 isPhase1Failure pcOpts _ e _ =
   testFailureMsg $
     "Expected phase 1 evaluation failure, got: "
@@ -487,7 +488,7 @@ isPhase1Failure pcOpts _ e _ =
 isPhase2Failure ::
   (IsProp prop) =>
   FailureProp prop
-isPhase2Failure _ _ (MCEValidationError Ledger.Phase2 _) _ = testSuccess
+isPhase2Failure _ _ (MCEValidationError P.Ledger.Phase2 _) _ = testSuccess
 isPhase2Failure pcOpts _ e _ =
   testFailureMsg $
     "Expected phase 2 evaluation failure, got: "
@@ -498,7 +499,7 @@ isPhase1FailureWithMsg ::
   (IsProp prop) =>
   String ->
   FailureProp prop
-isPhase1FailureWithMsg s _ _ (MCEValidationError Ledger.Phase1 (Ledger.CardanoLedgerValidationError text)) _
+isPhase1FailureWithMsg s _ _ (MCEValidationError P.Ledger.Phase1 (P.Ledger.CardanoLedgerValidationError text)) _
   | s `isInfixOf` T.unpack text =
       testSuccess
 isPhase1FailureWithMsg _ pcOpts _ e _ =
@@ -511,7 +512,7 @@ isPhase2FailureWithMsg ::
   (IsProp prop) =>
   String ->
   FailureProp prop
-isPhase2FailureWithMsg s _ _ (MCEValidationError Ledger.Phase2 (Ledger.ScriptFailure (Ledger.EvaluationError texts _))) _
+isPhase2FailureWithMsg s _ _ (MCEValidationError P.Ledger.Phase2 (P.Ledger.ScriptFailure (Api.EvaluationError texts _))) _
   | any (isInfixOf s . T.unpack) texts =
       testSuccess
 isPhase2FailureWithMsg _ pcOpts _ e _ =

--- a/src/Cooked/MockChain/Write.hs
+++ b/src/Cooked/MockChain/Write.hs
@@ -44,11 +44,11 @@ import Cooked.MockChain.State
 import Cooked.Skeleton
 import Cooked.Tweak.Common
 import Data.Map.Strict qualified as Map
-import Ledger.Index qualified as Ledger
+import Ledger.Index qualified as P.Ledger
 import Ledger.Orphans ()
-import Ledger.Slot qualified as Ledger
-import Ledger.Tx qualified as Ledger
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Slot qualified as P.Ledger
+import Ledger.Tx qualified as P.Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Scripts qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
@@ -60,9 +60,9 @@ import Polysemy.State
 -- | An effect that offers all the primitives that are performing modifications
 -- on the blockchain state.
 data MockChainWrite :: Effect where
-  WaitNSlots :: Integer -> MockChainWrite m Ledger.Slot
+  WaitNSlots :: Integer -> MockChainWrite m P.Ledger.Slot
   SetParams :: Emulator.Params -> MockChainWrite m ()
-  ValidateTxSkel :: TxSkel -> MockChainWrite m (Ledger.CardanoTx, Utxos)
+  ValidateTxSkel :: TxSkel -> MockChainWrite m (P.Ledger.CardanoTx, Utxos)
   SetConstitutionScript :: (ToVScript s) => s -> MockChainWrite m ()
   ForceOutputs :: [TxSkelOut] -> MockChainWrite m Utxos
 
@@ -73,7 +73,7 @@ runMockChainWrite ::
   forall effs a.
   ( Members
       '[ State MockChainState,
-         Error Ledger.ToCardanoError,
+         Error P.Ledger.ToCardanoError,
          Error MockChainError,
          MockChainLog,
          MockChainRead,
@@ -121,11 +121,11 @@ runMockChainWrite = interpret $ \case
     -- We create our transaction body, which only consists of the dummy input
     -- and the outputs to force, and make a transaction out of it.
     cardanoTx <-
-      Ledger.CardanoEmulatorEraTx . txSignatoriesAndBodyToCardanoTx []
+      P.Ledger.CardanoEmulatorEraTx . txSignatoriesAndBodyToCardanoTx []
         <$> fromEither
           ( Emulator.createTransactionBody params $
-              Ledger.CardanoBuildTx
-                ( Ledger.emptyTxBodyContent
+              P.Ledger.CardanoBuildTx
+                ( P.Ledger.emptyTxBodyContent
                     { Cardano.txOuts = outputs',
                       Cardano.txIns = [input]
                     }
@@ -137,16 +137,16 @@ runMockChainWrite = interpret $ \case
           Map.fromList $
             zipWith
               (\x y -> (x, (y, True)))
-              (Ledger.fromCardanoTxIn . snd <$> Ledger.getCardanoTxOutRefs cardanoTx)
+              (P.Ledger.fromCardanoTxIn . snd <$> P.Ledger.getCardanoTxOutRefs cardanoTx)
               outputsMinAda
     -- We update the index, which effectively receives the new utxos
     modify'
       ( over mcstLedgerStateL $
           Lens.over
             Emulator.elsUtxoL
-            ( Ledger.fromPlutusIndex
-                . Ledger.insert cardanoTx
-                . Ledger.toPlutusIndex
+            ( P.Ledger.fromPlutusIndex
+                . P.Ledger.insert cardanoTx
+                . P.Ledger.toPlutusIndex
             )
       )
     -- We update our internal map by adding the new outputs
@@ -184,7 +184,7 @@ runMockChainWrite = interpret $ \case
     -- We generate the transaction asscoiated with the skeleton, and apply on it
     -- the modifications from the skeleton options
     signatories <- viewTweak txSkelSignatoriesL
-    let cardanoTx = Ledger.CardanoEmulatorEraTx $ txSkelOptModTx $ txSignatoriesAndBodyToCardanoTx signatories body
+    let cardanoTx = P.Ledger.CardanoEmulatorEraTx $ txSkelOptModTx $ txSignatoriesAndBodyToCardanoTx signatories body
     -- To run transaction validation we need a minimal ledger state
     eLedgerState <- gets mcstLedgerState
     -- We finally run the emulated validation. We update our internal state
@@ -193,26 +193,26 @@ runMockChainWrite = interpret $ \case
     -- caller will need to catch those errors and do something with them.
     newOutputs <- case Emulator.validateCardanoTx newParams eLedgerState cardanoTx of
       -- In case of a phase 1 error, we give back the same index
-      (_, Ledger.FailPhase1 _ err) -> throw $ MCEValidationError Ledger.Phase1 err
-      (newELedgerState, Ledger.FailPhase2 _ err _) | Just (colInputs, mRetColOutput) <- mCollaterals -> do
+      (_, P.Ledger.FailPhase1 _ err) -> throw $ MCEValidationError P.Ledger.Phase1 err
+      (newELedgerState, P.Ledger.FailPhase2 _ err _) | Just (colInputs, mRetColOutput) <- mCollaterals -> do
         -- We update the emulated ledger state
         modify' (set mcstLedgerStateL newELedgerState)
         -- We remove the collateral utxos from our own stored outputs
         forM_ colInputs $ modify' . removeOutput
         -- We add the returned collateral to our outputs when it exists
-        case (mRetColOutput, Map.toList $ Ledger.getCardanoTxProducedReturnCollateral cardanoTx) of
+        case (mRetColOutput, Map.toList $ P.Ledger.getCardanoTxProducedReturnCollateral cardanoTx) of
           (Nothing, []) -> return ()
-          (Just retColOutput, [(txIn, _)]) -> modify' $ addOutput (Ledger.fromCardanoTxIn txIn) retColOutput
+          (Just retColOutput, [(txIn, _)]) -> modify' $ addOutput (P.Ledger.fromCardanoTxIn txIn) retColOutput
           _ -> fail "Unreachable case when processing return collaterals, please report a bug at https://github.com/tweag/cooked-validators/issues"
         -- We throw a mockchain error
-        throw $ MCEValidationError Ledger.Phase2 err
+        throw $ MCEValidationError P.Ledger.Phase2 err
       -- In case of success, we update the index with all inputs and outputs
       -- contained in the transaction
-      (newELedgerState, Ledger.Success {}) -> do
+      (newELedgerState, P.Ledger.Success {}) -> do
         -- We update the index with the utxos consumed and produced by the tx
         modify' (set mcstLedgerStateL newELedgerState)
         -- We retrieve the utxos created by the transaction
-        let utxos = Ledger.fromCardanoTxIn . snd <$> Ledger.getCardanoTxOutRefs cardanoTx
+        let utxos = P.Ledger.fromCardanoTxIn . snd <$> P.Ledger.getCardanoTxOutRefs cardanoTx
         -- We combine them with their corresponding `TxSkelOut`
         let newOutputs = zip utxos (txSkelOuts finalTxSkel)
         -- We add the news utxos to the state
@@ -224,7 +224,7 @@ runMockChainWrite = interpret $ \case
       -- This is a theoretical unreachable case. Since we fail in Phase 2, it
       -- means the transaction involved script, and thus we must have generated
       -- collaterals.
-      (_, Ledger.FailPhase2 {})
+      (_, P.Ledger.FailPhase2 {})
         | Nothing <- mCollaterals ->
             fail "Unreachable case when processing validation result, please report a bug at https://github.com/tweag/cooked-validators/issues"
     -- We apply a change of slot when requested in the options
@@ -233,38 +233,38 @@ runMockChainWrite = interpret $ \case
     modify $ set mcstParamsL oldParams
     modify $ over mcstLedgerStateL $ Emulator.updateStateParams oldParams
     -- We log the validated transaction
-    logEvent $ MCLogNewTx (Ledger.fromCardanoTxId $ Ledger.getCardanoTxId cardanoTx) (fromIntegral $ length $ Ledger.getCardanoTxOutRefs cardanoTx)
+    logEvent $ MCLogNewTx (P.Ledger.fromCardanoTxId $ P.Ledger.getCardanoTxId cardanoTx) (fromIntegral $ length $ P.Ledger.getCardanoTxOutRefs cardanoTx)
     -- We return the validated transaction
     return (cardanoTx, newOutputs)
 
 -- | Waits a certain number of slots and returns the new slot
-waitNSlots :: (Member MockChainWrite effs) => Integer -> Sem effs Ledger.Slot
+waitNSlots :: (Member MockChainWrite effs) => Integer -> Sem effs P.Ledger.Slot
 
 -- | Wait for a certain slot, or throws an error if the slot is already past
-awaitSlot :: (Members '[MockChainRead, MockChainWrite] effs) => Ledger.Slot -> Sem effs Ledger.Slot
-awaitSlot (Ledger.Slot targetSlot) = do
-  Ledger.Slot now <- currentSlot
+awaitSlot :: (Members '[MockChainRead, MockChainWrite] effs) => P.Ledger.Slot -> Sem effs P.Ledger.Slot
+awaitSlot (P.Ledger.Slot targetSlot) = do
+  P.Ledger.Slot now <- currentSlot
   waitNSlots (targetSlot - now)
 
 -- | Waits until the current slot becomes greater or equal to the slot
 --  containing the given POSIX time.  Note that that it might not wait for
 --  anything if the current slot is large enough.
-awaitEnclosingSlot :: (Members '[MockChainRead, MockChainWrite] effs) => Api.POSIXTime -> Sem effs Ledger.Slot
+awaitEnclosingSlot :: (Members '[MockChainRead, MockChainWrite] effs) => Api.POSIXTime -> Sem effs P.Ledger.Slot
 awaitEnclosingSlot time = getEnclosingSlot time >>= awaitSlot
 
 -- | Wait a given number of ms from the lower bound of the current slot and
 -- returns the current slot after waiting.
-waitNMSFromSlotLowerBound :: (Members '[MockChainRead, MockChainWrite, Fail] effs) => Integer -> Sem effs Ledger.Slot
+waitNMSFromSlotLowerBound :: (Members '[MockChainRead, MockChainWrite, Fail] effs) => Integer -> Sem effs P.Ledger.Slot
 waitNMSFromSlotLowerBound duration = currentMSRange >>= awaitEnclosingSlot . (+ fromIntegral duration) . fst
 
 -- | Wait a given number of ms from the upper bound of the current slot and
 -- returns the current slot after waiting.
-waitNMSFromSlotUpperBound :: (Members '[MockChainRead, MockChainWrite, Fail] effs) => Integer -> Sem effs Ledger.Slot
+waitNMSFromSlotUpperBound :: (Members '[MockChainRead, MockChainWrite, Fail] effs) => Integer -> Sem effs P.Ledger.Slot
 waitNMSFromSlotUpperBound duration = currentMSRange >>= awaitEnclosingSlot . (+ fromIntegral duration) . snd
 
 -- | Generates, balances and validates a transaction from a skeleton, and
 -- returns the validated transaction, alongside the created UTxOs.
-validateTxSkel :: (Member MockChainWrite effs) => TxSkel -> Sem effs (Ledger.CardanoTx, Utxos)
+validateTxSkel :: (Member MockChainWrite effs) => TxSkel -> Sem effs (P.Ledger.CardanoTx, Utxos)
 
 -- | Same as `validateTxSkel`, but only returns the generated UTxOs
 validateTxSkel' :: (Members '[MockChainRead, MockChainWrite] effs) => TxSkel -> Sem effs Utxos

--- a/src/Cooked/Pretty/Plutus.hs
+++ b/src/Cooked/Pretty/Plutus.hs
@@ -4,9 +4,9 @@
 module Cooked.Pretty.Plutus where
 
 import Cooked.Pretty.Class
-import Ledger.Index qualified as Ledger
-import Ledger.Scripts qualified as Ledger
-import Ledger.Tx.CardanoAPI qualified as Ledger
+import Ledger.Index qualified as P.Ledger
+import Ledger.Scripts qualified as P.Ledger
+import Ledger.Tx.CardanoAPI qualified as P.Ledger
 import PlutusLedgerApi.V1.Value qualified as Api
 import PlutusLedgerApi.V3 qualified as Api
 import Prettyprinter ((<+>))
@@ -65,16 +65,16 @@ instance PrettyCooked Api.POSIXTime where
 
 -- * Pretty instances for evalution error coming from plutus-ledger
 
-instance PrettyCooked Ledger.ValidationPhase where
-  prettyCookedOpt _ Ledger.Phase1 = "Phase 1"
-  prettyCookedOpt _ Ledger.Phase2 = "Phase 2"
+instance PrettyCooked P.Ledger.ValidationPhase where
+  prettyCookedOpt _ P.Ledger.Phase1 = "Phase 1"
+  prettyCookedOpt _ P.Ledger.Phase2 = "Phase 2"
 
-instance PrettyCooked Ledger.ValidationError where
-  prettyCookedOpt opts (Ledger.TxOutRefNotFound txIn) = "TxOutRef not found" <+> prettyCookedOpt opts (Ledger.fromCardanoTxIn txIn)
-  prettyCookedOpt opts (Ledger.ScriptFailure scriptError) = "Script failure" <+> prettyCookedOpt opts scriptError
-  prettyCookedOpt _ (Ledger.CardanoLedgerValidationError text) = "Cardano ledger validation error " <+> PP.pretty text
-  prettyCookedOpt _ Ledger.MaxCollateralInputsExceeded = "Max collateral inputs exceeded"
+instance PrettyCooked P.Ledger.ValidationError where
+  prettyCookedOpt opts (P.Ledger.TxOutRefNotFound txIn) = "TxOutRef not found" <+> prettyCookedOpt opts (P.Ledger.fromCardanoTxIn txIn)
+  prettyCookedOpt opts (P.Ledger.ScriptFailure scriptError) = "Script failure" <+> prettyCookedOpt opts scriptError
+  prettyCookedOpt _ (P.Ledger.CardanoLedgerValidationError text) = "Cardano ledger validation error " <+> PP.pretty text
+  prettyCookedOpt _ P.Ledger.MaxCollateralInputsExceeded = "Max collateral inputs exceeded"
 
-instance PrettyCooked Ledger.ScriptError where
-  prettyCookedOpt _ (Ledger.EvaluationError text string) = "Evaluation error" <+> PP.pretty text <+> PP.pretty string
-  prettyCookedOpt _ (Ledger.EvaluationException string1 string2) = "Evaluation exception" <+> PP.pretty string1 <+> PP.pretty string2
+instance PrettyCooked P.Ledger.ScriptError where
+  prettyCookedOpt _ (P.Ledger.EvaluationError text string) = "Evaluation error" <+> PP.pretty text <+> PP.pretty string
+  prettyCookedOpt _ (P.Ledger.EvaluationException string1 string2) = "Evaluation exception" <+> PP.pretty string1 <+> PP.pretty string2

--- a/src/Cooked/Pretty/Skeleton.hs
+++ b/src/Cooked/Pretty/Skeleton.hs
@@ -14,7 +14,7 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes)
 import Data.Set qualified as Set
-import Ledger.Slot qualified as Ledger
+import Ledger.Slot qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Address qualified as Script
 import Plutus.Script.Utils.Value qualified as Script
@@ -78,7 +78,7 @@ instance PrettyCooked (CertificateAction req) where
   prettyCookedOpt _ DRepUpdate = "Update DRep"
   prettyCookedOpt _ DRepUnRegister = "Unregister DRep"
   prettyCookedOpt opt (PoolRegister poolVfr) = "Register pool" <+> prettyHash opt poolVfr
-  prettyCookedOpt _ (PoolRetire (Ledger.Slot n)) = "Retire pool at slot" <+> PP.pretty n
+  prettyCookedOpt _ (PoolRetire (P.Ledger.Slot n)) = "Retire pool at slot" <+> PP.pretty n
   prettyCookedOpt opt (CommitteeRegisterHot cred) = "Register hot credential" <+> prettyCookedOpt opt cred
   prettyCookedOpt _ CommitteeResign = "Resign committee"
 

--- a/src/Cooked/Skeleton.hs
+++ b/src/Cooked/Skeleton.hs
@@ -56,7 +56,7 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Ledger.Slot qualified as Ledger
+import Ledger.Slot qualified as P.Ledger
 import Optics.Core
 import Optics.TH
 import Plutus.Script.Utils.Value qualified as Script
@@ -82,7 +82,7 @@ data TxSkel where
       -- for fees and balancing. You can change that with
       -- 'Cooked.Skeleton.Option.txSkelOptBalancingPolicy'.
       txSkelSignatories :: [TxSkelSignatory],
-      txSkelValidityRange :: Ledger.SlotRange,
+      txSkelValidityRange :: P.Ledger.SlotRange,
       -- | To each 'Api.TxOutRef' the transaction should consume, add a redeemer
       -- specifying how to spend it. You must make sure that
       --

--- a/src/Cooked/Skeleton/Certificate.hs
+++ b/src/Cooked/Skeleton/Certificate.hs
@@ -22,7 +22,7 @@ import Cooked.Skeleton.Redeemer
 import Cooked.Skeleton.User
 import Data.Kind (Type)
 import Data.Typeable (Typeable, cast)
-import Ledger.Slot qualified as Ledger
+import Ledger.Slot qualified as P.Ledger
 import Optics.Core
 import Plutus.Script.Utils.Address qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
@@ -38,7 +38,7 @@ data CertificateAction :: UserKind -> Type where
   DRepUpdate :: CertificateAction IsEither
   DRepUnRegister :: CertificateAction IsEither
   PoolRegister :: Api.PubKeyHash -> CertificateAction IsPubKey
-  PoolRetire :: Ledger.Slot -> CertificateAction IsPubKey
+  PoolRetire :: P.Ledger.Slot -> CertificateAction IsPubKey
   CommitteeRegisterHot :: Api.Credential -> CertificateAction IsEither
   CommitteeResign :: CertificateAction IsEither
 

--- a/src/Cooked/Tweak/ValidityRange.hs
+++ b/src/Cooked/Tweak/ValidityRange.hs
@@ -23,7 +23,7 @@ import Control.Monad
 import Cooked.MockChain.Read
 import Cooked.Skeleton
 import Cooked.Tweak.Common
-import Ledger.Slot qualified as Ledger
+import Ledger.Slot qualified as P.Ledger
 import PlutusLedgerApi.V1.Interval qualified as Api
 import Polysemy
 import Polysemy.NonDet
@@ -31,14 +31,14 @@ import Polysemy.NonDet
 -- | Looks up the current validity range of the transaction
 getValidityRangeTweak ::
   (Member Tweak effs) =>
-  Sem effs Ledger.SlotRange
+  Sem effs P.Ledger.SlotRange
 getValidityRangeTweak = viewTweak txSkelValidityRangeL
 
 -- | Changes the current validity range, returning the old one
 setValidityRangeTweak ::
   (Member Tweak effs) =>
-  Ledger.SlotRange ->
-  Sem effs Ledger.SlotRange
+  P.Ledger.SlotRange ->
+  Sem effs P.Ledger.SlotRange
 setValidityRangeTweak newRange = do
   oldRange <- getValidityRangeTweak
   setTweak txSkelValidityRangeL newRange
@@ -47,14 +47,14 @@ setValidityRangeTweak newRange = do
 -- | Ensures the skeleton makes for an unconstrained validity range
 setAlwaysValidRangeTweak ::
   (Member Tweak effs) =>
-  Sem effs Ledger.SlotRange
+  Sem effs P.Ledger.SlotRange
 setAlwaysValidRangeTweak = setValidityRangeTweak Api.always
 
 -- | Sets the left bound of the validity range. Leaves the right bound unchanged
 setValidityStartTweak ::
   (Member Tweak effs) =>
-  Ledger.Slot ->
-  Sem effs Ledger.SlotRange
+  P.Ledger.Slot ->
+  Sem effs P.Ledger.SlotRange
 setValidityStartTweak left =
   getValidityRangeTweak
     >>= setValidityRangeTweak
@@ -64,8 +64,8 @@ setValidityStartTweak left =
 -- | Sets the right bound of the validity range. Leaves the left bound unchanged
 setValidityEndTweak ::
   (Member Tweak effs) =>
-  Ledger.Slot ->
-  Sem effs Ledger.SlotRange
+  P.Ledger.Slot ->
+  Sem effs P.Ledger.SlotRange
 setValidityEndTweak right =
   getValidityRangeTweak
     >>= setValidityRangeTweak
@@ -75,14 +75,14 @@ setValidityEndTweak right =
 -- | Checks if the validity range satisfies a certain predicate
 validityRangeSatisfiesTweak ::
   (Member Tweak effs) =>
-  (Ledger.SlotRange -> Bool) ->
+  (P.Ledger.SlotRange -> Bool) ->
   Sem effs Bool
 validityRangeSatisfiesTweak = (<$> getValidityRangeTweak)
 
 -- | Checks if a given time belongs to the validity range of a transaction
 isValidAtTweak ::
   (Member Tweak effs) =>
-  Ledger.Slot ->
+  P.Ledger.Slot ->
   Sem effs Bool
 isValidAtTweak = validityRangeSatisfiesTweak . Api.member
 
@@ -95,7 +95,7 @@ isValidNowTweak = currentSlot >>= isValidAtTweak
 -- | Checks if a given range is included in the validity range of a transaction
 isValidDuringTweak ::
   (Member Tweak effs) =>
-  Ledger.SlotRange ->
+  P.Ledger.SlotRange ->
   Sem effs Bool
 isValidDuringTweak = validityRangeSatisfiesTweak . flip Api.contains
 
@@ -115,8 +115,8 @@ hasFullTimeRangeTweak = validityRangeSatisfiesTweak (Api.always ==)
 -- fails is the resulting interval is empty
 intersectValidityRangeTweak ::
   (Members '[Tweak, NonDet] effs) =>
-  Ledger.SlotRange ->
-  Sem effs Ledger.SlotRange
+  P.Ledger.SlotRange ->
+  Sem effs P.Ledger.SlotRange
 intersectValidityRangeTweak newRange = do
   oldRange <- viewTweak txSkelValidityRangeL
   let combinedRange = Api.intersection newRange oldRange
@@ -127,21 +127,21 @@ intersectValidityRangeTweak newRange = do
 -- | Centers the validity range around a value with a certain radius
 centerAroundValidityRangeTweak ::
   (Member Tweak effs) =>
-  Ledger.Slot ->
+  P.Ledger.Slot ->
   Integer ->
-  Sem effs Ledger.SlotRange
-centerAroundValidityRangeTweak t (Ledger.Slot -> radius) = do
+  Sem effs P.Ledger.SlotRange
+centerAroundValidityRangeTweak t (P.Ledger.Slot -> radius) = do
   setValidityRangeTweak $ Api.interval (t - radius) (t + radius)
 
 -- | Makes a transaction range equal to a singleton
 makeValidityRangeSingletonTweak ::
   (Member Tweak effs) =>
-  Ledger.Slot ->
-  Sem effs Ledger.SlotRange
+  P.Ledger.Slot ->
+  Sem effs P.Ledger.SlotRange
 makeValidityRangeSingletonTweak = setValidityRangeTweak . Api.singleton
 
 -- | Makes the transaction validity range comply with the current time
 makeValidityRangeNowTweak ::
   (Members '[Tweak, MockChainRead] effs) =>
-  Sem effs Ledger.SlotRange
+  Sem effs P.Ledger.SlotRange
 makeValidityRangeNowTweak = currentSlot >>= makeValidityRangeSingletonTweak

--- a/src/Cooked/Wallet.hs
+++ b/src/Cooked/Wallet.hs
@@ -20,9 +20,9 @@ where
 import Cardano.Crypto.Wallet qualified as Crypto
 import Data.Function (on)
 import Data.List (elemIndex)
-import Ledger.Address qualified as Ledger
-import Ledger.CardanoWallet qualified as Ledger
-import Ledger.Crypto qualified as Ledger
+import Ledger.Address qualified as P.Ledger
+import Ledger.CardanoWallet qualified as P.Ledger
+import Ledger.Crypto qualified as P.Ledger
 import Plutus.Script.Utils.Address qualified as Script
 import PlutusLedgerApi.V3 qualified as Api
 
@@ -33,14 +33,14 @@ import PlutusLedgerApi.V3 qualified as Api
 -- Because mock wallets from plutus-ledger change often, we provide our own
 -- wrapper on top of them to ensure that we can easily deal changes from Plutus.
 
--- | A 'Wallet' is a 'Ledger.MockWallet' from plutus-ledger
-type Wallet = Ledger.MockWallet
+-- | A 'Wallet' is a 'P.Ledger.MockWallet' from plutus-ledger
+type Wallet = P.Ledger.MockWallet
 
 instance Eq Wallet where
-  (==) = (==) `on` Ledger.mwWalletId
+  (==) = (==) `on` P.Ledger.mwWalletId
 
 instance Ord Wallet where
-  compare = compare `on` Ledger.mwWalletId
+  compare = compare `on` P.Ledger.mwWalletId
 
 -- | All the wallets corresponding to known Plutus mock wallets. This is a list
 -- of 10 wallets which will
@@ -49,14 +49,14 @@ instance Ord Wallet where
 --
 -- - be pretty-printed as part the final state after running a few transactions.
 knownWallets :: [Wallet]
-knownWallets = Ledger.knownMockWallets
+knownWallets = P.Ledger.knownMockWallets
 
 -- | Wallet corresponding to a given wallet number (or wallet ID) with an offset
 -- of 1 to start at 1 instead of 0
 wallet :: Integer -> Wallet
 wallet j
-  | j > 0 && j <= 10 = Ledger.knownMockWallet j
-  | otherwise = Ledger.fromWalletNumber $ Ledger.WalletNumber j
+  | j > 0 && j <= 10 = P.Ledger.knownMockWallet j
+  | otherwise = P.Ledger.fromWalletNumber $ P.Ledger.WalletNumber j
 
 -- | Retrieves the id of the known wallet that corresponds to a public key hash
 --
@@ -69,20 +69,20 @@ walletPKHashToWallet :: Api.PubKeyHash -> Maybe Wallet
 walletPKHashToWallet pkh = wallet . fromIntegral <$> walletPKHashToId pkh
 
 -- | Retrieves a wallet public key (PK)
-walletPK :: Wallet -> Ledger.PubKey
-walletPK = Ledger.unPaymentPubKey . Ledger.paymentPubKey
+walletPK :: Wallet -> P.Ledger.PubKey
+walletPK = P.Ledger.unPaymentPubKey . P.Ledger.paymentPubKey
 
 -- | Retrieves a wallet's public staking key (PK), if any
-walletStakingPK :: Wallet -> Maybe Ledger.PubKey
-walletStakingPK = fmap Ledger.toPublicKey . walletStakingSK
+walletStakingPK :: Wallet -> Maybe P.Ledger.PubKey
+walletStakingPK = fmap P.Ledger.toPublicKey . walletStakingSK
 
 -- | Retrieves a wallet's public key hash
 instance Script.ToPubKeyHash Wallet where
-  toPubKeyHash = Ledger.pubKeyHash . walletPK
+  toPubKeyHash = P.Ledger.pubKeyHash . walletPK
 
 -- | Retrieves a wallet's public staking key hash, if any
 walletStakingPKHash :: Wallet -> Maybe Api.PubKeyHash
-walletStakingPKHash = fmap Ledger.pubKeyHash . walletStakingPK
+walletStakingPKHash = fmap P.Ledger.pubKeyHash . walletStakingPK
 
 instance Script.ToCredential Wallet where
   toCredential = Api.PubKeyCredential . Script.toPubKeyHash
@@ -99,8 +99,8 @@ instance Script.ToAddress Wallet where
 
 -- | Retrieves a wallet private key (secret key SK)
 walletSK :: Wallet -> Crypto.XPrv
-walletSK = Ledger.unPaymentPrivateKey . Ledger.paymentPrivateKey
+walletSK = P.Ledger.unPaymentPrivateKey . P.Ledger.paymentPrivateKey
 
 -- | Retrieves a wallet's private staking key (secret key SK), if any
 walletStakingSK :: Wallet -> Maybe Crypto.XPrv
-walletStakingSK = fmap Ledger.unStakePrivateKey . Ledger.stakePrivateKey
+walletStakingSK = fmap P.Ledger.unStakePrivateKey . P.Ledger.stakePrivateKey

--- a/tests/Spec/Balancing.hs
+++ b/tests/Spec/Balancing.hs
@@ -7,7 +7,7 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text (isInfixOf)
-import Ledger.Index qualified as Ledger
+import Ledger.Index qualified as P.Ledger
 import Optics.Core
 import Optics.Core.Extras
 import Plutus.Script.Utils.V3 qualified as Script
@@ -222,15 +222,15 @@ failsAtBalancing (MCEBalancingError (NotEnoughFundForExtraMinAda {})) = testBool
 failsAtBalancing _ = testBool False
 
 failsWithTooLittleFee :: MockChainError -> Assertion
-failsWithTooLittleFee (MCEValidationError Ledger.Phase1 (Ledger.CardanoLedgerValidationError text)) = testBool $ isInfixOf "FeeTooSmallUTxO" text
+failsWithTooLittleFee (MCEValidationError P.Ledger.Phase1 (P.Ledger.CardanoLedgerValidationError text)) = testBool $ isInfixOf "FeeTooSmallUTxO" text
 failsWithTooLittleFee _ = testBool False
 
 failsWithValueNotConserved :: MockChainError -> Assertion
-failsWithValueNotConserved (MCEValidationError Ledger.Phase1 (Ledger.CardanoLedgerValidationError text)) = testBool $ isInfixOf "ValueNotConserved" text
+failsWithValueNotConserved (MCEValidationError P.Ledger.Phase1 (P.Ledger.CardanoLedgerValidationError text)) = testBool $ isInfixOf "ValueNotConserved" text
 failsWithValueNotConserved _ = testBool False
 
 failsWithEmptyTxIns :: MockChainError -> Assertion
-failsWithEmptyTxIns (MCEValidationError Ledger.Phase1 (Ledger.CardanoLedgerValidationError text)) = testBool $ isInfixOf "InputSetEmptyUTxO" text
+failsWithEmptyTxIns (MCEValidationError P.Ledger.Phase1 (P.Ledger.CardanoLedgerValidationError text)) = testBool $ isInfixOf "InputSetEmptyUTxO" text
 failsWithEmptyTxIns _ = testBool False
 
 failsAtCollateralsWith :: Integer -> MockChainError -> Assertion

--- a/tests/Spec/ReferenceScripts.hs
+++ b/tests/Spec/ReferenceScripts.hs
@@ -4,7 +4,7 @@ import Cardano.Api qualified as Cardano
 import Cooked
 import Data.Map qualified as Map
 import Data.Set qualified as Set
-import Ledger.Tx qualified as Ledger
+import Ledger.Tx qualified as P.Ledger
 import Optics.Core
 import Plutus.ReferenceScripts
 import Plutus.Script.Utils.V2 qualified as Script
@@ -59,7 +59,7 @@ checkReferenceScriptOnOref expectedScriptHash refScriptOref = do
 -- should be consumed in the transaction or not. If it should, then at
 -- transaction generation no reference input should appear, as inputs also act
 -- as reference inputs.
-useReferenceScript :: Wallet -> Bool -> Script.Versioned Script.Validator -> DirectMockChain Ledger.CardanoTx
+useReferenceScript :: Wallet -> Bool -> Script.Versioned Script.Validator -> DirectMockChain P.Ledger.CardanoTx
 useReferenceScript spendingSubmitter consumeScriptOref theScript = do
   scriptOref <- putRefScriptOnWalletOutput (wallet 3) theScript
   (oref, _) : _ <-
@@ -214,7 +214,7 @@ tests =
                       Script.toPubKeyHash $
                         wallet 1
               )
-              `withSuccessProp` \_ _ (Ledger.CardanoEmulatorEraTx (Cardano.Tx (Cardano.getTxBodyContent -> bodyContent) _)) _ ->
+              `withSuccessProp` \_ _ (P.Ledger.CardanoEmulatorEraTx (Cardano.Tx (Cardano.getTxBodyContent -> bodyContent) _)) _ ->
                 case Cardano.txInsReference bodyContent of
                   Cardano.TxInsReference _ [_] _ -> testSuccess
                   _ -> testFailure,
@@ -226,7 +226,7 @@ tests =
                       Script.toPubKeyHash $
                         wallet 1
               )
-              `withSuccessProp` \_ _ (Ledger.CardanoEmulatorEraTx (Cardano.Tx (Cardano.getTxBodyContent -> bodyContent) _)) _ ->
+              `withSuccessProp` \_ _ (P.Ledger.CardanoEmulatorEraTx (Cardano.Tx (Cardano.getTxBodyContent -> bodyContent) _)) _ ->
                 case Cardano.txInsReference bodyContent of
                   -- We get this from cardano-api instead of TxInsReferenceNone
                   Cardano.TxInsReference _ [] _ -> testSuccess

--- a/tests/Spec/Slot.hs
+++ b/tests/Spec/Slot.hs
@@ -4,8 +4,8 @@ import Cooked.MockChain.Error
 import Cooked.MockChain.Read
 import Cooked.MockChain.State
 import Data.Default
-import Ledger.Slot qualified as Ledger
-import Ledger.Tx qualified as Ledger
+import Ledger.Slot qualified as P.Ledger
+import Ledger.Tx qualified as P.Ledger
 import PlutusLedgerApi.V3 qualified as Api
 import Polysemy
 import Polysemy.Error
@@ -19,7 +19,7 @@ runSlot ::
     '[ MockChainRead,
        State MockChainState,
        Fail,
-       Error Ledger.ToCardanoError,
+       Error P.Ledger.ToCardanoError,
        Error MockChainError
      ]
     a ->
@@ -39,18 +39,18 @@ tests =
     [ testProperty "bounds computed by slotToMSRange are included in slot" $
         \n ->
           case runSlot $ do
-            (l, r) <- slotToMSRange $ Ledger.Slot n
-            Ledger.Slot nl <- getEnclosingSlot l
-            Ledger.Slot nr <- getEnclosingSlot r
+            (l, r) <- slotToMSRange $ P.Ledger.Slot n
+            P.Ledger.Slot nl <- getEnclosingSlot l
+            P.Ledger.Slot nr <- getEnclosingSlot r
             return (nl, nr) of
             Left _err -> False
             Right (nl, nr) -> nl == n && nr == n,
       testProperty "bounds computed by slotToMSRange are maximal" $
         \n ->
           case runSlot $ do
-            (l, r) <- slotToMSRange $ Ledger.Slot n
-            Ledger.Slot nl <- getEnclosingSlot (l - 1)
-            Ledger.Slot nr <- getEnclosingSlot (r + 1)
+            (l, r) <- slotToMSRange $ P.Ledger.Slot n
+            P.Ledger.Slot nl <- getEnclosingSlot (l - 1)
+            P.Ledger.Slot nr <- getEnclosingSlot (r + 1)
             return (nl, nr) of
             Left _err -> False
             Right (nl, nr) -> nl == n - 1 && nr == n + 1,

--- a/tests/Spec/Tweak/ValidityRange.hs
+++ b/tests/Spec/Tweak/ValidityRange.hs
@@ -13,8 +13,8 @@ import Cooked.Tweak.ValidityRange
 import Data.Default (def)
 import Data.Either (rights)
 import Data.Function (on)
-import Ledger.Slot qualified as Ledger
-import Ledger.Tx qualified as Ledger
+import Ledger.Slot qualified as P.Ledger
+import Ledger.Tx qualified as P.Ledger
 import PlutusLedgerApi.V1.Interval qualified as Api
 import Polysemy
 import Polysemy.Error
@@ -25,14 +25,14 @@ import Polysemy.Writer
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, testCase)
 
-toSlotRange :: Integer -> Integer -> Api.Interval Ledger.Slot
-toSlotRange = Api.interval `on` Ledger.Slot
+toSlotRange :: Integer -> Integer -> Api.Interval P.Ledger.Slot
+toSlotRange = Api.interval `on` P.Ledger.Slot
 
-toSlotRangeTranslate :: Ledger.Slot -> Integer -> Integer -> Api.Interval Ledger.Slot
+toSlotRangeTranslate :: P.Ledger.Slot -> Integer -> Integer -> Api.Interval P.Ledger.Slot
 toSlotRangeTranslate translation a b =
   toSlotRange
-    (Ledger.getSlot translation + a)
-    (Ledger.getSlot translation + b)
+    (P.Ledger.getSlot translation + a)
+    (P.Ledger.getSlot translation + b)
 
 checkIsValidDuring :: (Member Tweak effs) => Sem effs Assertion
 checkIsValidDuring = do
@@ -48,14 +48,14 @@ checkIsValidDuring = do
 checkAddToValidityRange :: (Members '[Tweak, MockChainRead, MockChainWrite, NonDet] effs) => Sem effs Assertion
 checkAddToValidityRange = do
   timeOrigin <- currentSlot
-  void $ centerAroundValidityRangeTweak (timeOrigin + Ledger.Slot 100) 80
+  void $ centerAroundValidityRangeTweak (timeOrigin + P.Ledger.Slot 100) 80
   b <- isValidDuringTweak $ toSlotRangeTranslate timeOrigin 25 35
-  b1 <- isValidAtTweak (timeOrigin + Ledger.Slot 130)
+  b1 <- isValidAtTweak (timeOrigin + P.Ledger.Slot 130)
   void $ intersectValidityRangeTweak $ toSlotRangeTranslate timeOrigin 110 220
-  b2 <- isValidAtTweak (timeOrigin + Ledger.Slot 130)
-  void $ awaitSlot $ timeOrigin + Ledger.Slot 130
+  b2 <- isValidAtTweak (timeOrigin + P.Ledger.Slot 130)
+  void $ awaitSlot $ timeOrigin + P.Ledger.Slot 130
   b3 <- isValidNowTweak
-  void $ awaitSlot $ Ledger.Slot 200
+  void $ awaitSlot $ P.Ledger.Slot 200
   b4 <- isValidNowTweak
   void makeValidityRangeNowTweak
   b5 <- isValidNowTweak
@@ -86,7 +86,7 @@ interpretValidityRange =
     . runMockChainWrite
     . evalTweak txSkelTemplate
     . insertAt @3
-      @'[ Error Ledger.ToCardanoError,
+      @'[ Error P.Ledger.ToCardanoError,
           Fail,
           Error MockChainError,
           State MockChainState,


### PR DESCRIPTION
Drop the forbidden catch-all Ledger import, normalise microlens to the Microlens prefix, and qualify cardano-ledger-core modules under C.Ledger. Rename the plutus-ledger alias Ledger to P.Ledger so the two ambiguous *-ledger families are disambiguated symmetrically (P.Ledger / C.Ledger), and document the scheme in doc/IMPORTS.md.