### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/doc/CHEATSHEET.md
+++ b/doc/CHEATSHEET.md
@@ -7,7 +7,7 @@ things, you will Learn how to:
 - write transactions
 - fetch information from the blockchain
 - submit these transactions for validation as part of a trace
-- run those traces in tests or in a `repl` environement!
+- run those traces in tests or in a `repl` environment!
 
 While this is not a complete tutorial, this document should be helpful to new
 users to get accustomed to `cooked-validators` as well as old users looking to
@@ -83,11 +83,11 @@ A `mockchain` is an abstraction of the Cardano blockchain. `cooked-validators`
 provides several monadic environments to instantiate this concept:
 - `DirectMockChain`: basic capabilities of the mockchain
 - `StagedMockChain`: basic capabilities of the mockchain, with the addition of
-  branching and temporal modifications. This is the go-to environement !
+  branching and temporal modifications. This is the go-to environment !
 - `FullMockChain`: all effects available, including low-level effects such as
   builtin-errors, to be used for maximum level of granularity
 - `ExtendedStagedMockChain eff`: same as `StagedMockChain` with additional
-  custom effects embedded in `eff`, to work in your own dedicated environement !
+  custom effects embedded in `eff`, to work in your own dedicated environment !
 
 ## Traces 
 
@@ -95,7 +95,7 @@ provides several monadic environments to instantiate this concept:
 
 A trace is a sequence of instructions in one of our `mockchain` instances:
 
-* In a fixed existing `mockchain` intance:
+* In a fixed existing `mockchain` instance:
 ```haskell
 myTrace :: [Direct|Staged|Full]MockChain ()
 myTrace = do
@@ -262,7 +262,7 @@ printing/debugging purposes at the end of a run.
 
 ### Aliases for static data
 
-Aliases for static data can be defined outside a mockchain run, in the pretty options direclty:
+Aliases for static data can be defined outside a mockchain run, in the pretty options directly:
 ```haskell
 walletNames :: [(Wallet, String)]
 walletNames = [(wallet 1, "Alice"), (wallet 2, "Bob"), (wallet 3, "Carie")]
@@ -438,7 +438,7 @@ Utxo searches are lists of UTxOs that can be manipulated conveniently.
     extract `b` when it exists, or remove the output when it does not.
   * several variants: `extractPure`, `extractAFold`, ...
   
-6. UTxO searches are made of the targetted outputs, alongside any piece of
+6. UTxO searches are made of the targeted outputs, alongside any piece of
    information that was extracted from them, in a type retaining way. Pieces of
    these searches can be retrieved, using `getOutputs`, `getExtracts`, ...
    

--- a/doc/IMPORTS.md
+++ b/doc/IMPORTS.md
@@ -14,7 +14,7 @@ modules and preferred import locations.
 
 ## Names of qualified modules related to Cardano
 
-Here is the correspondance between package and prefix for each of our main
+Here is the correspondence between package and prefix for each of our main
 dependencies:
 
 ### [`cardano-node-emulator`](https://github.com/IntersectMBO/cardano-node-emulator)
@@ -84,5 +84,5 @@ plutus-ledger) should. For instance, `Value` should always be coming from
 `Ledger` is a big module coming from `plutus-ledger` that re-exports many
 definitions. It re-exports too many definitions so that it hides where they
 really come from, but not enough so that importing `Ledger` alone sufficies in
-most projects. Thus, we avoid importing it altogher and instead rely on
+most projects. Thus, we avoid importing it altogether and instead rely on
 `PlutusLedgerApi.V3` and the sub-modules `Ledger.*` (aliased `P.Ledger`).

--- a/src/Cooked/Families.hs
+++ b/src/Cooked/Families.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | This module exposes some type families used to either directly constraint
--- values within our skeletons, or constrant inputs of smart constructors for
+-- values within our skeletons, or constraint inputs of smart constructors for
 -- components of these skeletons.
 module Cooked.Families
   ( -- * Type-level constraints

--- a/src/Cooked/MockChain/Automation/Balancing.hs
+++ b/src/Cooked/MockChain/Automation/Balancing.hs
@@ -232,7 +232,7 @@ collateralsFromFee ::
   Sem effs (Maybe Collaterals)
 collateralsFromFee _ Nothing = return Nothing
 collateralsFromFee fee (Just (collateralIns, returnCollateralUser)) = do
-  -- We retrieve the protocal parameters
+  -- We retrieve the protocol parameters
   params <- Emulator.pEmulatorPParams <$> getParams
   -- We retrieve the max number of collateral inputs, with a default of 10. In
   -- practice this will be around 3.
@@ -326,7 +326,7 @@ reachValue utxos target fuel outputOrUser = do
         (Script.toValue . (minAda -) . view valueLovelaceL -> missingAdaValue) -> do
           -- We need to run a new search with a target increased by the missing
           -- amount of ADA. For that purpose, we also need to increase the
-          -- surplus payment with the same amout, to keep everything balanced.
+          -- surplus payment with the same amount, to keep everything balanced.
           -- As a consequence, we also need to add bytes to the transaction.
           (sizeAdded, goOutputOrUser') <- case goOutputOrUser of
             -- If the surplus already exist, we add @missingAdaValue@ to it
@@ -344,7 +344,7 @@ reachValue utxos target fuel outputOrUser = do
             <$> go majorVersion goUtxos (goTarget <> missingAdaValue) goFuel goOutputOrUser' goAvailable
     -- We have not reached a solution, but we don't have fuel anymore
     go _ _ _ goFuel _ _ | goFuel <= 0 = return Nothing
-    -- We have not reached a soultion, but no more UTxOs are available
+    -- We have not reached a solution, but no more UTxOs are available
     go _ [] _ _ _ _ = return Nothing
     -- We have not reached a solution, but the total available value is
     -- insufficient to ever find one

--- a/src/Cooked/MockChain/Automation/GenerateTx/Anchor.hs
+++ b/src/Cooked/MockChain/Automation/GenerateTx/Anchor.hs
@@ -13,7 +13,7 @@ import GHC.IO.Unsafe
 import Network.HTTP.Simple qualified as Network
 
 -- | This function transforms a 'TxSkelAnchor' into its Cardano counterpart. If
--- the provided anchor does not provde a resolved page, it will be unsafely
+-- the provided anchor does not provide a resolved page, it will be unsafely
 -- fetched online, so use at your own discretion.
 toCardanoAnchor :: TxSkelAnchor -> C.Ledger.Anchor
 toCardanoAnchor txSkelAnchor =

--- a/src/Cooked/MockChain/Automation/GenerateTx/Proposal.hs
+++ b/src/Cooked/MockChain/Automation/GenerateTx/Proposal.hs
@@ -29,7 +29,7 @@ import PlutusLedgerApi.V1.Value qualified as Api
 import Polysemy
 import Polysemy.Error
 
--- | Transorms a `Cooked.Skeleton.Proposal.ParamChange` into an actual change
+-- | Transforms a `Cooked.Skeleton.Proposal.ParamChange` into an actual change
 -- over a Cardano parameter update
 toPParamsUpdate ::
   forall effs.

--- a/src/Cooked/MockChain/Effect/Write.hs
+++ b/src/Cooked/MockChain/Effect/Write.hs
@@ -72,7 +72,7 @@ data MockChainWrite :: Effect where
 
 makeSem_ ''MockChainWrite
 
--- | Interpretes the `MockChainWrite` effect
+-- | Interprets the `MockChainWrite` effect
 runMockChainWrite ::
   forall effs a.
   ( Members
@@ -136,7 +136,7 @@ runMockChainWrite = interpret $ \case
                 )
           )
     -- We need to adjust our internal state to account for the forced
-    -- transaction. We beging by computing the new map of outputs.
+    -- transaction. We begin by computing the new map of outputs.
     let outputsMap =
           Map.fromList $
             zipWith
@@ -286,7 +286,7 @@ setConstitutionScript :: (Member MockChainWrite effs, ToVScript s) => s -> Sem e
 
 -- | Forces the generation of utxos corresponding to certain
 -- `TxSkelOut`. Returns the created UTxOs, which might differ from the original
--- list if some min ADA adjustment occured.
+-- list if some min ADA adjustment occurred.
 forceOutputs :: (Member MockChainWrite effs) => [TxSkelOut] -> Sem effs Utxos
 
 -- | Same as `forceOutputs`, but discards the returned outputs

--- a/src/Cooked/MockChain/Run/Instances.hs
+++ b/src/Cooked/MockChain/Run/Instances.hs
@@ -9,7 +9,7 @@
 --
 -- - `StagedMockChain` exposes all the primitives required to run a mockchain,
 --   with the addition of branching and `Ltl` modifications using tweaks. This
---   should be the environement to use in 99% of the cases.
+--   should be the environment to use in 99% of the cases.
 --
 -- - `ExtendedStagedMockChain` exposes the same primitives as `StagedMockChain`,
 --   with an additional custom effect that can both be used in the main thread

--- a/src/Cooked/MockChain/Runtime/Error.hs
+++ b/src/Cooked/MockChain/Runtime/Error.hs
@@ -4,7 +4,7 @@ module Cooked.MockChain.Runtime.Error
     BalancingError (..),
     MockChainError (..),
 
-    -- * Interpretating effects into `Error MockChainError`
+    -- * Interpreting effects into `Error MockChainError`
     runToCardanoErrorInMockChainError,
     runFailInMockChainError,
   )
@@ -22,7 +22,7 @@ import Polysemy.Fail
 -- | Errors that can be produced during balancing
 data BalancingError
   = -- | The balancing user theoretically has enough funds to balancing the
-    -- trasaction, but this balancing results in a surplus payment which they
+    -- transaction, but this balancing results in a surplus payment which they
     -- cannot afford ADA-wise.
     NotEnoughFundForExtraMinAda Peer
   | -- | The balancing does not have enough funds to sustain the fee required to

--- a/src/Cooked/MockChain/Runtime/State.hs
+++ b/src/Cooked/MockChain/Runtime/State.hs
@@ -5,7 +5,7 @@
 -- ledger state, which typically does not exist in Cardano. This is useful for
 -- two reasons:
 --
--- - For printing purposes, where it is much more convient to see the available
+-- - For printing purposes, where it is much more convenient to see the available
 --   assets as "who owns what" rather than as a set of mixed Utxos.
 --
 -- - For testings purposes, when querying the final state of a run is

--- a/src/Cooked/Pretty/Options.hs
+++ b/src/Cooked/Pretty/Options.hs
@@ -132,7 +132,7 @@ hashNamesFromList = Map.fromList . map (first toHash)
 -- | Adds some additional names to these pretty cooked options. This has two
 -- practical use cases:
 --
--- * Users can use it in conjuction to 'hashNamesFromList' without having to
+-- * Users can use it in conjunction to 'hashNamesFromList' without having to
 -- remember to manually invoke 'defaultHashNames'
 --
 -- * We use it internally to account for names that have been registered during

--- a/src/Cooked/Pretty/Plutus.hs
+++ b/src/Cooked/Pretty/Plutus.hs
@@ -63,7 +63,7 @@ instance PrettyCooked Api.AssetClass where
 instance PrettyCooked Api.POSIXTime where
   prettyCookedOpt opts (Api.POSIXTime n) = "POSIXTime" <+> prettyCookedOpt opts n
 
--- * Pretty instances for evalution error coming from plutus-ledger
+-- * Pretty instances for evaluation error coming from plutus-ledger
 
 instance PrettyCooked P.Ledger.ValidationPhase where
   prettyCookedOpt _ P.Ledger.Phase1 = "Phase 1"

--- a/src/Cooked/Skeleton/Mint.hs
+++ b/src/Cooked/Skeleton/Mint.hs
@@ -102,7 +102,7 @@ newtype TxSkelMints = TxSkelMints
   deriving (Show, Eq)
 
 -- | Retrieves the inner map of a 'TxSkelMints'. This could be a lense but we
--- want to avoid unsafe assignement of this inner map, for which we keep
+-- want to avoid unsafe assignment of this inner map, for which we keep
 -- invariants so we have it as a getter instead.
 txSkelMintsMapG :: Getter TxSkelMints (Map Api.ScriptHash (User 'IsScript 'Redemption, Map Api.TokenName Integer))
 txSkelMintsMapG = to txSkelMintsMap
@@ -138,7 +138,7 @@ txSkelMintsAssetClassAmountL mp@(Script.toScriptHash . toVScript -> mph) tk =
         -- A previous mp and tk entry, which needs to be removed and the whole
         -- mp entry as well because it only contains this tk.
         Just (Map.delete tk . snd -> subMap) | subMap == mempty, i == 0 -> Map.delete mph mints
-        -- A prevous mp and tk entry, which either needs to be removed in case
+        -- A previous mp and tk entry, which either needs to be removed in case
         -- of i == 0, or updated otherwise.
         Just (prevUser, if i == 0 then Map.delete tk else Map.insert tk i -> subMap)
           | newUser <- maybe prevUser (flip (set userRedeemerL) prevUser) newRed -> Map.insert mph (newUser, subMap) mints

--- a/src/Cooked/Skeleton/Option.hs
+++ b/src/Cooked/Skeleton/Option.hs
@@ -207,7 +207,7 @@ data TxSkelOpts = TxSkelOpts
     -- a result, the balanced `Cooked.Skeleton.TxSkel` will never be computed
     -- and thus will be absent from the log, which is the only downside.
     --
-    -- When set to @True@: the phase 2 validation erros will be ignored during
+    -- When set to @True@: the phase 2 validation errors will be ignored during
     -- the balancing process. This will result in a worst performance (40%), but
     -- will allow the log to display a balanced version of the failing
     -- `Cooked.Skeleton.TxSkel`, which might be useful. Only use this when

--- a/src/Cooked/Skeleton/Redeemer.hs
+++ b/src/Cooked/Skeleton/Redeemer.hs
@@ -126,7 +126,7 @@ emptyTxSkelRedeemer :: TxSkelRedeemer
 emptyTxSkelRedeemer = someTxSkelRedeemer ()
 
 -- | Creates a 'TxSkelRedeemer' with no inner content and no reference input,
--- while dissallowing it to be automatically assinged
+-- while disallowing it to be automatically assigned
 emptyTxSkelRedeemerNoAutoFill :: TxSkelRedeemer
 emptyTxSkelRedeemerNoAutoFill = someTxSkelRedeemerNoAutoFill ()
 

--- a/src/Cooked/Skeleton/Value.hs
+++ b/src/Cooked/Skeleton/Value.hs
@@ -31,12 +31,12 @@ valueAssetClassAmountL (Script.toCurrencySymbol -> cs) tk =
         -- No previous cs entry, and something to add.
         Nothing -> Api.Value $ PMap.insert cs (PMap.singleton tk i) val
         -- A previous cs and tk entry, which needs to be removed and the whole
-        -- cs entry as well because it only containes this tk.
+        -- cs entry as well because it only contains this tk.
         Just (PMap.toList -> [(tk', _)]) | i == 0, tk == tk' -> Api.Value $ PMap.delete cs val
         -- A previous cs and tk entry, which needs to be removed, but the whole
         -- cs entry has other tokens and thus is kept.
         Just tokenMap | i == 0 -> Api.Value $ PMap.insert cs (PMap.delete tk tokenMap) val
-        -- A previous cs entry, in which we insert the new tk (regarless of
+        -- A previous cs entry, in which we insert the new tk (regardless of
         -- whether the tk was already present).
         Just tokenMap -> Api.Value $ PMap.insert cs (PMap.insert tk i tokenMap) val
     )

--- a/tests/Plutus/Attack/DatumHijacking.hs
+++ b/tests/Plutus/Attack/DatumHijacking.hs
@@ -53,7 +53,7 @@ mockValidatorSpendingPurpose getOutputs _ (Just FirstLock) _ txi =
   case getOutputs txi of
     o : _ ->
       traceIfFalse "not in 'SecondLock'-state after re-locking" (outputDatum txi o == Just SecondLock)
-        && traceIfFalse "not re-locking the right amout" (Api.txOutValue o == lockValue)
+        && traceIfFalse "not re-locking the right amount" (Api.txOutValue o == lockValue)
     _ -> trace "there must be a output re-locked" False
 mockValidatorSpendingPurpose _ _ _ _ _ = False
 

--- a/tests/Spec/Attack/ValidityTampering.hs
+++ b/tests/Spec/Attack/ValidityTampering.hs
@@ -40,7 +40,7 @@ tests =
     "Validity tampering"
     [ testGroup
         "Tampering with the lower bound"
-        [ testCase "Strict tampering of inifinite lower bound" $
+        [ testCase "Strict tampering of infinite lower bound" $
             []
               @=? runValidityTampering
                 lowerInfSlotRange
@@ -63,7 +63,7 @@ tests =
         ],
       testGroup
         "Tampering with the upper bound"
-        [ testCase "Strict tampering of inifinite upper bound" $
+        [ testCase "Strict tampering of infinite upper bound" $
             []
               @=? runValidityTampering
                 upperInfSlotRange

--- a/tests/Spec/Balancing.hs
+++ b/tests/Spec/Balancing.hs
@@ -60,7 +60,7 @@ testingBalancingTemplate ::
   Bool ->
   -- Option modifications
   (TxSkelOpts -> TxSkelOpts) ->
-  -- Wether to adjust the output with min ada
+  -- Whether to adjust the output with min ada
   Bool ->
   FullMockChain TestBalancingOutcome
 testingBalancingTemplate toBobValue toAliceValue spendSearch balanceSearch collateralSearch consumeScriptUtxo optionsMod adjust = do


### PR DESCRIPTION
Correct spelling mistakes found by codespell across source comments, Haddock documentation, doc/ markdown files, and a few test names and trace messages. 