### PR TITLE
Replace cabal test override with cooked-test commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 
 ### Changed
 
+- Test coverage analysis is no longer enabled by default in `cabal.project`,
+  so `cabal test` output is no longer cluttered with `Writing: ….html` lines.
+  The `nix develop .#default` dev shell provides two commands to run the test
+  suite, `cooked-test` (without coverage) and `cooked-test-coverage` (with
+  coverage), replacing the previous `cabal` function override that hid the
+  coverage output but did not work under `direnv` with shells other than `bash`.
 - `doc/BALANCING.md` has been updated to match the current implementation:
   Polysemy effect signatures, the `ExtendedTxSkel` result of `balanceTxSkel`, the
   effectful `reachValue`/`computeFeeAndBalance` signatures and their actual

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,24 @@ Alternatively, one can work on _Cooked Validators_ without Nix, using only GHC
 
 ### Running tests
 
-Unit tests are defined in `/cooked-validators/tests`. They can be run using:
+Unit tests are defined in `/cooked-validators/tests`. From within the
+`nix develop .#default` dev shell they can be run using:
+
+```console
+$ cooked-test
+...
+All 132 tests passed (3.18s)
+```
+
+This runs the suite without coverage analysis, which keeps the output clean. To
+run the suite with coverage analysis instead, use `cooked-test-coverage`. Both
+commands forward extra arguments to `cabal`, so a single test group or case can
+be selected with a [Tasty] pattern, e.g. `cooked-test -p "Balancing"`.
+
+Without the dev shell, the suite can still be run directly with:
 
 ```console
 $ cabal test all
-...
-All 132 tests passed (3.18s)
 ```
 
 Our continuous integration checks them automatically.
@@ -177,3 +189,4 @@ coding conventions in the exact same way the CI does.
 [ormolu]: https://github.com/tweag/ormolu
 [haddock]: https://haskell-haddock.readthedocs.io/en/latest/
 [nixfmt]: https://github.com/serokell/nixfmt
+[tasty]: https://github.com/UnkindPartition/tasty

--- a/cabal.project
+++ b/cabal.project
@@ -26,11 +26,6 @@ write-ghc-environment-files: never
 -- 'tasty' output.
 test-show-details: direct
 
--- We activate test coverage by default 
-package cooked-validators
-  coverage: True
-  library-coverage: True
-
 -- Removing optimization for these packages reduces their build time
 -- drastically and is not an issue for dev work
 package cardano-ledger-alonzo

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,29 @@
           }
         );
 
+        ## Runs the test suite without coverage, for clean output. 'spec.tix' is
+        ## removed first to avoid stale HPC '.tix'/'.mix' mismatches (caused by
+        ## '-fignore-hpc-changes' in 'package.yaml'). Extra arguments are
+        ## forwarded to the 'tasty' test binary (e.g. '-p PATTERN').
+        cooked-test = pkgs.writeShellScriptBin "cooked-test" ''
+          rm -f spec.tix
+          opts=(--test-option=--color=always)
+          for arg in "$@"; do opts+=("--test-option=$arg"); done
+          cabal test all "''${opts[@]}"
+        '';
+
+        ## Like 'cooked-test' but with coverage analysis (only checked
+        ## punctually). The verbose "Writing: ....html" coverage lines are
+        ## filtered out, and 'PIPESTATUS' preserves the test binary's exit status
+        ## through that pipe.
+        cooked-test-coverage = pkgs.writeShellScriptBin "cooked-test-coverage" ''
+          rm -f spec.tix
+          opts=(--test-option=--color=always)
+          for arg in "$@"; do opts+=("--test-option=$arg"); done
+          cabal test all --enable-coverage "''${opts[@]}" | grep -vE --color=never "^Writing:.*html$"
+          exit "''${PIPESTATUS[0]}"
+        '';
+
         pre-commit = pre-commit-hooks.lib.${system}.run {
           src = ./.;
           hooks = {
@@ -82,7 +105,6 @@
               pkgs.openldap # For freer-extras‽
               pkgs.libsodium
               pkgs.secp256k1
-              pkgs.lmdb
               blst-portable
             ];
 
@@ -102,24 +124,14 @@
                 pkgs.hlint
                 pkgs.ormolu
                 hpkgs.haskell-language-server
+                cooked-test
+                cooked-test-coverage
               ];
 
               inherit LD_LIBRARY_PATH;
               inherit LANG;
 
-              # In addition to the pre-commit hooks, this redefines a cabal
-              # command that gets rid of annoying "Writing: .....*.html" output
-              # when running cabal test.
-              shellHook = pre-commit.shellHook + ''
-                function cabal() {
-                      if [ "$1" != "test" ]; then
-                        command cabal "$@"
-                      else
-                        command cabal --test-option=--color=always "$@" | grep -vE --color=never "^Writing:.*html$"
-                      fi
-                }
-                export -f cabal
-              '';
+              shellHook = pre-commit.shellHook;
             };
           };
 


### PR DESCRIPTION
Closes #402.

## Problem

The `default` dev shell redefined `cabal` as an exported bash function in its `shellHook` to strip the verbose HPC `Writing: ….html` output of `cabal test` (coverage was enabled by default in `cabal.project`). That function was exported with `export -f`, so it was **not inherited under `direnv` with shells other than `bash`** (e.g. zsh), and the noisy output reappeared.

## Changes

- **`cabal.project`**: remove the default coverage settings (the redundant `coverage` + deprecated `library-coverage` fields). Coverage is now opt-in, so plain `cabal test` output is clean.
- **`flake.nix`**: replace the fragile `cabal` function override with two real scripts on `PATH` in the `default` shell (work regardless of shell/`direnv`):
  - `cooked-test` — runs the suite without coverage.
  - `cooked-test-coverage` — runs with `--enable-coverage` and filters the verbose `Writing: ….html` lines (preserving the real test exit status via `PIPESTATUS`).
  
  Both remove a stale `spec.tix` first to avoid HPC `.tix`/`.mix` hash mismatches (`-fignore-hpc-changes` lets GHC reuse instrumented objects across runs), and forward extra arguments to the `tasty` test binary (e.g. `cooked-test -p "Balancing"`).
- Also removed a duplicate `pkgs.lmdb` entry in `LD_LIBRARY_PATH`.
- **`CONTRIBUTING.md` / `CHANGELOG.md`**: documented the new commands and the default-coverage removal.

## Validation

- Pre-commit `nixfmt` hook passes; `nix eval` of the `default` dev shell succeeds.
- Verified `cooked-test` / `cooked-test-coverage` both run, including with a `-p` pattern, and that alternating between them no longer triggers the HPC `.tix` mismatch.